### PR TITLE
fix(#4017 follow-up): a read of the store copy of a published build reuses that build's context

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -223,6 +223,11 @@ internal interface ICompilationCacheService
     /// Resolving an assembly PATH is what a hub activation, a cell-surface session and an
     /// assembly-hydration scan all do, and none of them is evidence about which build is
     /// current.</para>
+    /// <para>🚨 <b>But it IS evidence about which build it wants.</b> A path this cache has not
+    /// seen whose bytes a live context of the NodeType already serves (same MVID — the assembly
+    /// store's copy of a build this process published) answers THAT context, aliased under the
+    /// new path. One generation, one collectible context, however many places its bytes
+    /// live.</para>
     /// </summary>
     NodeAssemblyLoadContext GetOrCreateLoadContextForPath(string nodeName, string dllPath);
 
@@ -261,6 +266,16 @@ internal interface ICompilationCacheService
     /// superseded would re-create the CURRENT generation's context under its own path, putting two
     /// live ALCs behind one file — the two-generations split #3911 describes, manufactured by the
     /// reclaim itself.</para>
+    ///
+    /// <para>🚨 <b>The cost the paragraph above MISSED, and how it is now closed.</b> "Hydrated"
+    /// is not only a foreign silo's build: THIS silo's own publish is copied into the store by
+    /// <c>UploadToStoreIfNeeded</c>, and instance activation resolves that store copy — so every
+    /// locally compiled generation was read back under a second path, got a second collectible
+    /// context over identical bytes, and the instance's lifetime lease (which covers every
+    /// context of the NodeType) pinned both. NodeTypeRecompileAlcLeakTest (MeshWeaver.Plugins)
+    /// caught it on the first core set carrying #4013's fix: 3 live contexts after 3 recompiles
+    /// against a bound of 2. A read now REUSES the live context that already serves its build
+    /// (same MVID) — never a supersession, so the ping-pong above cannot return through it.</para>
     /// </summary>
     NodeAssemblyLoadContext PublishLoadContextForPath(string nodeName, string dllPath);
 
@@ -1416,8 +1431,8 @@ internal class CompilationCacheService(
     }
 
     /// <summary>
-    /// Unloads every load context for <paramref name="nodeName"/> whose dictionary key is not
-    /// <paramref name="keepKey"/> — the assemblies a just-loaded recompile/release superseded —
+    /// Unloads every load context for <paramref name="nodeName"/> other than
+    /// <paramref name="keep"/> — the assemblies a just-loaded recompile/release superseded —
     /// bounding <see cref="_loadContexts"/> to the current context per NodeType instead of one per
     /// recompile.
     /// </summary>

--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -7,6 +7,7 @@ using System.Reactive.Subjects;
 using System.Reflection;
 using System.Runtime.Loader;
 using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Persistence;
 using MeshWeaver.ServiceProvider;
 using Microsoft.Extensions.Logging;
@@ -400,6 +401,36 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
     public bool IsDisposed => _disposed;
 
     /// <summary>
+    /// Whether this context has left service: disposed, unloading, or holding a DEFERRED unload
+    /// (<see cref="Dispose"/> was called while a lease was held). A retired context still runs
+    /// the hubs that lease it, but it must never be handed to a NEW caller as "the" context for
+    /// its build — see <c>CompilationCacheService.FindLiveContextOfSameBuild</c>.
+    /// </summary>
+    public bool IsRetired
+    {
+        get
+        {
+            lock (_loadLock)
+                return _disposed || _unloading || _unloadRequested;
+        }
+    }
+
+    /// <summary>
+    /// The MVID of the build this context serves — the IDENTITY of a generation, where a path is
+    /// only one of the places its bytes live (the compile's emit directory, the assembly store's
+    /// <c>v{version}-{tag}-{hash}.dll</c> copy, a hydrated blob). Read from the loaded assembly
+    /// when there is one (no IO), otherwise from the file's metadata via
+    /// <see cref="ServedBuildIdentity.OfFile"/> (a header read — nothing is loaded). Null for an
+    /// in-memory context or an unreadable file, which the caller treats as "no evidence".
+    /// </summary>
+    public string? BuildMvid
+        => LoadedAssembly is { } loaded
+            ? loaded.ManifestModule.ModuleVersionId.ToString("N")
+            : _buildMvidFromFile.Value;
+
+    private readonly Lazy<string?> _buildMvidFromFile;
+
+    /// <summary>
     /// Pins the context for the duration of a SCAN of its loaded assembly (GetTypes + attribute
     /// reflection + Activator). While any pin is held, <see cref="Dispose"/> waits before
     /// <see cref="System.Runtime.Loader.AssemblyLoadContext.Unload"/> so it cannot tear down the
@@ -558,6 +589,7 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         _nodeName = nodeName;
         _dllPath = dllPath;
         _logger = logger;
+        _buildMvidFromFile = new Lazy<string?>(() => ServedBuildIdentity.OfFile(dllPath));
 
         // Purge Autofac's process-static reflection cache of this context's assemblies the instant
         // it starts unloading — while the metadata the predicate walks is still valid. A cached
@@ -1237,6 +1269,35 @@ internal class CompilationCacheService(
     {
         ObjectDisposedException.ThrowIf(_disposed, this);
 
+        // 🚨 A READ of a path this process has not seen may still be a build it HAS: the same
+        // bytes at another address. The ordinary case is the one every locally compiled type
+        // hits — the post-emit scan PUBLISHES from the compile's {nodeName}_{ticks}_{guid}/
+        // directory, UploadToStoreIfNeeded copies those bytes into the assembly store as
+        // v{version}-{tag}-{hash}.dll, and every instance activation then resolves the STORE path.
+        // Two paths, one generation. Until #4013 the read's own supersession hid this (it evicted
+        // the publish's context); once reads stopped superseding, each generation got a SECOND
+        // collectible context over identical bytes, the instance hub's lifetime lease
+        // (LeaseNodeContexts — every context of the NodeType) pinned both, and a live instance
+        // held two contexts of a generation it had long stopped being current for — measured by
+        // NodeTypeRecompileAlcLeakTest (MeshWeaver.Plugins): 2 contexts at activation, 3 after
+        // each of 3 recompiles, where the bound is the current build plus the one generation the
+        // instance runs. So a read answers the live context that already serves its build, and
+        // aliases its key to it. That is a REUSE, never a supersession — nothing is evicted, so
+        // the #4013 ping-pong (two scans destroying each other's contexts) cannot come back
+        // through here. Publishes are untouched: they create their own context and supersede.
+        if (!supersedeOlderBuilds
+            && !_loadContexts.ContainsKey(dllPath)
+            && FindLiveContextOfSameBuild(nodeName, dllPath) is { } sameBuild)
+        {
+            var aliased = _loadContexts.GetOrAdd(dllPath, sameBuild);
+            // A publish can retire the context between the search and the alias — its evictor
+            // enumerated before our key existed. Never hand a retired context to a new caller:
+            // drop OUR alias (only if it is still ours) and resolve normally below.
+            if (!aliased.IsRetired)
+                return aliased;
+            _loadContexts.TryRemove(new KeyValuePair<string, NodeAssemblyLoadContext>(dllPath, aliased));
+        }
+
         var created = false;
         var ctx = _loadContexts.GetOrAdd(dllPath, path =>
         {
@@ -1270,9 +1331,31 @@ internal class CompilationCacheService(
         // disposal instead of on the next reader's resolve; see PublishLoadContextForPath for why
         // that trade is the right way round.
         if (created && supersedeOlderBuilds)
-            EvictSupersededContexts(nodeName, keepKey: dllPath);
+            EvictSupersededContexts(nodeName, keep: ctx);
 
         return ctx;
+    }
+
+    /// <summary>
+    /// The live (not retired) context of <paramref name="nodeName"/> that already serves the build
+    /// at <paramref name="dllPath"/> — same MVID, different path — or null. Null whenever the
+    /// identity cannot be read on either side: absence of evidence resolves a fresh context,
+    /// exactly as before, and never aliases two builds together.
+    /// </summary>
+    private NodeAssemblyLoadContext? FindLiveContextOfSameBuild(string nodeName, string dllPath)
+    {
+        var mvid = ServedBuildIdentity.OfFile(dllPath);
+        if (mvid is null)
+            return null;
+        foreach (var context in _loadContexts.Values)
+        {
+            if (!string.Equals(context.NodeName, nodeName, StringComparison.Ordinal)
+                || context.IsRetired)
+                continue;
+            if (string.Equals(context.BuildMvid, mvid, StringComparison.OrdinalIgnoreCase))
+                return context;
+        }
+        return null;
     }
 
     /// <summary>
@@ -1351,13 +1434,16 @@ internal class CompilationCacheService(
     /// rather than only on hub teardown — see <see cref="PublishLoadContextForPath"/> for why the
     /// trigger is a publish and not merely "a path-keyed context was created" (#4013).
     /// </remarks>
-    private void EvictSupersededContexts(string nodeName, string keepKey)
+    private void EvictSupersededContexts(string nodeName, NodeAssemblyLoadContext keep)
     {
         if (_disposed)
             return;
 
+        // By CONTEXT, not by key: a read may have aliased another path to the context being kept
+        // (ResolveLoadContextForPath — the store copy of the build this publish just loaded), and
+        // evicting that key would dispose the very generation being published.
         var stale = _loadContexts
-            .Where(kvp => !string.Equals(kvp.Key, keepKey, StringComparison.Ordinal)
+            .Where(kvp => !ReferenceEquals(kvp.Value, keep)
                        && string.Equals(kvp.Value.NodeName, nodeName, StringComparison.Ordinal))
             .Select(kvp => kvp.Key)
             .ToList();
@@ -1432,7 +1518,11 @@ internal class CompilationCacheService(
         var leases = _loadContexts
             .Where(kvp => string.Equals(kvp.Key, nodeName, StringComparison.Ordinal)
                        || string.Equals(kvp.Value.NodeName, nodeName, StringComparison.Ordinal))
-            .Select(kvp => kvp.Value.Lease())
+            // Once per CONTEXT: a context aliased under two paths (see ResolveLoadContextForPath)
+            // is one generation and takes one lease.
+            .Select(kvp => kvp.Value)
+            .Distinct()
+            .Select(context => context.Lease())
             .ToArray();
 
         if (leases.Length == 0)

--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -232,6 +232,32 @@ Two rules follow, and they generalise past these two files:
 - **The marker goes on BOTH copies.** A one-sided note is addressed to the party who does not need
   it. Core's twins now name the guard that enforces them.
 
+### Shape 7 in a memory bound: #4017 and `NodeTypeRecompileAlcLeakTest` (2026-09-11)
+
+Core #4017 (`b128b804d`) changed WHEN a NodeType load context is superseded — only a publish, never
+a read — behind an unchanged `ICompilationCacheService.GetOrCreateLoadContextForPath` signature. The
+pair gate was green and correct to be green: nothing was added or removed. The behaviour it changed
+is asserted in the dependent, by `NodeTypeRecompileAlcLeakTest.RecompilingANodeType_WithALiveInstance_StillReleasesSupersededContexts`
+(Plugins, `Portal hosts (shard 3)`), and Plugins resolves the newest SEALED core set per run — so the
+red arrived when the set carrying #4017 sealed, on every Plugins PR and on Plugins `main`, with no
+Plugins change:
+
+> `Expected 3 to be less than or equal to 2 because a live instance hub legitimately DEFERS an unload, but nothing may make that deferral permanent: …`
+
+**The control that settled causation held the Plugins diff constant and moved only the core set:**
+the same Plugins commit `401fcadb` passed shard 3 at 09:56Z on `3.0.0-ci.8340` and failed it at
+10:09Z on `3.0.0-ci.8345`. Across the 42 shard-3 runs between 05:10Z and 11:32Z the test failed 6 of
+6 on sets 8345/8350/8352 and 0 of 36 on 8323–8340, and #4017 was the only merge between 8340 and
+8345 touching compilation code. The deciding question was then not *who* but *which side is
+wrong*: the assertion was right (the read path had begun keeping a second context over the same
+build), so core was fixed forward and the test kept its bound — see
+[NodeTypeCompilation](../NodeTypeCompilation) → *One build at two paths is ONE generation*.
+
+Two lessons for this shape. **The dependent resolves the SEALED set, so a shape-7 red surfaces at
+seal time, not merge time** — attribute by the set each run's `Resolve the released platform` job
+names, never by the clock. And **a red in the dependent is evidence about core only after the diff
+is held constant** — one commit, two sets.
+
 ### 🚨 Shape 7 in the by-hand sweep: a `!` on the WRONG receiver hides the site (#3321)
 
 Shape 7 has no gate, so the only control is a **by-hand sweep of the dependents**. This is about how

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -1929,6 +1929,64 @@ which is why a LOAD is safe; with none, the drain may already be over, so a new 
 `TypeLoadException '…format is invalid'` tear the pin exists to prevent. The refusal is the
 contract; the recovery was the defect.
 
+### 🚨 One build at two paths is ONE generation — a read reuses, it never duplicates
+
+The "narrowed trigger" section above priced its residue at *generations a process only
+**hydrated***, and pictured a foreign silo's build. It missed the commonest hydration of all: the
+process's **own** publish. The post-emit scan publishes from the compile's
+`{nodeName}_{ticks}_{guid}/` directory; `UploadToStoreIfNeeded` then copies those bytes into the
+assembly store as `v{version}-{frameworkTag}-{hash}.dll`; and every instance activation resolves
+the **store** path (`MeshDataSource` / `NodeTypeEnrichmentHelpers` →
+`IAssemblyStore.TryGetAssemblyPath` → `GetConfigurationsFromExistingAssembly`). Two paths, one
+generation. While reads superseded, that read quietly evicted the publish's context. Once they
+stopped, every locally compiled generation got a **second collectible context over identical
+bytes** — and the instance hub's lifetime lease (`LeaseNodeContexts`, which leases *every* context of
+the NodeType) pinned both for the hub's whole life.
+
+Measured by `NodeTypeRecompileAlcLeakTest.RecompilingANodeType_WithALiveInstance_StillReleasesSupersededContexts`
+(MeshWeaver.Plugins, `Portal hosts (shard 3)`), which prints the file each live context was loaded
+from:
+
+| | contexts | loaded from |
+|---|---|---|
+| instance activated | 2 | `…/assembly-store…/AlcLeakTest_LeakType/v3-1a9794ba-dd22c75f5a55.dll` **and** `…/mesh-cache…/AlcLeakTest_LeakType_8df1004b5063522_…/AlcLeakTest_LeakType.dll` — the same build |
+| after each of 3 recompiles | 3, 3, 3 | those two, plus the current emit |
+
+Flat, not per-recompile — so not the unbounded curve the assertion's message describes — but a
+doubled pin on every generation a live instance runs, in every monolith and on every replica that
+compiles. The assertion (`≤ 2`: the current build plus the one generation the instance runs) was
+right; the core change was wrong. Across the 42 shard-3 runs from 05:10Z to 11:32Z on 2026-09-11 it
+failed **6 of 6** on core sets 8345/8350/8352 (all carrying #4013's fix, `b128b804d`) and **0 of 36**
+on sets 8323–8340; the same Plugins commit `401fcadb` passed at 09:56Z on 8340 and failed at 10:09Z
+on 8345.
+
+The repair keeps #4013's rule — **a read never supersedes** — and closes the duplicate at its
+source. `ResolveLoadContextForPath`, on a READ of a path it has not seen, asks whether a live
+(not retired) context of the NodeType already serves the same build — **same MVID**, read from the
+loaded assembly or, failing that, from the file's metadata via `ServedBuildIdentity.OfFile` (a header
+read, nothing loaded) — and if so answers that context, aliased under the new path. It is a REUSE:
+nothing is evicted, so the ping-pong above cannot come back through it. Three details make the alias
+safe:
+
+- **Eviction is by CONTEXT, not by key.** A read may alias the store path to the very context a
+  publish is keeping; a key-based evictor would dispose the build it had just published.
+- **A retired context is never aliased.** A publish can retire the context between the search and
+  the alias (its evictor enumerated before the alias key existed); the resolver then drops its own
+  alias and creates a fresh context, exactly as a first read of that path always did.
+- **One lease per context.** `LeaseNodeContexts` leases each context once however many keys name it,
+  so releasing the hub's one lease performs the deferred unload.
+
+No identity ⇒ no alias: an unreadable file, or an in-memory context, resolves a fresh context as
+before. Pinned in core by `ScanPinSupersessionTest.AReadOfTheStoreCopyOfThePublishedBuildIsThatBuildsContext`,
+`…AReadOfASupersededBuildsStoreCopyGetsItsOwnContextAndDoomsNothing` and
+`…AnAliasedGenerationIsLeasedOnceAndReclaimedByTheNextPublish`.
+
+🚨 **What this does NOT close.** A replica that never compiles a type still reads each new VERSION
+another replica published (a different build, a different MVID), and those reader-created contexts
+are still reclaimed only when the NodeType hub disposes — the residue the section above states. The
+alias removes the same-build duplicate; it does not decide which of two *different* builds is current,
+and must not (#4013).
+
 ### 🚨 Reading a node's content ACROSS two generations already works — #3911's headline, re-measured
 
 The 2026-09-10 control-instance incident (#3911) reported two collectible builds of

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-recompiled-type-no-longer-loads-its-build-twice.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-recompiled-type-no-longer-loads-its-build-twice.md
@@ -1,0 +1,18 @@
+---
+Name: A recompiled type no longer loads its build twice
+Category: Fix
+Description: A NodeType compiled on this server kept a second copy of each build in memory for as long as any of its instances stayed open; it now keeps one.
+Icon: Code
+Order: -20260911
+---
+
+# A recompiled type no longer loads its build twice
+
+Since this morning's compilation fix, a NodeType compiled on the same server that serves it loaded
+each new build twice — once from the compiler's output and once from the assembly store's copy of
+the same bytes — and an open instance of the type kept both copies alive until it closed. Memory
+grew by one extra build per recompile for every type with a live instance. A request for the
+store's copy now reuses the copy already loaded, so each build is loaded once, and a recompile
+releases it as before.
+
+Details: [One build at two paths is ONE generation](/Doc/Architecture/NodeTypeCompilation).

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ScanPinSupersessionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ScanPinSupersessionTest.cs
@@ -253,6 +253,93 @@ public sealed class ScanPinSupersessionTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 ONE BUILD AT TWO PATHS IS ONE GENERATION. The post-emit scan publishes from the compile's
+    /// own directory; <c>UploadToStoreIfNeeded</c> then copies those bytes into the assembly store,
+    /// and every instance activation resolves the STORE path. Since reads stopped superseding
+    /// (#4013), that read minted a second collectible context over identical bytes, and the
+    /// instance hub's lifetime lease pinned both — NodeTypeRecompileAlcLeakTest in
+    /// MeshWeaver.Plugins measured 3 live contexts against a bound of 2 on every core set carrying
+    /// #4017. A read of the store copy must answer the context the publish already created.
+    /// </summary>
+    [Fact]
+    public void AReadOfTheStoreCopyOfThePublishedBuildIsThatBuildsContext()
+    {
+        var published = EmitAssembly("emit");
+        var storeCopy = CopyToStore(published, "v3-tag-hash.dll");
+
+        using var publishScan = _service.PinForScan(NodeName, published, publishesTheBuild: true);
+        var read = _service.GetOrCreateLoadContextForPath(NodeName, storeCopy);
+
+        read.Should().BeSameAs(publishScan.Context,
+            "the store copy carries the published build's own bytes (same MVID), so a read of it is a "
+            + "read of that generation — a second collectible context over identical bytes is the "
+            + "duplicate a live instance's lease then pins for its whole lifetime");
+        read.LoadNodeAssembly().Should().NotBeNull();
+    }
+
+    /// <summary>
+    /// The reuse must be a REUSE and nothing else: once a publish has superseded the build, a read of
+    /// its store copy must NOT be handed the retired context (that would resurrect a generation the
+    /// publish already let go of, and hand a new caller a context closed to new scans), and it must
+    /// not supersede the newer publish either (#4013).
+    /// </summary>
+    [Fact]
+    public void AReadOfASupersededBuildsStoreCopyGetsItsOwnContextAndDoomsNothing()
+    {
+        var first = EmitAssembly("emit-1");
+        var firstStoreCopy = CopyToStore(first, "v1-tag-hash.dll");
+        var second = EmitAssembly("emit-2");
+
+        var firstContext = _service.PublishLoadContextForPath(NodeName, first);
+        var secondContext = _service.PublishLoadContextForPath(NodeName, second);
+        firstContext.IsDisposed.Should().BeTrue("the second publish supersedes the first generation");
+
+        var read = _service.GetOrCreateLoadContextForPath(NodeName, firstStoreCopy);
+
+        read.Should().NotBeSameAs(firstContext,
+            "a retired context is never handed to a new caller as the context for its build");
+        read.IsDisposed.Should().BeFalse();
+        read.LoadNodeAssembly().Should().NotBeNull();
+        secondContext.IsDisposed.Should().BeFalse(
+            "a read never supersedes — the published generation stays live (#4013)");
+    }
+
+    /// <summary>
+    /// A publish evicts by CONTEXT, so a store-copy alias of the build it keeps is not a
+    /// "superseded" entry — and one lease covers the generation however many paths name it.
+    /// </summary>
+    [Fact]
+    public void AnAliasedGenerationIsLeasedOnceAndReclaimedByTheNextPublish()
+    {
+        var first = EmitAssembly("emit-a");
+        var firstStoreCopy = CopyToStore(first, "v1-tag-hash.dll");
+
+        var published = _service.PublishLoadContextForPath(NodeName, first);
+        _service.GetOrCreateLoadContextForPath(NodeName, firstStoreCopy).Should().BeSameAs(published);
+
+        var lease = _service.LeaseNodeContexts(NodeName);
+        var next = _service.PublishLoadContextForPath(NodeName, EmitAssembly("emit-b"));
+
+        published.IsDisposed.Should().BeFalse("the instance's lease defers the unload while it runs");
+        next.IsDisposed.Should().BeFalse();
+        published.IsRetired.Should().BeTrue("the next publish superseded it under BOTH of its paths");
+
+        lease.Dispose();
+        published.IsDisposed.Should().BeTrue(
+            "releasing the ONE lease performs the deferred unload — a second lease taken through "
+            + "the alias would keep the generation pinned after the hub that ran it is gone");
+    }
+
+    private string CopyToStore(string dllPath, string storeFileName)
+    {
+        var storeDir = Path.Combine(_cacheDir, "store", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(storeDir);
+        var copy = Path.Combine(storeDir, storeFileName);
+        File.Copy(dllPath, copy);
+        return copy;
+    }
+
+    /// <summary>
     /// Emits a real, loadable assembly into its own release-shaped subdirectory, mirroring the
     /// one-directory-per-compile layout <c>EmitToDiskWithRetry</c> produces (which is why each
     /// recompile yields a NEW path key and evicts the previous one).


### PR DESCRIPTION
## What broke

Since core set `3.0.0-ci.8345` (the first carrying #4017, `b128b804d`), every MeshWeaver.Plugins run fails `Portal hosts (shard 3)` — including Plugins `main` — on:

> `Expected 3 to be less than or equal to 2 because a live instance hub legitimately DEFERS an unload, but nothing may make that deferral permanent: 3 contexts alive after 3 recompiles means each rebuild pins a generation for the hub's lifetime, which is the production memory curve.`

(`NodeTypeRecompileAlcLeakTest.RecompilingANodeType_WithALiveInstance_StillReleasesSupersededContexts`)

**Causation, with the denominator.** 42 shard-3 runs executed between 05:10Z and 11:32Z on 2026-09-11. The test failed **6 of 6** on sets 8345 / 8350 / 8352 (all carry #4017) and **0 of 36** on sets 8323–8340. Diff held constant: Plugins commit `401fcadb` passed at 09:56Z on 8340 and failed at 10:09Z on 8345. #4017 is the only merge between 8340 and 8345 that touches compilation code.

## Which side was wrong — the core change

The test was right. With a diagnostic that prints the FILE each live context was loaded from (Plugins side of this pair), the red run shows, at instance activation:

- `…/assembly-store…/AlcLeakTest_LeakType/v3-1a9794ba-dd22c75f5a55.dll`
- `…/mesh-cache…/AlcLeakTest_LeakType_8df1004b5063522_…/AlcLeakTest_LeakType.dll`

— the **same build at two paths**. The post-emit scan publishes from the compile's own directory; `UploadToStoreIfNeeded` copies the bytes into the assembly store; instance activation resolves the STORE path. While reads superseded, that read evicted the publish's context. #4017 (correctly) stopped reads superseding, so every locally compiled generation got a second collectible context over identical bytes, and the instance hub's lifetime lease (`LeaseNodeContexts`, every context of the NodeType) pinned both. Counts: 2 at activation, 3/3/3 after three recompiles — flat, so not the unbounded per-recompile curve, but a doubled pin on every generation a live instance runs, in every monolith and on every compiling replica. #4017's own cost statement priced its residue at "generations a process only HYDRATED" and pictured a foreign silo's build; it missed the process's own publish coming back through the store.

## The fix (forward, keeps #4013's rule)

`CompilationCacheService.ResolveLoadContextForPath`: on a **read** of a path it has not seen, if a live (not retired) context of the NodeType already serves the same build — **same MVID** (from the loaded assembly, else `ServedBuildIdentity.OfFile`, a header read) — answer that context, aliased under the new path. A reuse, never a supersession: nothing is evicted, so the #4013 ping-pong cannot return through it. Publishes are untouched.

- Eviction is by **context**, not key — an alias of the build being kept is not "superseded".
- A **retired** context is never aliased; if a publish retires it between search and alias, the resolver drops its own alias and creates a fresh context.
- `LeaseNodeContexts` leases each context **once** however many keys name it.
- No identity (unreadable file, in-memory context) ⇒ no alias, exactly as before.

Not closed, and stated in the doc: a replica that never compiles still reads each new VERSION another replica published (a different MVID); those reader-created contexts are still reclaimed at NodeType-hub disposal, as #4017 described.

## Controls — both directions, exact text

**Plugins test** (same Plugins commit `79fac200`, `MeshWeaverRoot` = this worktree, `-c Release -warnaserror`, `0 Error(s)`):
- core `origin/main` (`4526bc990`, carries #4017): **FAIL** — `Expected 3 to be less than or equal to 2 because a live instance hub legitimately DEFERS an unload…`; activation 2 contexts, then 3/3/3.
- this branch: **PASS** — activation `live contexts: 1` (the emit path; the store copy aliased), then 2/2/2.

**Core unit tests** (`ScanPinSupersessionTest`, 3 new): 22/22 green in the cache suites. Falsified by disabling only the reuse branch: `AReadOfTheStoreCopyOfThePublishedBuildIsThatBuildsContext` and `AnAliasedGenerationIsLeasedOnceAndReclaimedByTheNextPublish` go red with `Expected value to refer to the same instance because the store copy carries the published build's own bytes (same MVID)…` / `Expected value to refer to the same instance, but it did not.`; restored → green. `AReadOfASupersededBuildsStoreCopyGetsItsOwnContextAndDoomsNothing` is a guard against over-reach (no resurrection of a retired generation, no supersession by a read) and passes either way — it is not claimed as a control of the reuse.

## Cross-repo

Behaviour change behind unchanged signatures (AGENTS.md break shape 7) — recorded on `Doc/Architecture/CrossRepoPairGate`. No public type or member removed; no interface member added; no i18n key.

Pairs-with: none — no public surface removed; every changed member is internal/private (`CompilationCacheService`, `NodeAssemblyLoadContext`)

The Plugins half (`fix/alc-lease-4017-test`, a diagnostic print in the test, no assertion change) goes green once a core set carrying this seals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
