### PR TITLE
docs+i18n(#4022): a refused log-incident update is loud — bell strings and the doc

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -352,9 +352,12 @@ A refusal is information, not a transient: nothing retries it and nothing swallo
 itself cannot be written, that is logged at Error — which the watcher tickets like any other red
 line — and the marker is cleared, so the next refusal tries again.
 
-The bell's text is platform-owned and lives in the catalog (`logIncident.refused.*`), resolved in
-the writer's language. The platform addressee is a group, not a viewer, so like every other
-platform-bell notification the row is stored in the platform default language (English).
+The bell's text is platform-owned and lives in the catalog (`logIncident.refused.*`, English and
+German). A notification row stores its title and message **verbatim**, and the platform addressee
+is a group of operators rather than one viewer — so the writer resolves the keys **explicitly in the
+platform default language (English)**, never in whatever locale the writing context happens to
+carry, which would store one operator's language for all of them. The German message is phrased
+count-neutrally, because the counts are runtime values that can be `1`.
 
 #### Is `occurrencesAtLastComment` lagging `occurrences` enough on its own?
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -306,6 +306,86 @@ and asking again is honoured. **Something has to do the asking**, though, and th
 - `Filing` **with** an `IssueNumber` is not in-flight at all: the write-back lands the link, so that
   state is a completed file whose status simply settled, and the issue-link rule keeps it quiet.
 
