### PR TITLE
Module registry hand-over: Plugins caller wiring — roster pending state, declared output, pre-merge check-callers (#3878)

### DIFF
--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -78,7 +78,7 @@ repos:
         job: publish-modules
         lane: node-repo-module-publish.yml
         grants: {contents: read}
-        pending: lands with Systemorph/MeshWeaver.Plugins#PLUGINS_PR, which switches modules-floor to publish-mode staged and adds this caller (MeshWeaver#3878). Once it has merged the marker is spent and this row is compared key for key.
+        pending: lands with Systemorph/MeshWeaver.Plugins branch fix/3878-staged-module-publication, which switches modules-floor to publish-mode staged and adds this caller (MeshWeaver#3878). Once it has merged the marker is spent and this row is compared key for key.
       - workflow: ci.yml
         job: supersede
         lane: node-repo-supersede.yml

--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -38,6 +38,14 @@
 # TO REGENERATE A ROW, in a checkout of that repository:
 #     python3 check-workflow-permission-pairing.py --root . --emit-fleet-row Systemorph/<repo>
 #
+# 🚨 A CALLER THAT IS ARRIVING IS RECORDED HERE FIRST, AS `pending: <reason>` (MeshWeaver#3878).
+# Every satellite asserts its row against THIS file at core's `main`, so a new caller cannot land in
+# either order under strict equality: the row first reds the satellite (a recorded caller it does not
+# have), the caller first reds it too (a caller the roster does not know). `pending:` excuses ABSENCE
+# only — once the caller is present it is compared key for key, so the marker can never hide a
+# lowered grant — and core's `--fleet` checks a pending row's grant like any other, which is the
+# point of landing the row first. An empty reason is RED in both modes.
+#
 # Measured 2026-09-11 against each repository's LIVE default branch via the contents API. (A local
 # checkout is NOT a valid source here: every satellite clone on this machine was days stale and
 # reported pinned `uses:` refs and narrower grants than the live tree actually carries.)
@@ -64,6 +72,13 @@ repos:
         job: publish-bake
         lane: node-repo-publish-bake.yml
         grants: {contents: read, id-token: write}
+      # The module registry hand-over, moved out of `modules-floor`'s matrix legs to after the whole
+      # validation verdict (MeshWeaver#3878). The lane's one job demands `contents: read`.
+      - workflow: ci.yml
+        job: publish-modules
+        lane: node-repo-module-publish.yml
+        grants: {contents: read}
+        pending: lands with Systemorph/MeshWeaver.Plugins#PLUGINS_PR, which switches modules-floor to publish-mode staged and adds this caller (MeshWeaver#3878). Once it has merged the marker is spent and this row is compared key for key.
       - workflow: ci.yml
         job: supersede
         lane: node-repo-supersede.yml

--- a/.github/scripts/check-workflow-permission-pairing.py
+++ b/.github/scripts/check-workflow-permission-pairing.py
@@ -373,6 +373,24 @@ def assert_fleet_row(root: str, repo: str, roster_path: str, platform_repo: str)
     roster does not know and (b) a satellite LOWERS a grant the roster still records — both of them
     "the roster overstates", both caught here, in a job that DOES run (a roster mismatch is not a
     permission escalation, so the graph is accepted and the red is visible).
+
+    🚨 THE THIRD DIRECTION IS NEITHER OF THOSE, AND STRICT EQUALITY MADE IT UNLANDABLE. A row the
+    roster HAS and the repository does NOT is the roster overstating nothing: core checks a caller
+    that is not there yet, which is stricter than reality, never looser. But a satellite gains a
+    caller by the same inverted ordering as `Pairs-with:` — the core half lands first, because the
+    roster is how core's own pull request sees the fleet — and every satellite asserts this row
+    against core's `main` (`scripts-ref: main`). Demanding equality in that direction therefore
+    reddens EVERY pull request in that repository for the whole gap between the two merges, on a
+    caller that is arriving. Measured while wiring MeshWeaver#3878's publication job into
+    MeshWeaver.Plugins: 16 open pull requests, and `validate / Validate node repos` is a required
+    context there, so the window is a repository-wide block, not a warning.
+
+    So a row may declare itself `pending: <reason>`, and that excuses ABSENCE ONLY. The moment the
+    repository has the caller it is compared key for key like every other row, so a pending marker
+    can never launder a lowered grant or an unrecorded caller. An absent row WITHOUT the marker
+    stays RED — a caller deleted and its row forgotten is the roster describing a repository that
+    does not exist — and a marker with an empty reason is RED for the same reason `asserted-by:`
+    must say something.
     """
     roster = _load_roster(roster_path)
     entry = roster["repos"].get(repo)
@@ -385,11 +403,47 @@ def assert_fleet_row(root: str, repo: str, roster_path: str, platform_repo: str)
                 f"a change to a lane it calls is checked against NOTHING in that repo's own pull "
                 f"request — which is how MeshWeaver#3933 reached 28 zero-job runs.\n" + recipe]
     want = sorted((entry.get("callers") or []), key=lambda r: (str(r.get("workflow")), str(r.get("job"))))
-    if [_row_key(r) for r in want] == [_row_key(r) for r in actual]:
-        return []
-    out = [f"fleet roster: {repo}'s recorded callers no longer match this repository.\n"
-           f"      recorded: {[_row_key(r) for r in want]}\n"
-           f"      actual:   {[_row_key(r) for r in actual]}\n" + recipe]
+    recorded_keys = {_row_key(r) for r in want}
+    present_keys = {_row_key(r) for r in actual}
+    out: list[str] = []
+
+    # (a) + (b) — the two directions in which the roster OVERSTATES. Every caller this repository
+    # really has must be recorded WITH EXACTLY ITS GRANT; a lowered grant changes the key, so it
+    # arrives here as an unrecorded caller rather than slipping through as a match.
+    for row in actual:
+        if _row_key(row) not in recorded_keys:
+            out.append(
+                f"fleet roster: {repo} calls `{row['lane']}` from {row['workflow']}#{row['job']} "
+                f"granting {row['grants']}, and the roster records no such caller — it was either "
+                f"ADDED here without a row or LOWERED away from the grant recorded. Both make core's "
+                f"fleet check answer a confident green on a broken fleet.\n"
+                f"      recorded: {sorted(recorded_keys)}\n"
+                f"      actual:   {sorted(present_keys)}\n" + recipe)
+
+    # (c) — a row this repository does not have. Safe for core, so it is a refusal only when nothing
+    # DECLARED it, and the declaration has to say something.
+    for row in want:
+        label = f"{row.get('workflow')}#{row.get('job')} -> {row.get('lane')}"
+        if _row_key(row) in present_keys:
+            if "pending" in row:
+                print(f"  note: {label} is still marked `pending:` in the roster and this repository "
+                      f"now HAS it — the marker is spent; remove it from {platform_repo}.")
+            continue
+        pending = row.get("pending")
+        if pending is None:
+            out.append(
+                f"fleet roster: the roster records {repo} calling {label}, which this repository does "
+                f"not have. A row whose caller was DELETED describes a repository that no longer "
+                f"exists; a row whose caller has not LANDED yet must say so with "
+                f"`pending: <reason naming the pull request that lands it>`.\n" + recipe)
+        elif not str(pending).strip():
+            out.append(
+                f"fleet roster: {repo}'s row for {label} is marked `pending:` with no reason. An "
+                f"exemption that says nothing is indistinguishable from one nobody meant — name the "
+                f"pull request that lands the caller.")
+        else:
+            print(f"  note: {label} is recorded as PENDING and is not in this repository yet — "
+                  f"{str(pending).strip()}")
     return out
 
 

--- a/.github/scripts/check-workflow-permission-pairing.py
+++ b/.github/scripts/check-workflow-permission-pairing.py
@@ -68,6 +68,15 @@ legitimate; demanding it without pairing the callers is the defect.
 It does not claim to cover a lane nobody is recorded as calling. Those are PRINTED with the verdict,
 never silently folded into a green (`--fleet` names them), because a lane with zero known callers is
 a coverage gap, not a clean measurement.
+
+A ROW MAY BE `pending: <reason>` (MeshWeaver#3878)
+-------------------------------------------------
+A satellite GAINS a caller by the same inverted ordering as `Pairs-with:`: the roster row lands in
+core first, so core's own pull request checks the new pair before either half merges. Strict
+equality in `--assert-fleet-row` made that ordering unlandable — whichever half merged first reddened
+the satellite's required `validate` context — so a row may say it is still arriving. `pending:`
+excuses ABSENCE only: a present caller is compared key for key like every other row, an empty reason
+is RED in both modes, and `--fleet` still checks the pending row's grant against the lane.
 """
 from __future__ import annotations
 import argparse, copy, os, sys, glob, tempfile
@@ -91,6 +100,7 @@ except ImportError:
 DEFAULT_FLOOR = {"contents": "read", "packages": "read", "metadata": "read"}
 
 WORKFLOW_LEVEL = "«workflow»"           # the pseudo-job name a workflow-level demand is reported as
+PENDING_NOTE = "PENDING: "              # a fleet note that IS covered, as opposed to a NOT COVERED one
 
 # Scopes the real-tree control below strengthens a lane with, in order. The first one the caller
 # demonstrably does not grant is used, so the control mutates a lane the repo ACTUALLY calls rather
@@ -312,6 +322,16 @@ def check_fleet(root: str, roster_path: str) -> tuple[list[str], int, list[str]]
             lane_name = str(caller.get("lane") or "")
             grants = _roster_grants(caller.get("grants"))
             label = f"{repo} {caller.get('workflow')}#{caller.get('job')}"
+            if "pending" in caller:
+                reason = str(caller.get("pending") or "").strip()
+                if not reason:
+                    problems.append(
+                        f"fleet roster: {label} is marked `pending:` with no reason. The marker excuses "
+                        f"a caller that has not LANDED yet, and an exemption that says nothing is "
+                        f"indistinguishable from one nobody meant — name the pull request that lands it.")
+                else:
+                    notes.append(f"{PENDING_NOTE}{label} -> {lane_name}: its grant IS checked below; "
+                                 f"{repo} asserts only that the caller has not landed yet — {reason}")
             if lane_name not in lanes:
                 problems.append(
                     f"fleet roster: {label} calls `{lane_name}`, which this checkout does not have as "
@@ -600,6 +620,53 @@ def _roster_roundtrip_cases(fleet: str) -> list[tuple[str, bool]]:
     return cases
 
 
+def _pending_cases(fleet: str) -> list[tuple[str, bool]]:
+    """🚨 CONTROLS ON THE `pending:` STATE, both directions, from the REAL roster's first row.
+
+    The marker is an exemption, and an exemption that has never been shown to be NARROW is a hole.
+    So each case below is a way it could be too wide — excusing a deleted caller, excusing nothing
+    in particular, or laundering a lowered grant — and each must red, beside the one shape it exists
+    for (a caller that has not landed yet), which must not.
+    """
+    doc = _load(fleet)
+    if isinstance(doc, Exception) or not isinstance(doc, dict) or not (doc.get("repos") or {}):
+        return [("the fleet roster parses and has rows to build the pending controls from", False)]
+    repo, entry = sorted((doc.get("repos") or {}).items())[0]
+    rows = copy.deepcopy((entry or {}).get("callers") or [])
+    arriving = {"workflow": "ci.yml", "job": "arriving-caller", "lane": "node-repo-gate.yml",
+                "grants": {"contents": "read", "id-token": "write"}}
+
+    def roster_with(extra: dict) -> str:
+        d = copy.deepcopy(doc)
+        d["repos"][repo] = dict(d["repos"][repo] or {})
+        d["repos"][repo]["callers"] = rows + [extra]
+        fd, path = tempfile.mkstemp(prefix="wfperm-roster-", suffix=".yml")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            yaml.safe_dump(d, fh, sort_keys=False)
+        return path
+
+    def verdict(extra: dict, present: list[dict]) -> list[str]:
+        import contextlib, io
+        with contextlib.redirect_stdout(io.StringIO()):
+            return assert_fleet_row(_materialize_row(rows + present, "Systemorph/MeshWeaver"), repo,
+                                    roster_with(extra), "Systemorph/MeshWeaver")
+
+    pending = dict(arriving, pending="lands with a named pull request")
+    lowered = dict(arriving, grants={"contents": "read"})
+    return [
+        ("a `pending:` row whose caller has NOT landed passes — the window the marker exists for",
+         verdict(pending, []) == []),
+        ("the same row WITHOUT the marker is caught — a caller deleted and its row forgotten",
+         verdict(arriving, []) != []),
+        ("a `pending:` marker with an EMPTY reason is caught",
+         verdict(dict(arriving, pending="  "), []) != []),
+        ("a SPENT marker (the caller has landed, exact grant) passes and is compared key for key",
+         verdict(pending, [arriving]) == []),
+        ("a `pending:` marker cannot launder a LOWERED grant once the caller lands",
+         verdict(pending, [lowered]) != []),
+    ]
+
+
 def _real_tree_cases(root: str, platform_root: str | None, fleet: str | None) -> list[tuple[str, bool]]:
     """🚨 CONTROLS DERIVED FROM THE REAL TREE, IN BOTH DIRECTIONS.
 
@@ -645,6 +712,7 @@ def _real_tree_cases(root: str, platform_root: str | None, fleet: str | None) ->
 
     if fleet:
         cases += _roster_roundtrip_cases(fleet)
+        cases += _pending_cases(fleet)
 
     # 🚨 THE FLEET CONTROLS BELONG TO THE CHECKOUT THAT OWNS THE LANES, and asking a satellite to run
     # them reds it for a true statement. A satellite's `--root` holds callers and no lane at all, so
@@ -657,6 +725,21 @@ def _real_tree_cases(root: str, platform_root: str | None, fleet: str | None) ->
         fleet_problems, fleet_pairs, _ = check_fleet(root, fleet)
         cases.append((f"the unmodified tree passes the fleet roster ({fleet_pairs} pair(s))",
                       not fleet_problems and fleet_pairs > 0))
+
+        # An empty `pending:` reason must red HERE, in core's pull request — not first in a satellite.
+        roster_doc = copy.deepcopy(_load(fleet))
+        first_repo = sorted(roster_doc["repos"])[0]
+        first_rows = (roster_doc["repos"][first_repo] or {}).get("callers") or []
+        if first_rows:
+            first_rows[0]["pending"] = ""
+            fd, blank = tempfile.mkstemp(prefix="wfperm-blank-pending-", suffix=".yml")
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                yaml.safe_dump(roster_doc, fh, sort_keys=False)
+            probs, _, _ = check_fleet(root, blank)
+            cases.append(("an EMPTY `pending:` reason reds the fleet check in core itself",
+                          any("`pending:` with no reason" in p for p in probs)))
+        else:
+            cases.append((f"{first_repo} has a roster row to blank a `pending:` reason on", False))
 
         # 🚨 THE 2026-09-10 SHAPE, ON THE REAL TREE. #3933 put `id-token: write` on
         # node-repo-module-pack.yml's `pack`. Core's own caller grants it; MeshWeaver.Plugins'
@@ -753,7 +836,9 @@ def main() -> int:
               f"resolved, {len(problems)} violation(s), root={os.path.abspath(args.root)}, "
               f"roster={os.path.abspath(args.fleet)}")
         for n in notes:
-            print(f"  NOT COVERED: {n}")
+            # A pending row is COVERED — its grant is checked above — so it must not be printed under
+            # the heading that names what this check cannot see.
+            print(f"  {n}" if n.startswith(PENDING_NOTE) else f"  NOT COVERED: {n}")
         if pairs == 0:
             print("  NOTE: zero roster pairs resolved — the roster is empty or names no lane this "
                   "checkout has. Zero is not a pass.")

--- a/.github/scripts/module-publication.py
+++ b/.github/scripts/module-publication.py
@@ -32,6 +32,12 @@ its whole validation set, and it is deliberately built so that "the validation d
                 literal, and must account for every other job in the workflow — covered, or
                 declared unrelated with a reason. This is the half `verdict` cannot see: a
                 dependency dropped from `needs:` AND from `required-jobs` is invisible at runtime.
+  check-callers The same caller-graph check, run BEFORE MERGE over every workflow in a repository
+                (node-repo-validate.yml runs it on every satellite pull request), plus the wiring
+                one call cannot see: every `publish-mode: staged` pack call has exactly one
+                publisher reading its `lane`/`selected`/`declared` outputs, and that publisher runs
+                on exactly the events the pack call stages on. A staged pack call nobody publishes
+                would hand the registry NOTHING, silently — the FrameworkDeclined outage of #2088.
   publish       The staged evidence is matched against the selection before ONE byte is POSTed:
                 exactly one publication record per selected module, stamped with THIS call's lane,
                 naming the bytes by sha256 and the framework identity read back off those bytes.
@@ -44,6 +50,7 @@ USAGE
   module-publication.py check-caller --workflow .github/workflows/ci.yml \\
         --uses node-repo-module-publish.yml --required "validate compile-check" \\
         --unrelated "auto-arm: arms auto-merge, validates nothing"
+  module-publication.py check-callers --root .
   module-publication.py publish --staged DIR --lane L --declared @modules.json \\
         --selected "MeshWeaver.AI" --registry https://memex.meshweaver.cloud --source Plugins
   module-publication.py --self-test
@@ -308,6 +315,157 @@ def check_caller(workflow: Path, uses_suffix: str, required_raw: str, unrelated_
     return 1 if problems else 0
 
 
+# ══════════════════════════════════ check-callers ══════════════════════════════════
+PACK_LANE = "node-repo-module-pack.yml"
+PUBLISH_LANE = "node-repo-module-publish.yml"
+
+
+def _norm_condition(value) -> str:
+    """A job `if:` or a pack call's `publish:` in comparable form.
+
+    `${{ }}` is decoration on both (a job `if:` is an expression either way), a folded scalar adds
+    line breaks, and an absent `if:` means "always" — so all three are normalised away before the
+    two are compared. Nothing is EVALUATED: two different spellings of one condition read as a
+    mismatch, which is the safe direction for a check whose failure mode is silence.
+    """
+    if value is None or value is True:
+        return "true"
+    if value is False:
+        return "false"
+    text = str(value).strip()
+    m = re.fullmatch(r"\$\{\{(.*)\}\}", text, re.S)
+    if m:
+        text = m.group(1)
+    return re.sub(r"\s+", " ", text).strip()
+
+
+def _needs_output(value, output: str) -> str | None:
+    """The job X in `${{ needs.X.outputs.<output> }}`, or None for any other shape."""
+    m = re.fullmatch(r"\$\{\{\s*needs\.([A-Za-z0-9_-]+)\.outputs\.([A-Za-z0-9_-]+)\s*\}\}",
+                     str(value or "").strip())
+    return m.group(1) if m and m.group(2) == output else None
+
+
+def _calls(jobs: dict, lane: str) -> dict[str, dict]:
+    return {jid: job for jid, job in jobs.items()
+            if isinstance(job, dict) and isinstance(job.get("uses"), str)
+            and job["uses"].split("@")[0].rstrip("/").endswith("/" + lane)}
+
+
+def check_callers(root: Path) -> int:
+    """Every module publication in `root` is wired to wait for its whole validation verdict.
+
+    🚨 WHY THIS RUNS BEFORE MERGE. `node-repo-module-publish.yml` runs `check-caller` itself, but
+    only when it is invoked — on trunk. A publisher broken on a pull request is first judged by the
+    post-merge run on `main`, which refuses (fail-closed: the registry is untouched) and reds main.
+    And one call cannot see the other half at all: a pack call switched to `staged` whose publisher
+    was never added, or runs on fewer events, hands the registry NOTHING and reports green.
+    """
+    try:
+        import yaml
+    except ImportError:
+        die("module-publication.py check-callers needs PyYAML (pip install pyyaml)")
+    wf_dir = root / ".github" / "workflows"
+    if not wf_dir.is_dir():
+        die(f"`{wf_dir}` does not exist — this check read no workflow at all, and a check that read "
+            "nothing must never pass.")
+    files = sorted(list(wf_dir.glob("*.yml")) + list(wf_dir.glob("*.yaml")))
+    problems: list[str] = []
+    n_pack = n_pub = 0
+    for wf in files:
+        try:
+            doc = yaml.safe_load(wf.read_text(encoding="utf-8")) or {}
+        except Exception as exc:  # noqa: BLE001
+            problems.append(f"`{wf.name}` does not parse as YAML ({exc}) — its publications, if any, "
+                            "could not be checked.")
+            continue
+        jobs = doc.get("jobs") if isinstance(doc, dict) else None
+        if not isinstance(jobs, dict):
+            continue
+        packs, pubs = _calls(jobs, PACK_LANE), _calls(jobs, PUBLISH_LANE)
+        n_pack += len(packs)
+        n_pub += len(pubs)
+
+        for pid, pj in sorted(pubs.items()):
+            w = pj.get("with") or {}
+            required, unrelated = w.get("required-jobs"), w.get("unrelated-jobs") or ""
+            for key, val in (("required-jobs", required), ("unrelated-jobs", unrelated)):
+                if "${{" in str(val or ""):
+                    problems.append(f"{wf.name}: `{pid}` passes `{key}` as an expression. It must be a "
+                                    "literal, so the static half of this gate reads the same list the "
+                                    "lane will enforce.")
+            if not names(str(required or "")):
+                problems.append(f"{wf.name}: `{pid}` declares no `required-jobs` — the lane refuses an "
+                                "empty list at run time, so this publisher would never publish.")
+            print(f"== {wf.name}#{pid}: the caller-graph check the publication lane runs on trunk")
+            if check_caller(wf, PUBLISH_LANE, str(required or ""), str(unrelated)) != 0:
+                problems.append(f"{wf.name}: `{pid}` fails the caller-graph check above — on trunk "
+                                "the publication lane would refuse the same way, after the merge.")
+
+            src = _needs_output(w.get("lane"), "lane")
+            if src is None:
+                problems.append(f"{wf.name}: `{pid}` must pass `lane` as the lane output of the pack "
+                                f"call it publishes (needs.<call>.outputs.lane) — got {w.get('lane')!r}. "
+                                "Artifacts are run-wide; without the lane key a sibling call's bundles "
+                                "could answer this publication.")
+                continue
+            if src not in packs:
+                problems.append(f"{wf.name}: `{pid}` reads its lane from `{src}`, which is not a "
+                                f"{PACK_LANE} call in this workflow.")
+                continue
+            for key, output in (("selected", "selected"), ("modules", "declared")):
+                if _needs_output(w.get(key), output) != src:
+                    problems.append(f"{wf.name}: `{pid}` must pass `{key}` as "
+                                    f"needs.{src}.outputs.{output} — the SAME call whose lane it "
+                                    f"publishes — got {w.get(key)!r}.")
+            need = pj.get("needs") or []
+            need = [need] if isinstance(need, str) else need
+            if src not in need:
+                problems.append(f"{wf.name}: `{pid}` reads needs.{src}.outputs but `{src}` is not in "
+                                "its own `needs:` — that context resolves only for a job named there.")
+            pw = packs[src].get("with") or {}
+            mode = str(pw.get("publish-mode", "direct")).strip()
+            if mode != "staged":
+                problems.append(f"{wf.name}: `{pid}` publishes `{src}`, whose publish-mode is "
+                                f"`{mode}`, not `staged` — that call POSTs in-leg itself and stages "
+                                "nothing, so this lane would refuse on an empty staged set.")
+            stage_on, publish_on = _norm_condition(pw.get("publish", False)), _norm_condition(pj.get("if"))
+            if stage_on != publish_on:
+                problems.append(
+                    f"{wf.name}: `{src}` stages on `{stage_on}` but `{pid}` runs on `{publish_on}`. A "
+                    "run that stages and does not publish hands the registry NOTHING while every tick "
+                    "is green (every portal then reads FrameworkDeclined, #2088); a run that publishes "
+                    "without staging refuses. Give the publisher exactly the pack call's condition.")
+
+        for kid, kj in sorted(packs.items()):
+            kw = kj.get("with") or {}
+            mode = str(kw.get("publish-mode", "direct")).strip()
+            wired = sorted(pid for pid, pj in pubs.items()
+                           if _needs_output((pj.get("with") or {}).get("lane"), "lane") == kid)
+            if mode == "staged" and not wired:
+                problems.append(
+                    f"{wf.name}: `{kid}` stages its bundles (publish-mode: staged) and NO "
+                    f"{PUBLISH_LANE} job reads its lane — the staged bytes reach nobody, and this "
+                    "repository silently stops publishing modules.")
+            elif mode == "staged" and len(wired) > 1:
+                problems.append(f"{wf.name}: `{kid}` is published by {len(wired)} jobs ({', '.join(wired)}) "
+                                "— the same bytes would be POSTed twice from one validated call.")
+            elif mode != "staged" and _norm_condition(kw.get("publish", False)) != "false":
+                print(f"  NOTE: {wf.name}#{kid} publishes IN-LEG (publish-mode: {mode}): each module "
+                      "reaches the registry right after its own suite, before this run's other gates "
+                      f"report (MeshWeaver#3878). Not refused here; adopt publish-mode: staged and a "
+                      f"{PUBLISH_LANE} job.")
+
+    print(f"module-publication check-callers: {n_pack} {PACK_LANE} call(s) and {n_pub} {PUBLISH_LANE} "
+          f"call(s) across {len(files)} workflow file(s) under {wf_dir}")
+    if not n_pack and not n_pub:
+        print("  this repository calls neither lane — nothing here hands module bundles to a registry, "
+              "so there is no hand-over to order.")
+    for p in problems:
+        print(f"::error title=Publication wiring::{p}", file=sys.stderr)
+    return 1 if problems else 0
+
+
 # ══════════════════════════════════ publish ══════════════════════════════════
 REQUIRED_RECORD_FIELDS = ("lane", "package", "module", "version", "frameworkIdentity")
 
@@ -520,6 +678,11 @@ def self_test() -> int:  # noqa: C901 — a table of cases reads better than a d
     import tempfile
 
     failures: list[str] = []
+    # 🚨 The cases below drive `verdict`/`publish` into their REFUSED arms on purpose, and both write
+    # a table to $GITHUB_STEP_SUMMARY. Left set, the job summary of every run that proves this gate
+    # (the publication lane itself, node-repo-validate) opens with "REFUSED — nothing was handed to
+    # the registry" for a publication that never existed.
+    os.environ.pop("GITHUB_STEP_SUMMARY", None)
 
     def check(label: str, ok: bool, detail: str = ""):
         print(("  ok   " if ok else "  FAIL ") + label + (f" — {detail}" if detail and not ok else ""))
@@ -643,6 +806,86 @@ jobs:
             "node-repo-module-publish.yml@abc", "node-repo-tag-modules.yml@abc"))
         check("a workflow with NO publishing job refuses (empty denominator)", rc == 1, out)
 
+    print("== check-callers (the pre-merge half, over a whole repository)")
+    wired = """
+name: ci
+on: { push: { branches: [main] }, pull_request: {} }
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps: [{ run: echo }]
+  modules:
+    needs: [validate]
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@main
+    with:
+      publish: >-
+        ${{ github.event_name == 'push'
+        || github.event_name == 'schedule' }}
+      publish-mode: staged
+  gate:
+    needs: [modules]
+    runs-on: ubuntu-latest
+    steps: [{ run: echo }]
+  publish-modules:
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'schedule'
+    needs: [validate, modules, gate]
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-publish.yml@main
+    with:
+      verdicts: ${{ toJSON(needs) }}
+      required-jobs: validate modules gate
+      lane: ${{ needs.modules.outputs.lane }}
+      selected: ${{ needs.modules.outputs.selected }}
+      modules: ${{ needs.modules.outputs.declared }}
+      platform-ref: abc
+"""
+    with tempfile.TemporaryDirectory() as td:
+        repo = Path(td)
+        (repo / ".github" / "workflows").mkdir(parents=True)
+
+        def callers(text: str) -> tuple[int, str]:
+            (repo / ".github" / "workflows" / "ci.yml").write_text(text, encoding="utf-8")
+            return run(check_callers, repo)
+
+        rc, out = callers(wired)
+        check("a staged pack call with one publisher on the same events passes", rc == 0, out)
+        rc, out = callers(wired.split("  publish-modules:")[0])
+        check("MUTATION: a staged pack call whose publisher was never added is caught",
+              rc == 1 and "reach nobody" in out, out)
+        rc, out = callers(wired.replace("      github.event_name == 'push' ||\n", ""))
+        check("MUTATION: a publisher running on FEWER events than the pack call stages on is caught",
+              rc == 1 and "stages on" in out, out)
+        rc, out = callers(wired.replace("needs: [validate, modules, gate]", "needs: [validate, modules]"))
+        check("MUTATION: a required dependency dropped from the publisher's `needs:` is caught pre-merge",
+              rc == 1 and "gate" in out, out)
+        rc, out = callers(wired.replace("    if: >\n", "    if: ${{ !cancelled() }} && >\n", 1)
+                          .replace("    if: ${{ !cancelled() }} && >\n      github.event_name == 'push' ||\n"
+                                   "      github.event_name == 'schedule'\n",
+                                   "    if: ${{ !cancelled() }}\n"))
+        check("MUTATION: a status function on the publisher's `if:` is caught pre-merge",
+              rc == 1 and "status function" in out, out)
+        rc, out = callers(wired.replace("publish-mode: staged", "publish-mode: direct"))
+        check("a publisher wired to a pack call that still POSTs in-leg is caught",
+              rc == 1 and "not `staged`" in out, out)
+        rc, out = callers(wired.replace("${{ needs.modules.outputs.declared }}", "'[]'"))
+        check("a publisher whose `modules` is not the pack call's own `declared` output is caught",
+              rc == 1 and "declared" in out, out)
+        rc, out = callers(wired.replace("${{ needs.modules.outputs.lane }}", "catalog"))
+        check("a publisher whose `lane` is a literal rather than the call's lane output is caught",
+              rc == 1 and "lane output" in out, out)
+        rc, out = callers(wired.replace("required-jobs: validate modules gate",
+                                        "required-jobs: ${{ vars.REQUIRED }}"))
+        check("a `required-jobs` passed as an expression is caught (the static half could not read it)",
+              rc == 1 and "expression" in out, out)
+        direct = wired.split("  publish-modules:")[0].replace("publish-mode: staged", "publish-mode: direct")
+        rc, out = callers(direct)
+        check("an in-leg (direct) publisher is NOT refused, but is NAMED", rc == 0 and "IN-LEG" in out, out)
+        rc, out = callers("on: push\njobs:\n  a:\n    runs-on: ubuntu-latest\n    steps: [{ run: echo }]\n")
+        check("a repository calling neither lane passes and SAYS so", rc == 0 and "neither lane" in out, out)
+        rc, out = run(check_callers, repo / "missing")
+        check("a root with no workflow directory refuses — it read nothing", rc == 1, out)
+
     print("== publish")
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
@@ -735,7 +978,8 @@ jobs:
 
 def main() -> int:
     p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
-    p.add_argument("command", nargs="?", choices=("verdict", "check-caller", "publish"))
+    p.add_argument("command", nargs="?", choices=("verdict", "check-caller", "check-callers", "publish"))
+    p.add_argument("--root", default="")
     p.add_argument("--verdicts", default="")
     p.add_argument("--required", default="")
     p.add_argument("--unrelated", default="")
@@ -762,6 +1006,10 @@ def main() -> int:
         if not a.workflow:
             p.error("check-caller needs --workflow")
         return check_caller(Path(a.workflow), a.uses, a.required, a.unrelated)
+    if a.command == "check-callers":
+        if not a.root:
+            p.error("check-callers needs --root")
+        return check_callers(Path(a.root))
     if a.command == "publish":
         for needed in ("staged", "registry", "source"):
             if not getattr(a, needed):

--- a/.github/scripts/test-module-publication.py
+++ b/.github/scripts/test-module-publication.py
@@ -370,6 +370,16 @@ def main() -> int:  # noqa: C901
     check("the lane publishes its `lane` key so one publication can only reach one call's evidence",
           "lane" in outs)
     check("…and its `selected` set, so a module that never staged is a NAMED refusal", "selected" in outs)
+    # The matrix the call was GIVEN, so the publisher's set-aside check reads the one catalog the pack
+    # call was handed instead of a second copy of it in the caller (Plugins refuses a second
+    # `modules:` list in its ci.yml, #3732 — and a copy drifts).
+    check("…and the matrix it was GIVEN (`declared`), routed through `select`",
+          "declared" in outs and str((outs.get("declared") or {}).get("value", "")).replace(" ", "")
+          == "${{jobs.select.outputs.declared}}", str(outs.get("declared")))
+    select_outs = pack["jobs"]["select"].get("outputs") or {}
+    check("…fed VERBATIM from the `modules` input, never a derived or filtered list",
+          str(select_outs.get("declared", "")).replace(" ", "") == "${{inputs.modules}}",
+          str(select_outs.get("declared")))
 
     steps = {s.get("id") or s.get("name"): s for s in (pack["jobs"]["pack"]["steps"])}
     handover = steps.get("publish")

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -74,7 +74,7 @@ name: node-repo module pack
 #       required-jobs: <the same list, by name>
 #       lane:     ${{ needs.module-pack.outputs.lane }}
 #       selected: ${{ needs.module-pack.outputs.selected }}
-#       modules:  <the same JSON matrix this call was given>
+#       modules:  ${{ needs.module-pack.outputs.declared }}   # this call's own catalog, never a copy
 #       platform-ref: <the same pin>
 #     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
 #
@@ -599,6 +599,14 @@ on:
           the receipts against. The publication lane requires a staged record for every one of
           them, so "its leg never staged" cannot read like "there was nothing to stage".
         value: ${{ jobs.select.outputs.selected }}
+      declared:
+        description: >
+          The module matrix this call was GIVEN (the `modules` input), verbatim. A caller wiring
+          `node-repo-module-publish.yml` passes it as that lane's `modules`, so the publisher sets
+          aside any staged record outside this call's catalog without the caller keeping a SECOND
+          copy of the catalog — a copy drifts, and MeshWeaver.Plugins refuses a second `modules:`
+          list in its ci.yml outright (#3732). MeshWeaver#3878.
+        value: ${{ jobs.select.outputs.declared }}
 
 jobs:
   # ─────────────────────── WHICH BUNDLES THIS DIFF CAN REACH ───────────────────────
@@ -624,6 +632,9 @@ jobs:
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
       lane: ${{ steps.lane.outputs.id }}
+      # The matrix as GIVEN, for the workflow's `declared` output — never the selection above, which a
+      # narrowed run shrinks; the publication lane's set-aside check needs the whole catalog.
+      declared: ${{ inputs.modules }}
     steps:
       # ───────────── THIS CALL'S ARTIFACT NAMESPACE — derived, never assumed ─────────────
       # 🚨 ARTIFACTS ARE RUN-WIDE. A repo may invoke this reusable workflow more than once in one

--- a/.github/workflows/node-repo-module-publish.yml
+++ b/.github/workflows/node-repo-module-publish.yml
@@ -63,13 +63,19 @@ name: node-repo module publish
 #       required-jobs: preflight validate repo-gates compile-check test-repos tests-ratchet portal-hosts-gate modules-floor
 #       lane:     ${{ needs.modules-floor.outputs.lane }}
 #       selected: ${{ needs.modules-floor.outputs.selected }}
-#       modules:  ${{ ... the same JSON the modules-floor call was given ... }}
+#       modules:  ${{ needs.modules-floor.outputs.declared }}   # the pack call's own catalog, never a copy
 #       platform-ref: ${{ needs.platform-ref.outputs.sha }}
 #     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
 #
 # One call per pack call: the lane, the selection and the declared matrix all belong to ONE call
 # of the pack workflow (Plugins runs two — floor and rest), and mixing them would be exactly the
 # run-wide-artifact confusion the lane key exists to prevent (Plugins#1077).
+#
+# 🚨 THE WIRING IS CHECKED BEFORE MERGE, not only here. This lane runs its caller-graph check when it
+# is invoked, which is on trunk — after the merge that broke it. `node-repo-validate.yml` runs
+# `module-publication.py check-callers` on every pull request of every satellite: the same graph
+# check, plus what one call cannot see — every `publish-mode: staged` pack call has exactly one
+# publisher on its `lane`/`selected`/`declared` outputs, running on exactly the events it stages on.
 #
 # WHAT IS NOT IN SCOPE HERE, and must not be described as solved by it (#3878): atomic visibility
 # if the publication ITSELF fails or is cancelled part-way, every publisher's source provenance,

--- a/.github/workflows/node-repo-validate.yml
+++ b/.github/workflows/node-repo-validate.yml
@@ -142,6 +142,12 @@ jobs:
           gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/check-workflow-permission-pairing.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/check-workflow-permission-pairing.py" \
             || { echo "::error::could not fetch .github/scripts/check-workflow-permission-pairing.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
           head -c 400 "$RUNNER_TEMP/check-workflow-permission-pairing.py" | grep -q "check-workflow-permission-pairing" || { echo "::error::the fetched check-workflow-permission-pairing.py at ${SCRIPTS_REF} does not look like the guard"; exit 1; }
+          # MeshWeaver#3878: the module publication gate. Its caller-graph check used to run only INSIDE
+          # the publication lane — on trunk, after the merge that broke it — so it is fetched here too
+          # and run against this repository's callers on every pull request (step further down).
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/module-publication.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/module-publication.py" \
+            || { echo "::error::could not fetch .github/scripts/module-publication.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver — a pin older than the guard needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/module-publication.py" | grep -q "module-publication" || { echo "::error::the fetched module-publication.py at ${SCRIPTS_REF} does not look like the publication gate"; exit 1; }
           # 🚨 The pairing guard needs the LANE DEFINITIONS, not just the script: the defect is a
           # relation between this repo's caller and the lane it is about to call, and neither half
           # alone shows it. Fetch every shared lane at the same ref into a platform root. A fetch
@@ -204,6 +210,18 @@ jobs:
       # visible). Re-measure with `--emit-fleet-row` and land the printed block in core.
       - name: "This repo's callers still match the platform's fleet roster"
         run: python3 "$RUNNER_TEMP/check-workflow-permission-pairing.py" --root . --fleet "$RUNNER_TEMP/lane-caller-grants.yml" --assert-fleet-row "${{ github.repository }}"
+      # 🚨 MeshWeaver#3878: A MODULE REGISTRY HAND-OVER WAITS FOR THE WHOLE VALIDATION VERDICT, and the
+      # wiring that makes it wait is checked HERE, before merge. `node-repo-module-publish.yml` runs
+      # the same caller-graph check itself, but only on trunk — the first run of a broken publisher
+      # would be the post-merge run on `main`, refusing, with nothing published and main red. This
+      # step runs it against every publisher in this repo's workflows on the pull request, and adds
+      # the wiring the lane cannot see from inside one call: every `publish-mode: staged` pack call
+      # has exactly one publisher on its `lane`, `selected` and `declared` outputs, and that publisher
+      # runs on exactly the events the pack call stages on. A repo that calls neither lane prints so.
+      - name: "The module publication gate can refuse (self-test)"
+        run: python3 "$RUNNER_TEMP/module-publication.py" --self-test
+      - name: "A module registry hand-over waits for this repo's whole validation verdict"
+        run: python3 "$RUNNER_TEMP/module-publication.py" check-callers --root .
       - name: "Every job is capped at 45 minutes — the gate can fail (self-test)"
         run: python3 "$RUNNER_TEMP/check-workflow-timeouts.py" --self-test
       - name: "Every job in this repo's workflows is capped at 45 minutes"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePublicationGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePublicationGate.md
@@ -135,6 +135,83 @@ publication. Two things run in core CI instead, self-test first:
   leaves the request log EMPTY even though the module packed and staged successfully. "The registry
   was left untouched" is read off the log, never off an exit code.
 
+## The caller that adopted it: MeshWeaver.Plugins
+
+`modules-floor` passes `publish-mode: staged`; everything it builds, uploads, marks and tests stays
+exactly where it was, because `compile-check` and the Tests-area gate consume those artifacts. The
+POST moved into a new job, `publish-modules`, which calls this lane:
+
+| input | value | why |
+|---|---|---|
+| `if:` | `modules-floor`'s `publish:` condition, verbatim — push to `main`, `repository_dispatch`, `schedule` | a run that stages and does not publish hands the registry nothing while every tick is green |
+| `needs:` / `required-jobs` | `platform-ref preflight validate validate-name-shim repo-gates compile-check test-repos tests-ratchet portal-hosts-gate modules-floor gates-executed` | the gate set `publish-bake` already honours, plus the jobs this call reads outputs from, the legacy-name shim of `validate` and the skip detector — one verdict for both publishers of the run |
+| `unrelated-jobs` | `supersede`, `test-drift`, `rn-app`, `e2e-static`, `memex-template`, `tag-modules`, `publish-bake`, each with its reason | none of them validates bytes that reach a module bundle |
+| `lane` / `selected` / `modules` | `needs.modules-floor.outputs.lane` / `.selected` / `.declared` | one pack call, one publication; `declared` is the matrix that call was given |
+| `permissions` | `contents: read` | exactly what the lane's one job demands |
+| `publish-token` | `secrets.REGISTRY_PUBLISH_TOKEN` | the SAME secret `modules-floor` used to hold — no new credential, scope or permission |
+
+`declared` is a new output of `node-repo-module-pack.yml`: the `modules` input, verbatim. Without it
+the publisher would need a second copy of the 37-entry catalog in the caller, which drifts — and
+Plugins' `check-modules-published.py` refuses a second `modules:` list in its `ci.yml` outright
+(#3732).
+
+The token's `pr-secret-preflight-allow.txt` entry, which exempted it on `modules-floor`, is deleted
+in the same change: `publish-modules`' `if:` is provably false on a pull request, so no
+pull-request-reachable job references the token any more and the checker refuses a stale entry.
+
+## Both directions, on the real caller
+
+**Green validation publishes.** Every job in `needs:` succeeds, so GitHub runs `publish-modules`;
+the verdict, the caller-graph check and the staged-evidence check pass; the exact staged bytes are
+POSTed to `/api/plugins/bundles/<package>?version=…&packagePath=Plugins/<package>`; the ledger
+records `Published` only after the 2xx (Plugins runs with the ledger off).
+
+**A later sibling failure leaves the registry untouched**, even though every module packed and
+staged successfully. How each non-positive verdict is refused:
+
+| verdict | what stops the hand-over |
+|---|---|
+| `failure` | GitHub's default rule skips `publish-modules`, so the lane never runs; if a caller ever re-opened the `if:`, the lane's `verdict` step refuses by name |
+| `cancelled` | the same default rule; the verdict step refuses `cancelled` too |
+| `skipped` | the same default rule, which does NOT treat a skipped need as satisfied the way branch protection treats a skipped context; the verdict step refuses `skipped` by name |
+| missing | a validation job absent from `needs:` is caught statically on the pull request (`check-callers`, below) and at run time (`caller-gate`); a name in `required-jobs` that is not in `needs:` is refused by the verdict step as "NOT among this job's needs" |
+| unknown | a needs entry with no readable `result` is refused by the verdict step — it never resolves to "passed" |
+
+The consequence has to be said out loud: **while Plugins `main` is red, no module version reaches
+the registry** — including the release-follow republish that stops portals reading
+`FrameworkDeclined` after a platform release (#2088). That is the point of the change (a red main
+must be invisible to portals, #3842), and it means a red `main` now delays module adoption rather
+than serving unvalidated bytes.
+
+## Checked before merge: `check-callers`
+
+The lane's `caller-gate` step only runs when the lane is invoked, which is on trunk — so the first
+judgement of a broken publisher would be the post-merge run on `main`, refusing, with `main` red.
+`node-repo-validate.yml` therefore fetches `module-publication.py` and runs
+`check-callers --root .` on every pull request of every satellite. It runs the same caller-graph
+check over every publisher in the repository's workflows, and adds the wiring one call cannot see:
+
+| refused | why |
+|---|---|
+| a `publish-mode: staged` pack call with no publisher | the staged bytes reach nobody and the repository silently stops publishing |
+| two publishers on one pack call | the same validated bytes would be POSTed twice |
+| a publisher whose `if:` differs from the pack call's `publish:` | stage-without-publish is silent; publish-without-stage refuses |
+| `lane`, `selected` or `modules` not read from the SAME pack call's outputs, or that call not a direct need | a sibling call's evidence could answer the publication, or the output does not resolve |
+| a publisher wired to a `direct` pack call | that call POSTs in-leg and stages nothing |
+| `required-jobs` / `unrelated-jobs` passed as an expression, or `required-jobs` empty | the static half could not read what the lane will enforce |
+
+A `direct` pack call that publishes is **named, not refused** — refusing it would red every
+repository that has not adopted this lane yet. A repository that calls neither lane prints so.
+
+## Landing order across the two repositories
+
+A new caller of a platform lane has to appear in core's fleet roster
+(`.github/lane-caller-grants.yml`, see [Workflow Permission Pairing](/Doc/Architecture/WorkflowPermissionPairing)),
+and every satellite asserts its roster row against core's `main`. Under strict equality that is
+unlandable in either order, so the Plugins row landed first marked `pending:`, which excuses
+absence only. The order is: core (the `declared` output, `check-callers` in the validate lane, the
+pending row), then the Plugins caller, then a core follow-up that removes the spent marker.
+
 ## What this does NOT solve
 
 Stated because #3878 says it must not be described as solved by moving one step:
@@ -144,6 +221,13 @@ Stated because #3878 says it must not be described as solved by moving one step:
 * **every publisher's source provenance**, and **last-green source selection** — MeshWeaver#3842
   and the generation work in #3461;
 * **core's own `plugins-bake`**, which publishes a NodeType and module set through a separate path.
+* **MeshWeaver.SocialMedia still publishes in-leg.** Its `module` job calls the pack lane with
+  `publish:` set and no `publish-mode`, so each bundle still reaches the registry right after its
+  own suite. `check-callers` names it on every SocialMedia pull request; adopting the lane there is
+  a separate change.
+* **The jobs Plugins declares unrelated do not gate the hand-over.** A red `rn-app`, `e2e-static`,
+  `test-drift` or `memex-template` still publishes, exactly as it still bakes — they are not part of
+  either publisher's verdict.
 
 Related: [The Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) for the other family of
 "green here, red there" couplings, and [Reading CI Signals](/Doc/Architecture/ReadingCiSignals) for

--- a/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WorkflowPermissionPairing.md
@@ -86,7 +86,7 @@ Its cover is narrow by construction: it hard-codes **one lane** and **three job 
 | | lane jobs it reds on |
 |---|---|
 | `test-cd-steps.py` | **3** of 22 (`node-repo-module-pack.yml` only, and only 3 of its 6 jobs) |
-| the fleet roster | **16** of 22 — every lane job that has a recorded caller |
+| the fleet roster | **17** of 22 — every lane job that has a recorded caller (16 before MeshWeaver#3878 recorded `node-repo-module-publish`'s first caller) |
 
 `node-repo-module-pack.yml`'s `select`, `tests` and `verify` are in that lane, break the fleet
 identically, and were covered by neither before this change.
@@ -120,14 +120,45 @@ roster mismatch is not a permission escalation and so the run graph is accepted.
 python3 check-workflow-permission-pairing.py --root . --emit-fleet-row Systemorph/<repo>
 ```
 
+## A caller that is arriving: `pending:`
+
+A satellite gains a caller of a platform lane in two repositories, and the roster made that
+unlandable. Every satellite asserts its row against core's `main` (`scripts-ref: main`), so under
+strict equality:
+
+| lands first | what reds | where |
+|---|---|---|
+| the roster row | "the roster records a caller this repository does not have" | every pull request of the satellite, until its half merges |
+| the satellite's caller | "a caller the roster records no row for" | the satellite's own pull request, which cannot merge |
+
+`validate / Validate node repos` is a required context in every satellite, so either order is a
+repository-wide block. Found while wiring MeshWeaver#3878's `publish-modules` job into
+MeshWeaver.Plugins — whose `main` was already red on a host shard, so "the window is short" could
+not be assumed.
+
+So a row may carry `pending: <reason naming the change that lands it>`, and the roster row lands
+**first**, like `Pairs-with:` and `Implementers:` — which is what lets core's own pull request check
+the new pair's grant before either half merges. The marker is deliberately narrow:
+
+| state | verdict |
+|---|---|
+| `pending:` row, caller not in the repository yet | passes, and prints the reason |
+| the same row with no marker | **red** — a caller deleted and its row forgotten describes a repository that does not exist |
+| `pending:` with an empty reason | **red** in `--assert-fleet-row` **and** in `--fleet`, so core refuses it before any satellite sees it |
+| `pending:` row, caller present with exactly its grant | passes; the note says the marker is spent |
+| `pending:` row, caller present with a lower grant | **red** — the marker excuses absence only, never a mismatch |
+
+`--fleet` checks a pending row's grant like any other and prints it as `PENDING:`, not under
+`NOT COVERED:`. Once the satellite's caller merges, a core follow-up removes the spent marker.
+
 ## What the guard does not see
 
 A reader should not leave this page believing it covers more than it does.
 
 - **It does not see a repository that is not in the roster.** Coverage is exactly the roster's rows.
-- **It does not see a lane with no recorded caller.** Four lanes / **6 of 22 lane jobs** are in
-  that state today (`node-repo-module-publish`, `node-repo-platform-canary`,
-  `node-repo-platform-ref-bump`, `plugin-build`). They are **printed as `NOT COVERED` on every run**
+- **It does not see a lane with no recorded caller.** Three lanes / **5 of 22 lane jobs** are in
+  that state today (`node-repo-platform-canary`, `node-repo-platform-ref-bump`, `plugin-build`;
+  `node-repo-module-publish` left the list when MeshWeaver#3878 recorded its first caller). They are **printed as `NOT COVERED` on every run**
   rather than folded into the green, because a lane with zero known callers is a coverage gap, not a
   clean measurement.
 - **A silent lane job is not always a gap, and the two causes must not be conflated.** Adding
@@ -171,10 +202,13 @@ nothing about the thing it names.
 |---|---|
 | the unmodified tree pairs cleanly, with a non-zero pair count | green must be earned |
 | a scope the real caller lacks, injected into a lane it really calls, is caught **and names that caller** | red |
-| the unmodified tree passes the fleet roster (45 pairs) | green must be earned |
+| the unmodified tree passes the fleet roster (46 pairs) | green must be earned |
 | **`id-token: write` on `node-repo-module-pack.yml#pack`** reds the fleet check and names the ungranting callers | red |
 | a checkout rebuilt from a recorded roster row matches it | green must be earned |
 | a repo that lowers a grant / adds a caller / is missing entirely | red |
+| a `pending:` row whose caller has not landed / a spent marker with exactly its grant | green must be earned |
+| the same row with no marker / an empty reason / a lowered grant behind a marker | red |
+| an empty `pending:` reason in core's own fleet run | red |
 
 The falsification that closes the loop, run on this tree:
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-module-updates-wait-for-a-green-plugin-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-module-updates-wait-for-a-green-plugin-build.md
@@ -1,0 +1,26 @@
+---
+Name: Module updates wait for a green plugin build
+Category: Fix
+Description: A plugin module update used to be offered to every portal the moment its own build finished, even when the rest of the same plugin build later failed. Module bundles now reach the registry only after every validation job of that build has passed.
+Icon: ShieldCheckmark
+Order: -20260911
+---
+
+# Module updates wait for a green plugin build
+
+Plugin modules such as the AI engine, Maps or Mail reach your portal through the plugin registry.
+Until now, each module was handed to the registry as soon as its own tests passed — while the rest
+of the same build (the other modules' tests, the portal-host tests, the compile check of every node
+type and the tests shipped inside the content) was still running. When one of those failed later,
+the update had already been offered to every portal.
+
+Now the build only prepares each module and sets it aside. The hand-over to the registry happens in
+a separate step that runs only after every validation job of that build has passed. If anything
+failed, was skipped or was cancelled, the registry is left untouched and your portal keeps the
+version it has.
+
+One consequence is visible: while the plugin build is red, no new module version is published at
+all, so an update can arrive later than before. What arrives is a version whose whole build passed.
+
+How the hand-over is gated, and what it does not cover yet, is written up under
+[The Module Publication Gate](/Doc/Architecture/ModulePublicationGate).


### PR DESCRIPTION
Core half of the Plugins caller adoption for #3878 (the lane itself landed in #3895). Refs #3878, #3842.

## What this changes

**1. The fleet roster can record a caller that is still arriving (`pending:`).** Every satellite checks its roster row against core's `main`, so under strict equality a new caller could not land in either order: the row first reds every Plugins PR, the caller first reds its own PR (`validate / Validate node repos` is required there). A row may now carry `pending: <reason>`, which excuses ABSENCE only:

| state | verdict |
|---|---|
| pending row, caller not landed | pass, reason printed |
| same row, no marker | red (a deleted caller whose row was forgotten) |
| empty reason | red in `--assert-fleet-row` and in `--fleet` |
| caller present, exact grant | pass, "marker is spent" |
| caller present, lower grant | red (a marker cannot hide a mismatch) |

`--fleet` still checks the pending row's grant, which is why the row lands first. Five self-test controls cover the table, plus one that an empty reason reds core's own fleet run. Fleet: **46 pairs, 0 violations**. The roster gains `MeshWeaver.Plugins ci.yml#publish-modules -> node-repo-module-publish.yml {contents: read}`, pending on Systemorph/MeshWeaver.Plugins branch fix/3878-staged-module-publication.

**2. `node-repo-module-pack.yml` exposes `declared`**, the `modules` input verbatim (through `select`). The publisher reads the pack call's own catalog. A second copy in the caller would drift, and Plugins' `check-modules-published.py` refuses a second `modules:` list (#3732). This is an added output only, so every existing caller is unchanged.

**3. `module-publication.py check-callers --root .`, run by `node-repo-validate.yml` on every satellite PR.** The lane's `caller-gate` only runs when the lane is invoked, which is on trunk, so the first check of a broken publisher used to be a post-merge refusal on `main`. `check-callers` runs that graph check before merge and adds the wiring a single call cannot see:
- a staged pack call with no publisher, or two publishers;
- a publisher whose `if:` differs from the pack call's `publish:`, meaning it stages without publishing (silent) or publishes without staging;
- `lane`/`selected`/`modules` read from another call's outputs;
- a publisher wired to a `direct` pack call;
- `required-jobs` passed as an expression, or empty.

A `direct` publisher (SocialMedia today) is named, not refused.

**4.** The self-test no longer writes its deliberately REFUSED verdict tables into the real `$GITHUB_STEP_SUMMARY`.

## Evidence (local, this tree)
- `module-publication.py --self-test`: all 45 cases pass, including 12 new `check-callers` cases (4 of them mutations: dropped need, status function, publisher removed, fewer events).
- `test-module-publication.py`: all green, plus two checks that `declared` exists and comes from `inputs.modules` verbatim.
- `check-workflow-permission-pairing.py --self-test --root . --fleet …`: 26/26. Pairing: 2 pairs, 0 violations. Fleet: 46 pairs, 0 violations.
- Against the Plugins branch (with this branch's scripts and roster): `check-callers` exit 0; the publisher waits for 14 jobs, and 7 are declared unrelated with reasons. `--assert-fleet-row` passes with 7 callers and 0 mismatches (spent-marker note). Satellite self-test 23/23. `check-pr-secret-preflight`, `check-workflow-timeouts`, `check-abbreviated-shas`, `check-workflow-yaml-keys`, `check-shared-lanes`, `check-modules-published` and `gen-manifests --check` all pass.
- Core: `check-workflow-timeouts` (84 jobs, 0 violations), `check-workflow-yaml-keys`, `check-workflow-shell`, `check-pr-secret-preflight`, `check-shared-rules`, `test-cd-steps`, `check-abbreviated-shas` all pass. actionlint on the three changed lanes: the same 7 pre-existing shellcheck infos as `main`, nothing new.

## Landing order
1. this PR;
2. Systemorph/MeshWeaver.Plugins branch fix/3878-staged-module-publication (`modules-floor` → `publish-mode: staged`, the new `publish-modules` job; the token and its preflight allow entry move with the POST);
3. a core follow-up that removes the spent `pending:` marker.

## What this does NOT solve
- Atomic visibility if the publication itself fails part-way: each module is its own POST.
- Every publisher's source provenance and last-green selection (#3842, #3461).
- Core main-CD's `plugins-bake` publisher.
- MeshWeaver.SocialMedia still publishes in-leg; `check-callers` names it on its PRs.
- Plugins jobs declared unrelated (`rn-app`, `e2e-static`, `test-drift`, `memex-template`) gate neither publisher.
- #3878 stays open until the Plugins caller merges and a production publication through the new job is observed (requirement 6).

Pairs-with: none — this PR removes no public C# type or member; the workflow change adds one output and two validate steps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
