### PR TITLE
docs(#4029 review): attribute b128b804d to #4017; the duplicate was flat, not per-recompile

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -273,7 +273,7 @@ internal interface ICompilationCacheService
     /// locally compiled generation was read back under a second path, got a second collectible
     /// context over identical bytes, and the instance's lifetime lease (which covers every
     /// context of the NodeType) pinned both. NodeTypeRecompileAlcLeakTest (MeshWeaver.Plugins)
-    /// caught it on the first core set carrying #4013's fix: 3 live contexts after 3 recompiles
+    /// caught it on the first core set carrying #4017 (the fix for #4013): 3 live contexts after 3 recompiles
     /// against a bound of 2. A read now REUSES the live context that already serves its build
     /// (same MVID) — never a supersession, so the ping-pong above cannot return through it.</para>
     /// </summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -1956,7 +1956,7 @@ Flat, not per-recompile — so not the unbounded curve the assertion's message d
 doubled pin on every generation a live instance runs, in every monolith and on every replica that
 compiles. The assertion (`≤ 2`: the current build plus the one generation the instance runs) was
 right; the core change was wrong. Across the 42 shard-3 runs from 05:10Z to 11:32Z on 2026-09-11 it
-failed **6 of 6** on core sets 8345/8350/8352 (all carrying #4013's fix, `b128b804d`) and **0 of 36**
+failed **6 of 6** on core sets 8345/8350/8352 (all carrying #4017, `b128b804d`) and **0 of 36**
 on sets 8323–8340; the same Plugins commit `401fcadb` passed at 09:56Z on 8340 and failed at 10:09Z
 on 8345.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-recompiled-type-no-longer-loads-its-build-twice.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-recompiled-type-no-longer-loads-its-build-twice.md
@@ -1,7 +1,7 @@
 ---
 Name: A recompiled type no longer loads its build twice
 Category: Fix
-Description: A NodeType compiled on this server kept a second copy of each build in memory for as long as any of its instances stayed open; it now keeps one.
+Description: A NodeType compiled on this server kept a second copy of the build its open instances were running; it now keeps one.
 Icon: Code
 Order: -20260911
 ---
@@ -10,9 +10,9 @@ Order: -20260911
 
 Since this morning's compilation fix, a NodeType compiled on the same server that serves it loaded
 each new build twice — once from the compiler's output and once from the assembly store's copy of
-the same bytes — and an open instance of the type kept both copies alive until it closed. Memory
-grew by one extra build per recompile for every type with a live instance. A request for the
-store's copy now reuses the copy already loaded, so each build is loaded once, and a recompile
-releases it as before.
+the same bytes — and an open instance of the type kept both copies alive until it closed. The
+extra copy did not grow with further recompiles, but every build a live instance was running sat
+in memory twice. A request for the store's copy now reuses the copy already loaded, so each build
+is loaded once, and a recompile releases it as before.
 
 Details: [One build at two paths is ONE generation](/Doc/Architecture/NodeTypeCompilation).


### PR DESCRIPTION
Follow-up to #4029, carrying the three Copilot review fixes that could not be pushed while #4029 sat in the merge queue:

- `NodeTypeCompilation.md` and the `ICompilationCacheService` doc comment attributed `b128b804d` to "#4013's fix"; it is **#4017** (the PR that fixed #4013).
- The What's New entry implied memory grew by one build per recompile. The measurement was flat (3/3/3): one redundant copy of the build a live instance runs. Reworded.

Doc/comment only. Built `-c Release -warnaserror` (`MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Documentation.Test`: `0 Error(s)`); `DocumentationLinkIntegrityTest` 1/1 passed.

Pairs-with: none — no public surface changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