+### A refused update is loud — once
+
+Every leg that talks to GitHub can be refused, and a refusal used to live in exactly one place: the
+incident's own `Status: Failed` / `Error` fields, which nobody opens unless they already suspect
+something. The issue thread shows nothing — no error, no gap marker — so **a thread that went quiet
+because the commenter was refused reads exactly like a fault that stopped firing.** It fails toward
+"fine".
+
+Measured on `memex.systemorph.com` on 2026-09-11
+([#4022](https://github.com/Systemorph/MeshWeaver/issues/4022)): `Admin/_LogIncident/af1ee515fdf60bd1`
+stood at `occurrences: 7`, `occurrencesAtLastComment: 5`, `status: Failed`,
+`error: "Resource not accessible by integration"` against issue #3876 — two occurrences that never
+reached the ticket. It was not one incident. The App (`meshweaver-cloud`, installation `144517285`)
+had **opened 261 issues and commented on none of them** (its 39 comments are all on pull requests),
+because its permission set, read from the App itself, is `contents:write, emails:write,
+metadata:read, pull_requests:write` — no `issues` at all, at either the App or the installation.
+Every recurrence comment since the watcher's first live run on 2026-08-10 was refused, and the only
+record was a field on each node.
+
+A refused `File` or `Comment` therefore rings the **platform bell** — `Admin/_Notification`, whose
+read scope is exactly `hub.IsGlobalAdmin()` — as a `System` notification whose row opens the
+incident:
+
+| Leg | Bell title (English) | The message names |
+|---|---|---|
+| `Comment` | `Incident {fingerprint}: updates are not reaching {owner/repo}#{n}` | the refusal, how many occurrences never reached the issue, the total, and the incident path |
+| `File` | `Incident {fingerprint} could not be filed` | the refusal, the occurrence count, and the incident path |
+
+The same moment logs one Warning, `[IssueRefused] Incident {path}: {leg} to {issue} was refused —
+{reason}`, naming both sides — the precedent is `ConfigsTargeting`'s zero-match Warning
+([Sync Ref Contract](../SyncRefContract)): "I could not do the thing you think I did" is said out
+loud, once, where it can be found.
+
+**Once per refusal, not once per recurrence.** A ticketed incident requests a `Comment` on every
+report, and after filing `LastCommentedAt` is `null`, so the comment rate limit never engages while
+the post keeps failing — a refused incident retries on **every** report. A bell per attempt would
+turn one missing permission into one notification per occurrence. So the failure write stamps
+`RefusalAnnouncedAt` when it rings the bell, and a post that lands clears it: one refusal episode,
+one bell, and the next refusal after a landed post rings again. The marker cannot be `Error` — the
+claim clears `Error` before every attempt, so a marker keyed on it would announce the same refusal
+every time.
+
+A refusal is information, not a transient: nothing retries it and nothing swallows it. If the bell
+itself cannot be written, that is logged at Error — which the watcher tickets like any other red
+line — and the marker is cleared, so the next refusal tries again.
+
+The bell's text is platform-owned and lives in the catalog (`logIncident.refused.*`), resolved in
+the writer's language. The platform addressee is a group, not a viewer, so like every other
+platform-bell notification the row is stored in the platform default language (English).
+
+#### Is `occurrencesAtLastComment` lagging `occurrences` enough on its own?
+
+It is stored, it is truthful, and the bell quotes it — but as a detector it cannot stand alone:
+
+- **Lag is normal.** `CommentInterval` (6 h) means a healthy, continuously firing incident lags for
+  up to six hours by design. Lag alone cannot tell "rate-limited, will post" from "refused, never
+  will".
+- **The lag's age is not stored.** After filing, `LastCommentedAt` is `null`, so "how long has it
+  lagged" has no timestamp to read.
+- **It cannot see the `File` leg.** An incident that was never filed has no issue to lag behind.
+- **Suppressed incidents lag by design** — occurrences keep counting and tickets stop.
+- **It is passive.** Like `Error`, it answers only someone who already thought to ask.
+
+So the lag stays what it is good for — an audit query and the number in the bell — and the
+announcement is the bell.
+
+#### Granting the App what the commenter needs
+
+An App's permissions are not writable through any API, and a new permission takes effect only when
+the installation accepts it. This is an **organization-owner** action:
+
+1. `github.com/organizations/Systemorph/settings/apps/meshweaver-cloud/permissions` →
+   **Repository permissions** → **Issues: Read and write** → **Save changes**.
+2. `github.com/organizations/Systemorph/settings/installations/144517285` → **Review request** →
+   **Accept new permissions**. Until the installation accepts, its tokens still carry no `issues`.
+3. Verify from GitHub, never from the absence of an error: an App-JWT `GET /app/installations`
+   lists `"issues": "write"` on installation `144517285`; then the next recurrence comment lands,
+   the bot's first comment appears on the issue, and that incident's `occurrencesAtLastComment`
+   advances. Never print the key or a token while doing it — permission names only.
+
 ### The one state nothing requests: `Triaging`
 
 `Triaging` is entered by the control plane and is supposed to be left by the **agent**, which writes
@@ -360,6 +440,13 @@ override is logged and recorded on the ticket rather than silently ignored.
 Issues are opened as the **GitHub App** — the same machine identity the plugin registry uses — never
 a user's OAuth token, because a red log at 03:00 must not depend on whose credential happens to be
 stored.
+
+🚨 **Opening an issue is not the same grant as updating one.** A recurrence comment, and the reopen
+that precedes it on a closed issue, need the App's **Issues: Read and write** repository permission.
+Without it GitHub answers every one with `Resource not accessible by integration` — while the issue
+itself still opens, so the pipeline looks healthy from the one place anyone checks. What that looked
+like in production, and how a refusal is now surfaced, is under "A refused update is loud — once"
+below.
 
 ## Configuration
 

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1481,5 +1481,9 @@
   "unifiedData.error.readStreamEnded": "Der gemeinsame Lesedatenstrom für {0}/{1} endete, bevor er seinen aktuellen Zustand bereitstellte.",
   "unifiedData.error.readBarrierEnded": "Der gemeinsame Lesedatenstrom für {0}/{1} endete, bevor er die bestätigte Version erreichte.",
   "unifiedData.error.updateFailed": "Die Aktualisierung ist fehlgeschlagen.",
-  "unifiedData.error.deleteFailed": "Das Löschen ist fehlgeschlagen."
+  "unifiedData.error.deleteFailed": "Das Löschen ist fehlgeschlagen.",
+  "logIncident.refused.commentTitle": "Vorfall {0}: Aktualisierungen erreichen {1} nicht",
+  "logIncident.refused.commentMessage": "Die Aktualisierung konnte nicht gepostet werden: {0}\n\n{1} Vorkommen haben das Ticket nie erreicht — der Vorfall ist {2}-mal aufgetreten, {3} davon wurden dort gemeldet. Ein stiller Ticket-Verlauf bedeutet NICHT, dass der Vorfall still ist.\n\nVorfall: {4}",
+  "logIncident.refused.fileTitle": "Vorfall {0} konnte nicht gemeldet werden",
+  "logIncident.refused.fileMessage": "Das Ticket konnte nicht eröffnet werden: {0}\n\nDer Vorfall ist {1}-mal aufgetreten und hat kein Ticket.\n\nVorfall: {2}"
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1483,7 +1483,7 @@
   "unifiedData.error.updateFailed": "Die Aktualisierung ist fehlgeschlagen.",
   "unifiedData.error.deleteFailed": "Das Löschen ist fehlgeschlagen.",
   "logIncident.refused.commentTitle": "Vorfall {0}: Aktualisierungen erreichen {1} nicht",
-  "logIncident.refused.commentMessage": "Die Aktualisierung konnte nicht gepostet werden: {0}\n\n{1} Vorkommen haben das Ticket nie erreicht — der Vorfall ist {2}-mal aufgetreten, {3} davon wurden dort gemeldet. Ein stiller Ticket-Verlauf bedeutet NICHT, dass der Vorfall still ist.\n\nVorfall: {4}",
+  "logIncident.refused.commentMessage": "Die Aktualisierung konnte nicht gepostet werden: {0}\n\nVorkommen ohne Meldung im Ticket: {1} (insgesamt {2}, davon im Ticket gemeldet: {3}). Ein stiller Ticket-Verlauf bedeutet NICHT, dass der Vorfall still ist.\n\nVorfall: {4}",
   "logIncident.refused.fileTitle": "Vorfall {0} konnte nicht gemeldet werden",
   "logIncident.refused.fileMessage": "Das Ticket konnte nicht eröffnet werden: {0}\n\nDer Vorfall ist {1}-mal aufgetreten und hat kein Ticket.\n\nVorfall: {2}"
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1481,5 +1481,9 @@
   "unifiedData.error.readStreamEnded": "The shared read stream for {0}/{1} ended before it exposed its current state.",
   "unifiedData.error.readBarrierEnded": "The shared read stream for {0}/{1} ended before it reached the committed version.",
   "unifiedData.error.updateFailed": "Update failed.",
-  "unifiedData.error.deleteFailed": "Delete failed."
+  "unifiedData.error.deleteFailed": "Delete failed.",
+  "logIncident.refused.commentTitle": "Incident {0}: updates are not reaching {1}",
+  "logIncident.refused.commentMessage": "The update could not be posted: {0}\n\n{1} occurrence(s) never reached the issue — the incident has fired {2} time(s), {3} of them reported there. A quiet issue thread does NOT mean the incident is quiet.\n\nIncident: {4}",
+  "logIncident.refused.fileTitle": "Incident {0} could not be filed",
+  "logIncident.refused.fileMessage": "The issue could not be opened: {0}\n\nThe incident has fired {1} time(s) and has no ticket.\n\nIncident: {2}"
 }


### PR DESCRIPTION
## What

The core half of #4022 — a log incident whose GitHub issue update is refused went **silently** quiet.

- **Catalog keys** `logIncident.refused.{commentTitle,commentMessage,fileTitle,fileMessage}` in `strings.en.json` and `strings.de.json`: the platform-bell text the Plugins log-incident control plane rings when GitHub refuses a `File` or `Comment`.
- **Doc** `Doc/Architecture/LogWatchTriage`: new section "A refused update is loud — once": the measured cause, the once-per-episode bell and its marker, why the `occurrencesAtLastComment` lag cannot stand alone as a detector, and the org-owner steps to grant the App **Issues: Read and write**. The repository-routing paragraph now says that opening an issue and updating one need different grants.

## Measured (never inherited)

- App `meshweaver-cloud` (id 4220566), read with an App JWT (no key or token printed): permissions `contents:write, emails:write, metadata:read, pull_requests:write`. Installation `144517285` (Systemorph, all repos): `contents:write, metadata:read, pull_requests:write`. **No `issues` at either level.**
- The App **opened 261 issues** in this repo (newest #3986) and **commented on 0 issues ever**. Its 39 comments are all on PRs. A direct read of #1172, #1198 and #1127 shows only human comments. So every recurrence comment since the watcher's first run on 2026-08-10 was refused.
- `Admin/_LogIncident/af1ee515fdf60bd1` on memex.systemorph.com (`/api/version` 45306a33): `occurrences 7`, `occurrencesAtLastComment 5`, `status Failed`, `error "Resource not accessible by integration"`, issue #3876.

## The grant is an org-owner action

An App's permissions are not writable through any API. The steps are in the doc and in the Plugins PR body. Until they are done, the Plugins change makes the refusal **loud** instead of silent. It does not make it succeed.

## Verification

- `dotnet build test/MeshWeaver.Messaging.Hub.Test -c Release -warnaserror`: 0 Warning(s), 0 Error(s). `LocalizationTest`: 58 passed.
- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror`: 0 Warning(s), 0 Error(s). `DocumentationLinkIntegrityTest`: passed.

No public type or member removed and no interface member added.

Mirror-sync: none — the four logIncident.refused.* keys are resolved server-side by the Plugins log-incident control plane into stored platform-bell text; no React client renders them.

Refs #4022. Not closing: the grant (step 1 of the issue) is an org-owner action still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
