### PR TITLE
fix(#4023): the mesh router carries a reply to its live recipient during DisposeHostedHubs

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -506,9 +506,13 @@ whose parent is in `DisposeHostedHubs` has only just been ASKED to dispose, and 
 does is wait for the replies it is owed.
 
 **The fix** (`RouteReplyDuringMeshTeardown`) is scoped exactly as #3303 scoped its seam: at that
-run level a delivery carrying `PostOptions.RequestId` — an answer — is still delivered to its
-recipient if the recipient hub already EXISTS (`HostedHubCreation.Never`; nothing is built during
-teardown). Everything else keeps the historical drop. The recipient's own intake gate still decides —
+run level a delivery carrying `PostOptions.RequestId` — an answer — is still delivered to a recipient
+that ALREADY exists, in the order the live path serves the two recipient kinds: a hosted hub
+(`HostedHubCreation.Never`; nothing is built during teardown), then a recipient registered with the
+router as a stream (portal and session hubs register this way, and can exist with no hosted hub).
+Ordering is the live path's too: while an activation serializer for the address is draining, the
+answer joins its queue (#1145), and the serializer carries it on at this run level instead of
+dropping it. Everything else keeps the historical drop. The recipient's own intake gate still decides —
 a Quiescing hub admits answers by design, a hub past its own `DisposeHostedHubs` refuses them — so
 the change adds no admission rule; it stops pre-empting that gate. There is no undeliverable-reply
 sink on this path: the mesh hands the router a PACKAGED (`RawJson`) delivery the sink cannot type,
@@ -521,16 +525,22 @@ guard; a distributed portal does not take this path.
 
 ### The controls, and the evidence each can fail
 
-`ReplyRoutedDuringMeshTeardownReachesItsWaiterTest` holds the state open by construction — the
-recipient's action block parked on an accepted turn, so it stays below `DisposeHostedHubs` while the
-mesh cannot leave it — and hands deliveries to `IRoutingService` exactly as the mesh's handler does.
-Both facts are judged once the mesh is `Dead`, after which nothing more can arrive.
+`ReplyRoutedDuringMeshTeardownReachesItsWaiterTest` holds the state open by construction — a
+mesh-hosted hub's action block parked on an accepted turn, so it stays below `DisposeHostedHubs`
+while the mesh cannot leave it — and hands deliveries to `IRoutingService` exactly as the mesh's
+handler does. Every fact is judged once the mesh is `Dead`, after which nothing more can arrive, and
+every route error is recorded and asserted absent, so a router that THROWS cannot pass a "not
+delivered" check (a review finding on the first version, which only logged it).
 
-| build | `AReplyTheMeshRoutesInDisposeHostedHubs_ReachesItsLiveRecipient` | `TrafficNobodyWaitsFor_IsStillRefusedWhileTheMeshTearsDown` |
-|---|---|---|
-| unfixed router | **fails** — *"Expected collection to contain … because the reply carried a correlation id and was routed while the mesh was in DisposeHostedHubs and its recipient was alive …"* | passes |
-| the fix | passes | passes |
-| over-broad fix (carry everything) | fails on its uncorrelated check | **fails** — *"Did not expect collection to contain … because an ordinary teardown with nothing owed must carry nothing …"* |
+| build | answer → hosted hub | answer → registered-stream recipient (no hosted hub) | uncorrelated traffic still refused |
+|---|---|---|---|
+| unfixed router | **fails** | **fails** | passes |
+| the fix | passes | passes | passes |
+| over-broad fix (carry everything) | fails on its uncorrelated check | fails on its uncorrelated check | **fails** |
+| no registered-stream hook | passes | **fails** | passes |
+
+The stream fact also asserts its own precondition — the recipient has no hosted hub — so it cannot
+pass by exercising the hosted-hub branch instead.
 
 ### Still open: judging the ordinary route at the owner's `Dead` is a race
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DisposalStallVerdicts.md
@@ -424,6 +424,137 @@ for why the precondition was made causal in the first place.
 to what either twin asserts is not done until the Plugins copy carries it (break shape 7; see
 [Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) → "Shape 7's worst form").
 
+## Resolved 2026-09-11 (#4023): the answer was dropped by the mesh's ROUTER, not by the NACK
+
+The sighting above recurred on MeshWeaver.Plugins run 34581527040 (`Portal hosts (shard 2)`), and
+it was reproduced locally: **4 failures in 3,600 iterations** of the test body under CPU contention
+(`DOTNET_PROCESSOR_COUNT=2` plus 18 spinning processes), **0 in 200** without it. Each iteration
+recorded the armed request's fate trail with extra stages, including — the instrument that decided
+it — every stage of the REPLY's own journey mirrored onto its request's trail. The ledger's own
+verdict already said *"a reply WAS posted … chase the response delivery"*; until then nothing
+recorded that delivery.
+
+### The first hypothesis held — and proved nothing about a NACK
+
+The check this page prescribed came back clean: no `Error during shutdown of hub` in the failing
+job (126,780 bytes, ANSI-stripped), and the ShutDown-phase registrant is on every failing trail at
+`runLevel=ShutDown`. But it ran with **`claimed=False`**: the once-only ack gate had already been
+claimed by a **success** ack. The owner had COMMITTED the patch (`PATCH_MERGE_STAMPED v=2 refused=0
+→ PATCH_ECHO_SEEN → PATCH_ACK ok`). In no failing iteration was an `OwnerDisposing` NACK minted, so
+"the owner minted an OwnerDisposing NACK" — the assertion's own premise — was false every time it
+failed. "The registrant ran" is necessary and not sufficient: read `claimed=` before drawing
+anything from it.
+
+### Why #2778's fix "stopped holding": it did not — the test moved off it
+
+- **#2868's direct `Dispatch` never failed.** In every iteration where the registrant claimed the
+  gate it dispatched and the watch was consumed (41 of 200 unstressed, 42 of 400 stressed).
+- **#3291 moved the test onto another path** (`f92305ae1`, 2026-09-04, "no forced teardown"). The
+  parked merge turn now releases on `owner.IsShuttingDown` — which flips at the FIRST instant of
+  `Mesh.Dispose()`, through the `CloseCreation` cascade, while the owner is still `Started`. The
+  queued merge then commits, the live ack claims the gate, and the registrant correctly stands down.
+  Which route the answer took to the armed watch, over 400 stressed iterations:
+
+| iterations | route | since |
+|---|---|---|
+| 347 | live ack; the owner's route-up finds the parent past `DisposeHostedHubs` and hands it to `IUndeliverableReplySink` | 97a0284f5 (#3303) |
+| 42 | the merge did not commit; the ShutDown-phase registrant's direct `Dispatch` | #2868 (#2778) |
+| 10 | live ack; the owner's own post is refused and falls through to the sink | #3196 |
+| **1 — FAIL** | live ack on the **ordinary** route (owner → mesh → caller's `cache/…` hub), parent still below `DisposeHostedHubs` | — |
+
+So the test stopped exercising #2778's seam in about nine iterations of ten, and started exercising
+"does a committed write's ack survive routing through a tree being torn down". That depends on
+three OTHER seams, and the fourth route had a hole.
+
+### The failing trail, and the ordering it shows
+
+Two v3 captures, **identical** in shape (iterations 335 and 927; 335 shown):
+
+```
+PATCH_ACK ok                        @TestData/teardown-nack-node   +50ms
+RESPONSE_POSTED target=cache/…      @TestData/teardown-nack-node   +50ms
+RECEIVED runLevel=Started           @TestData/teardown-nack-node   +50ms   (post accepted; routed up)
+RECEIVED runLevel=Quiescing         @mesh/…                        +50ms   (a reply is exempt at the Quiescing tier)
+QUEUED queue=main depth=4           @mesh/…                        +50ms
+ROUTED onTarget=False state=Forwarded @mesh/…                      +67ms   (after the mesh's own DisposeHostedHubs turn)
+  — never RECEIVED @cache/… —
+DIAG registrant claimed=False runLevel=ShutDown @TestData/teardown-nack-node +125ms
+```
+
+Snapshot at the owner's `Dead`: `mesh RunLevel=DisposeHostedHubs`; `cache/… RunLevel=Quiescing
+Queue(buffer=0,deferred=0) PendingCallbacks=1[…PatchDataRequest@TestData/teardown-nack-node]` — the
+caller's hub alive, its queue empty, waiting for exactly this reply. The watch was **still armed
+5,001 ms later**: the caller's own 2 s response wait expires first, and that branch deliberately
+leaves the watch armed, so the writer does burn the full 31 s `WriteVerdictBound` and reports
+`OwnerUnreachable` for a write that was applied. The remaining teardown is the discriminator: 1,849 ms
+locally and 1,948/1,949 ms in both CI failures (the caller's hub waiting out its 2 s quiesce budget),
+against a passing maximum of 69–107 ms.
+
+In the passing ordinary-route iterations `RECEIVED @cache` is recorded BEFORE the mesh's own
+`ROUTED` stage — the hand-over is inline. Here the mesh reports `Forwarded` and nothing arrives,
+which rules out both of `RouteAlongHostingHierarchy`'s direct branches and leaves the routing HANDLER
+that runs ahead of them: `MeshBuilder` hands every delivery not addressed to the mesh itself to
+`IRoutingService.DeliverMessage`.
+
+### The defect: the third site of "nobody is waiting"
+
+`RoutingServiceBase.RouteInMesh` dropped every delivery once the mesh reached `DisposeHostedHubs` —
+no NACK, no log, and `Forwarded` returned — under the comment *"recipients are likely also
+disposing"*. That is the sentence #2778 removed from the owner's disposal NACK and #3303 removed
+from `HierarchicalRouting`'s route-up refusal. It is false here for the same reason: a hosted hub
+whose parent is in `DisposeHostedHubs` has only just been ASKED to dispose, and what a Quiescing hub
+does is wait for the replies it is owed.
+
+**The fix** (`RouteReplyDuringMeshTeardown`) is scoped exactly as #3303 scoped its seam: at that
+run level a delivery carrying `PostOptions.RequestId` — an answer — is still delivered to its
+recipient if the recipient hub already EXISTS (`HostedHubCreation.Never`; nothing is built during
+teardown). Everything else keeps the historical drop. The recipient's own intake gate still decides —
+a Quiescing hub admits answers by design, a hub past its own `DisposeHostedHubs` refuses them — so
+the change adds no admission rule; it stops pre-empting that gate. There is no undeliverable-reply
+sink on this path: the mesh hands the router a PACKAGED (`RawJson`) delivery the sink cannot type,
+so the case with no live recipient stays a drop, now named on the request's trail
+(`REPLY_UNROUTABLE_DURING_MESH_TEARDOWN`).
+
+**Where it applies.** `RoutingServiceBase` backs `MonolithRoutingService` — the monolith and every
+CI test mesh. `OrleansRoutingService` implements `IRoutingService` separately and carries no such
+guard; a distributed portal does not take this path.
+
+### The controls, and the evidence each can fail
+
+`ReplyRoutedDuringMeshTeardownReachesItsWaiterTest` holds the state open by construction — the
+recipient's action block parked on an accepted turn, so it stays below `DisposeHostedHubs` while the
+mesh cannot leave it — and hands deliveries to `IRoutingService` exactly as the mesh's handler does.
+Both facts are judged once the mesh is `Dead`, after which nothing more can arrive.
+
+| build | `AReplyTheMeshRoutesInDisposeHostedHubs_ReachesItsLiveRecipient` | `TrafficNobodyWaitsFor_IsStillRefusedWhileTheMeshTearsDown` |
+|---|---|---|
+| unfixed router | **fails** — *"Expected collection to contain … because the reply carried a correlation id and was routed while the mesh was in DisposeHostedHubs and its recipient was alive …"* | passes |
+| the fix | passes | passes |
+| over-broad fix (carry everything) | fails on its uncorrelated check | **fails** — *"Did not expect collection to contain … because an ordinary teardown with nothing owed must carry nothing …"* |
+
+### Still open: judging the ordinary route at the owner's `Dead` is a race
+
+One of the four local failures was different (iteration 220 of an earlier run): the reply had reached
+the caller's hub queue and was delivered **12 ms after** the assertion. Judging at the owner's `Dead`
+is exact for the registrant and sink routes, which complete on the owner's own turns, and not for
+the ordinary route, whose last two queues are crossed afterwards — see the correction in
+[Teardown Verdicts Are Causal](/Doc/Architecture/TeardownVerdictsAreCausal). Seen once in 3,600
+stressed iterations and never in CI. Closing it is a change to what BOTH twins assert (break shape
+7), and is not part of this change.
+
+### Hypotheses killed, each by a measurement
+
+- **A drop at the root's "no route while disposing" arm** — zero such stages; `messageHubs` still
+  returns a disposing child while it is registered.
+- **An asynchronous turn holding the caller's hub** — its queue is empty in the snapshot, and every
+  handler it carries is synchronous.
+- **Queue depth on arrival** — an iteration passed with the reply behind the same depth of 3, taken
+  38 ms after queueing.
+- **The owner's commit push holding the caller's hub** — `DataChangedEvent` is handled on the
+  synchronization sub-hub, synchronously.
+- **Thread-pool starvation** — every monolith hub drains on `TaskScheduler.Default`, and the owner
+  went `Started → Dead` in about 80 ms in the very iteration where the reply was lost.
+
 ## The install holds the root: deferring a recycle instead of stranding a write (#3510)
 
 Naming the disposer (the section above) made the next occurrence a read. It did not stop the

--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownVerdictsAreCausal.md
@@ -151,6 +151,19 @@ Three things get strictly better:
    be answered either way; deriving it (`LateResponseWatchBound - 10.Seconds()`) keeps that true
    without a second literal, per [Bounds must be ordered](../BoundsMustBeOrdered).
 
+> 🚨 **Correction (#4023, 2026-09-11): `Dead` is the instant the owner has had its chance to
+> ANSWER — not the instant the answer has ARRIVED.** Of the routes an answer takes to the armed
+> watch, two complete on the owner's own turns: the ShutDown-phase registrant's direct `Dispatch`,
+> and the undeliverable-reply sink that routing offers a reply to when the parent is past
+> `DisposeHostedHubs`. For those, the reading above is exact. The third does not: since #3291 the
+> parked merge usually COMMITS during teardown, and a success ack posted while the parent is still
+> below `DisposeHostedHubs` travels the ordinary route — owner → mesh → the caller's hub — whose last
+> two queues are crossed after the owner reaches `Dead`. Measured once in 3,600 stressed iterations
+> (the reply sat in the caller's hub queue at `Dead` and was delivered 12 ms after the assertion).
+> The other failures on that route were a real defect — the mesh's router dropped the reply — and
+> are fixed; see [Reading a Disposal Stall Verdict](/Doc/Architecture/DisposalStallVerdicts) →
+> "Resolved 2026-09-11". A twin that judges at the owner's `Dead` can still report the residual race.
+
 ### What makes `Dead` safe to read: the run level is monotone, and that is enforced
 
 The shape above rests on one property that is easy to assume and was not, until #3647, actually

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-saved-change-is-confirmed-even-during-shutdown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-saved-change-is-confirmed-even-during-shutdown.md
@@ -1,0 +1,30 @@
+---
+Name: A saved change is confirmed even during shutdown
+Category: Fix
+Description: A change that was saved while the system was shutting down could be reported back as "the owner did not answer" after half a minute. The confirmation was being thrown away on its way back. It now arrives.
+Icon: ArrowReply
+Order: -20260911
+---
+
+When the system shuts down, every part of it is asked to finish what it is doing before it goes.
+A change that is being saved at that moment is one of those things: it gets written, and then a
+confirmation travels back to whoever made the change.
+
+That confirmation could be lost. The part of the system that passes messages along stopped passing
+*anything* once shutdown had started — on the assumption that whoever was waiting was going away
+too. They were not: the one waiting for the confirmation was still there, doing exactly what it is
+supposed to do during shutdown, which is wait for the answers it is owed. It waited out its full
+half-minute and then reported that the change had not been confirmed — for a change that had in
+fact been saved.
+
+## What changed
+
+**A confirmation is now delivered to whoever is waiting for it, even while shutdown is under way.**
+Only answers are carried this way, and only to someone who is still there to receive them; nothing
+new is started during shutdown.
+
+## What did NOT change
+
+Everything that is *not* an answer is still stopped at shutdown, exactly as before. That is what
+keeps a shutdown from turning into a flood of messages nobody will ever read, and a test now checks
+that it stays that way.

--- a/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
+++ b/src/MeshWeaver.Hosting.Monolith/MonolithRoutingService.cs
@@ -34,6 +34,21 @@ internal class MonolithRoutingService(
     }
 
 
+    /// <inheritdoc />
+    protected override bool TryDeliverToRegisteredStream(Address address, IMessageDelivery delivery)
+    {
+        if (!streams.TryGetValue(address, out var stream))
+            return false;
+        // The callback is a cold IObservable — the live path returns it for the base to subscribe;
+        // here nothing else will, so subscribe it, and surface a fault rather than swallow it.
+        stream.Invoke(delivery, CancellationToken.None).Subscribe(
+            _ => { },
+            ex => logger.LogWarning(ex,
+                "Teardown delivery of {MessageType} to the stream registered at {Address} faulted",
+                delivery.Message.GetType().Name, address));
+        return true;
+    }
+
     protected override IObservable<IMessageDelivery> RouteImpl(
         IMessageDelivery delivery,
         MeshNode? node,

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -72,9 +72,13 @@ namespace MeshWeaver.Hosting
 
         private void RouteInMesh(IMessageDelivery delivery)
         {
-            // Don't route during shutdown - recipients are likely also disposing
+            // 🚨 "Recipients are likely also disposing" is the #2778 assumption — "nobody is
+            // waiting" — and it is FALSE for an answer. See RouteReplyDuringMeshTeardown.
             if (Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
+            {
+                RouteReplyDuringMeshTeardown(delivery);
                 return;
+            }
 
             // ONE traversal is enough, and the serializer key MUST be this same value:
             // GetHostAddress is idempotent (every return path yields an address with
@@ -122,6 +126,60 @@ namespace MeshWeaver.Hosting
             // drains and the serializer self-retires — subsequent messages take the
             // direct short-circuit above (no per-message ResolvePath).
             EnqueueForActivation(delivery, address);
+        }
+
+        /// <summary>
+        /// 🚨 A correlated REPLY is still carried to its LIVE recipient once the mesh has reached
+        /// <see cref="MessageHubRunLevel.DisposeHostedHubs"/> — issue #4023, the third site of the
+        /// #2778 assumption.
+        ///
+        /// <para><b>The defect.</b> This router dropped EVERY delivery from that run level on, with no
+        /// NACK, no log, and a <c>Forwarded</c> result — on the stated ground that "recipients are
+        /// likely also disposing". That is the sentence #2778 removed from the owner's disposal NACK
+        /// ("nobody is waiting") and #3303 removed from <c>HierarchicalRouting</c>'s route-up refusal,
+        /// and it is false here for the same reason: a hosted hub whose parent is in
+        /// <c>DisposeHostedHubs</c> has only just been ASKED to dispose. It is Quiescing — and the one
+        /// thing a Quiescing hub does is wait for the replies it is still owed. Measured
+        /// (<c>NackReachesTheWaiterDuringTeardownTest</c>, CI runs 34513634943 and 34581527040, and a
+        /// local capture): the owner COMMITTED the patch and posted its ack while the mesh was
+        /// Quiescing; the mesh accepted it (a reply is exempt from the Quiescing intake tier) and
+        /// routed it one turn later, after its own <c>DisposeHostedHubs</c> turn — here — where it was
+        /// dropped. The caller's hub sat Quiescing with the callback for exactly that reply pending
+        /// for its whole quiesce budget, its 2 s response wait expired first and left the late watch
+        /// armed, and the writer then reported <c>OwnerUnreachable</c> after 31 s for a write the owner
+        /// had applied.</para>
+        ///
+        /// <para><b>Scoped exactly as #3303 scoped its seam.</b> Only a delivery carrying
+        /// <see cref="PostOptions.RequestId"/> — an ANSWER somebody is waiting for — is carried, and
+        /// only to a hub that ALREADY exists (<see cref="HostedHubCreation.Never"/>: nothing is built
+        /// during teardown). Everything else keeps the historical drop: fire-and-forget traffic and
+        /// new requests have nothing to finish here, and answering them is the storm shape the guard
+        /// exists to avoid. The recipient's own intake gate still decides what it accepts — a
+        /// Quiescing hub admits answers by design, a hub past its own <c>DisposeHostedHubs</c> refuses
+        /// them — so this adds no new admission rule; it stops pre-empting that gate.</para>
+        ///
+        /// <para>No undeliverable-reply sink here, deliberately: the mesh's routing handler hands this
+        /// router a PACKAGED delivery (<c>RawJson</c>), which the sink cannot type. The case with no
+        /// live recipient stays a drop — now a named one on the request's trail.</para>
+        /// </summary>
+        private void RouteReplyDuringMeshTeardown(IMessageDelivery delivery)
+        {
+            if (delivery.Target is null
+                || !delivery.Properties.TryGetValue(PostOptions.RequestId, out var raw)
+                || raw?.ToString() is not { Length: > 0 } requestId)
+                return;
+
+            var address = GetHostAddress(delivery.Target);
+            if (Mesh.GetHostedHub(address, HostedHubCreation.Never) is { } recipient)
+            {
+                Mesh.NoteRequestStage(requestId,
+                    $"REPLY_ROUTED_DURING_MESH_TEARDOWN to={recipient.Address} meshRunLevel={Mesh.RunLevel}");
+                recipient.DeliverMessage(delivery);
+                return;
+            }
+
+            Mesh.NoteRequestStage(requestId,
+                $"REPLY_UNROUTABLE_DURING_MESH_TEARDOWN target={delivery.Target} — no live recipient hub");
         }
 
         private void EnqueueForActivation(IMessageDelivery delivery, Address hostAddress)

--- a/src/MeshWeaver.Hosting/RoutingServiceBase.cs
+++ b/src/MeshWeaver.Hosting/RoutingServiceBase.cs
@@ -151,12 +151,17 @@ namespace MeshWeaver.Hosting
         ///
         /// <para><b>Scoped exactly as #3303 scoped its seam.</b> Only a delivery carrying
         /// <see cref="PostOptions.RequestId"/> — an ANSWER somebody is waiting for — is carried, and
-        /// only to a hub that ALREADY exists (<see cref="HostedHubCreation.Never"/>: nothing is built
-        /// during teardown). Everything else keeps the historical drop: fire-and-forget traffic and
-        /// new requests have nothing to finish here, and answering them is the storm shape the guard
-        /// exists to avoid. The recipient's own intake gate still decides what it accepts — a
-        /// Quiescing hub admits answers by design, a hub past its own <c>DisposeHostedHubs</c> refuses
-        /// them — so this adds no new admission rule; it stops pre-empting that gate.</para>
+        /// only to a recipient that ALREADY exists: a hosted hub (<see cref="HostedHubCreation.Never"/>:
+        /// nothing is built during teardown) or, failing that, a recipient registered with this router
+        /// as a stream — the two recipient kinds, in the order, the live path serves. Everything else
+        /// keeps the historical drop: fire-and-forget traffic and new requests have nothing to finish
+        /// here, and answering them is the storm shape the guard exists to avoid. The recipient's own
+        /// intake gate still decides what it accepts — a Quiescing hub admits answers by design, a hub
+        /// past its own <c>DisposeHostedHubs</c> refuses them — so this adds no admission rule.</para>
+        ///
+        /// <para><b>Ordering is the live path's.</b> While an activation serializer for the address is
+        /// draining, the answer joins its queue exactly as every live delivery must (#1145), and the
+        /// serializer carries it on at this run level instead of dropping it.</para>
         ///
         /// <para>No undeliverable-reply sink here, deliberately: the mesh's routing handler hands this
         /// router a PACKAGED delivery (<c>RawJson</c>), which the sink cannot type. The case with no
@@ -164,12 +169,44 @@ namespace MeshWeaver.Hosting
         /// </summary>
         private void RouteReplyDuringMeshTeardown(IMessageDelivery delivery)
         {
-            if (delivery.Target is null
-                || !delivery.Properties.TryGetValue(PostOptions.RequestId, out var raw)
-                || raw?.ToString() is not { Length: > 0 } requestId)
+            if (!TryGetReplyCorrelation(delivery, out var requestId))
                 return;
 
-            var address = GetHostAddress(delivery.Target);
+            var address = GetHostAddress(delivery.Target!);
+
+            // The SAME FIFO rule as the live path above (#1145): while an activation serializer for
+            // this address is draining, every delivery joins its queue, or an answer could overtake
+            // deliveries queued ahead of it. The serializer's RouteOne carries it on at this run level
+            // (see there), so joining the queue does not re-open the drop.
+            if (activationSerializers.TryGetValue(address, out var draining)
+                && draining.TryEnqueue(delivery))
+                return;
+
+            DeliverReplyToLiveRecipient(delivery, requestId, address);
+        }
+
+        /// <summary>True when <paramref name="delivery"/> is an ANSWER — it carries the
+        /// <see cref="PostOptions.RequestId"/> of the request a caller is waiting on.</summary>
+        private static bool TryGetReplyCorrelation(IMessageDelivery delivery, out string requestId)
+        {
+            requestId = string.Empty;
+            if (delivery.Target is null
+                || !delivery.Properties.TryGetValue(PostOptions.RequestId, out var raw)
+                || raw?.ToString() is not { Length: > 0 } id)
+                return false;
+            requestId = id;
+            return true;
+        }
+
+        /// <summary>
+        /// Hands an answer to the recipient that is still there to take it, during a mesh teardown:
+        /// a hub that ALREADY exists first (nothing is created), then a recipient registered as a
+        /// stream with this router (<see cref="TryDeliverToRegisteredStream"/>) — the same two
+        /// recipient kinds, in the same order, the live path serves. With neither, the drop stands
+        /// and is named on the request's trail.
+        /// </summary>
+        private void DeliverReplyToLiveRecipient(IMessageDelivery delivery, string requestId, Address address)
+        {
             if (Mesh.GetHostedHub(address, HostedHubCreation.Never) is { } recipient)
             {
                 Mesh.NoteRequestStage(requestId,
@@ -178,9 +215,25 @@ namespace MeshWeaver.Hosting
                 return;
             }
 
+            if (TryDeliverToRegisteredStream(address, delivery))
+            {
+                Mesh.NoteRequestStage(requestId,
+                    $"REPLY_ROUTED_DURING_MESH_TEARDOWN to=stream:{address} meshRunLevel={Mesh.RunLevel}");
+                return;
+            }
+
             Mesh.NoteRequestStage(requestId,
-                $"REPLY_UNROUTABLE_DURING_MESH_TEARDOWN target={delivery.Target} — no live recipient hub");
+                $"REPLY_UNROUTABLE_DURING_MESH_TEARDOWN target={delivery.Target} — no live recipient");
         }
+
+        /// <summary>
+        /// Delivers to a recipient registered with <see cref="RegisterStream"/> for
+        /// <paramref name="address"/>, when there is one — a recipient kind that can exist without a
+        /// hosted hub. Used only by the mesh-teardown answer path; the live path reaches registered
+        /// streams through <see cref="RouteImpl"/>. The base router holds no registrations.
+        /// </summary>
+        /// <returns>True when a registered stream took the delivery.</returns>
+        protected virtual bool TryDeliverToRegisteredStream(Address address, IMessageDelivery delivery) => false;
 
         private void EnqueueForActivation(IMessageDelivery delivery, Address hostAddress)
         {
@@ -279,10 +332,16 @@ namespace MeshWeaver.Hosting
             private IObservable<IMessageDelivery> RouteOne(IMessageDelivery delivery) =>
                 Observable.Defer(() =>
                 {
-                    // Disconnect after dispose: never resolve/deliver/post once the
-                    // mesh is tearing down — the recipients are disposing too.
+                    // Never resolve, activate or post once the mesh is tearing down. The ONE
+                    // exception is an ANSWER to a caller that is still waiting (#4023): it is
+                    // carried to a recipient that already exists — nothing is created — exactly as
+                    // RouteReplyDuringMeshTeardown does for a delivery that did not queue here.
                     if (owner.Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
+                    {
+                        if (TryGetReplyCorrelation(delivery, out var requestId))
+                            owner.DeliverReplyToLiveRecipient(delivery, requestId, address);
                         return Observable.Empty<IMessageDelivery>();
+                    }
                     return owner.RouteMessage(delivery, address);
                 })
                 .Catch<IMessageDelivery, Exception>(ex =>

--- a/test/MeshWeaver.Graph.Test/ReplyRoutedDuringMeshTeardownReachesItsWaiterTest.cs
+++ b/test/MeshWeaver.Graph.Test/ReplyRoutedDuringMeshTeardownReachesItsWaiterTest.cs
@@ -1,0 +1,225 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#4023 — the mesh's router dropped a reply its recipient was still waiting for.</b>
+///
+/// <para><b>The defect.</b> <c>RoutingServiceBase.RouteInMesh</c> dropped EVERY delivery once the
+/// mesh reached <see cref="MessageHubRunLevel.DisposeHostedHubs"/> — no NACK, no log, and a
+/// <c>Forwarded</c> result — because "recipients are likely also disposing". A hosted hub whose
+/// parent is in that phase has only just been ASKED to dispose: it is Quiescing, waiting for the
+/// replies it is still owed. <c>NackReachesTheWaiterDuringTeardownTest</c> caught the consequence
+/// intermittently (CI runs 34513634943 and 34581527040): the owner committed the patch and posted
+/// its ack while the mesh was Quiescing, the mesh routed that ack one turn after its own
+/// <c>DisposeHostedHubs</c> turn, and the ack vanished — the caller's hub then sat out its whole
+/// quiesce budget for it and the writer reported <c>OwnerUnreachable</c> after 31 s.</para>
+///
+/// <para><b>Why this test is deterministic where that one is not.</b> That test reaches the state by
+/// racing a released merge turn against the mesh's own phase changes (2 failures in 2000 stressed
+/// local iterations). Here the state is HELD OPEN BY CONSTRUCTION: the recipient's action block is
+/// parked on an accepted turn, so the <c>ShutdownRequest</c> its disposal posts queues behind it and
+/// it stays below <c>DisposeHostedHubs</c>; and the mesh cannot leave <c>DisposeHostedHubs</c> until
+/// that recipient has disposed. Both halves of "mesh past the mark, recipient still alive" are
+/// fences, not timings. The reply is handed to the mesh's <see cref="IRoutingService"/> exactly as
+/// the mesh's routing handler hands it (<c>MeshBuilder</c>: <c>DeliverMessage(delivery.Package(…))</c>).</para>
+///
+/// <para><b>Both controls, and why each is falsifiable.</b> The positive one fails on the unfixed
+/// router (the reply is dropped). The negative one — the SAME payload without a correlation id — fails
+/// on a fix that simply stops dropping: teardown must still refuse traffic nobody is waiting for,
+/// which is what keeps the storm class the guard was written for closed. Both are judged once the
+/// mesh is <c>Dead</c>, the instant after which nothing more can arrive — a cause, not a clock.</para>
+/// </summary>
+public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>A message whose handler parks the recipient's single-threaded action block.</summary>
+    private record ParkTurn;
+
+    private static readonly Address WaiterAddress = new("reply-teardown-waiter", "1");
+    private static readonly Address ResponderAddress = new("reply-teardown-responder", "1");
+
+    private const string RouteProbe = "route-probe";
+    private const string AnsweredMarker = "the-answer";
+    private const string UncorrelatedMarker = "nobody-waits-for-this";
+
+    [Fact(Timeout = 120_000)]
+    public async Task AReplyTheMeshRoutesInDisposeHostedHubs_ReachesItsLiveRecipient()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (waiter, arrived, routing, releaseTurn, turnEntered) = CreateParkableWaiter();
+        try
+        {
+            await ProveTheRouteIsLive(routing, arrived, ct);
+            await ParkTheWaiterAndTearDownTheMesh(waiter!, turnEntered);
+
+            // Sent in this order on purpose: the waiter's queue is FIFO, so if the uncorrelated message
+            // were delivered it would be processed BEFORE the answer — its absence is then conclusive.
+            Deliver(routing, Response(UncorrelatedMarker, requestId: null));
+            Deliver(routing, Response(AnsweredMarker, requestId: $"reply-teardown-{Guid.NewGuid():N}"));
+
+            Volatile.Write(ref releaseTurn.Value, 1);
+            await TheMeshIsDead(ct);
+
+            arrived.Should().Contain(r => r.Error == AnsweredMarker,
+                "the reply carried a correlation id and was routed while the mesh was in DisposeHostedHubs "
+                + "and its recipient was alive and below that mark; the router dropped every delivery at that "
+                + "run level — on the assumption that recipients are disposing too — which is #4023: the "
+                + "caller's hub then waits out its quiesce budget for an answer that was already minted");
+            arrived.Should().NotContain(r => r.Error == UncorrelatedMarker,
+                "a delivery nobody is waiting for must still be refused during teardown; only answers are "
+                + "carried, so the storm class the teardown guard exists for stays closed");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseTurn.Value, 1);
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task TrafficNobodyWaitsFor_IsStillRefusedWhileTheMeshTearsDown()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (waiter, arrived, routing, releaseTurn, turnEntered) = CreateParkableWaiter();
+        try
+        {
+            await ProveTheRouteIsLive(routing, arrived, ct);
+            await ParkTheWaiterAndTearDownTheMesh(waiter!, turnEntered);
+
+            // Nothing is owed: only uncorrelated traffic crosses the router during teardown.
+            Deliver(routing, Response(UncorrelatedMarker, requestId: null));
+
+            Volatile.Write(ref releaseTurn.Value, 1);
+            await TheMeshIsDead(ct);
+
+            arrived.Should().NotContain(r => r.Error == UncorrelatedMarker,
+                "an ordinary teardown with nothing owed must carry nothing: the router refuses traffic nobody "
+                + "is waiting for once the mesh is in DisposeHostedHubs, and a change that delivered it would "
+                + "reopen the teardown storm class");
+            arrived.Should().OnlyContain(r => r.Error == RouteProbe,
+                "the only delivery this waiter may ever have seen is the pre-teardown route probe");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseTurn.Value, 1);
+        }
+    }
+
+    /// <summary>A volatile flag the test writes and the parked turn polls — boxed so it can be shared.</summary>
+    private sealed class Flag
+    {
+        public int Value;
+    }
+
+    private (IMessageHub? Waiter, ConcurrentQueue<PatchDataResponse> Arrived, IRoutingService Routing,
+        Flag ReleaseTurn, AsyncSubject<Unit> TurnEntered) CreateParkableWaiter()
+    {
+        // Resolved BEFORE any teardown — a disposal path never resolves from DI.
+        var routing = Mesh.ServiceProvider.GetRequiredService<IRoutingService>();
+        var arrived = new ConcurrentQueue<PatchDataResponse>();
+        var releaseTurn = new Flag();
+        var turnEntered = new AsyncSubject<Unit>();
+
+        // 🚨 No hand-woven gate: the turn → test signal is an AsyncSubject the parked turn completes;
+        // the release travels back INTO the deliberately parked turn, so it is a volatile flag polled
+        // under a bounded SpinUntil and written in each test's `finally`.
+        var waiter = Mesh.GetHostedHub(WaiterAddress, c => c
+                .WithTypes(typeof(ParkTurn), typeof(PatchDataResponse))
+                .WithHandler<ParkTurn>((_, d) =>
+                {
+                    turnEntered.OnNext(Unit.Default);
+                    turnEntered.OnCompleted();
+                    SpinWait.SpinUntil(() => Volatile.Read(ref releaseTurn.Value) == 1, 60.Seconds());
+                    return d.Processed();
+                })
+                .WithHandler<PatchDataResponse>((_, d) =>
+                {
+                    arrived.Enqueue(d.Message);
+                    return d.Processed();
+                }),
+            HostedHubCreation.Always);
+        waiter.Should().NotBeNull();
+        return (waiter, arrived, routing, releaseTurn, turnEntered);
+    }
+
+    /// <summary>
+    /// POSITIVE ANCHOR, before anything is torn down: this router carries this message type to this
+    /// recipient. Without it, "the reply did not arrive" would not distinguish a teardown refusal from
+    /// an address that was never reachable.
+    /// </summary>
+    private async Task ProveTheRouteIsLive(
+        IRoutingService routing, ConcurrentQueue<PatchDataResponse> arrived, CancellationToken ct)
+    {
+        Deliver(routing, Response(RouteProbe, requestId: "probe-nobody-armed"));
+        await Observable.Interval(25.Milliseconds()).StartWith(0L)
+            .Where(_ => arrived.Any(r => r.Error == RouteProbe))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+        Output.WriteLine("[probe] the mesh router delivers to the waiter while nothing is shutting down");
+    }
+
+    private async Task ParkTheWaiterAndTearDownTheMesh(IMessageHub waiter, AsyncSubject<Unit> turnEntered)
+    {
+        waiter.Post(new ParkTurn(), o => o.WithTarget(WaiterAddress));
+        await turnEntered.Should().Within(20.Seconds()).Emit(
+            "the parked turn must hold the waiter's action block before the mesh is torn down — that park "
+            + "is what keeps the waiter's own ShutdownRequest queued behind it");
+
+        Mesh.Dispose();
+        Output.WriteLine("[dispose] mesh disposal invoked");
+
+        // 🚨 The fence, and a control as much as a wait: it IS the precondition of the defect. Without
+        // it the deliveries below would route through a live mesh and prove nothing about teardown.
+        await Observable.Interval(25.Milliseconds()).StartWith(0L)
+            .Where(_ => Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs
+                        && waiter.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
+        Output.WriteLine($"[fence] mesh={Mesh.RunLevel} waiter={waiter.RunLevel} — the router is past the mark, the recipient is alive");
+    }
+
+    /// <summary>
+    /// The causal judgment point: once the mesh is Dead every hosted hub has disposed, so every
+    /// delivery that was going to reach the waiter has reached it. The bound is a liveness guard on
+    /// that precondition, not a budget for the answer.
+    /// </summary>
+    private async Task TheMeshIsDead(CancellationToken ct)
+    {
+        var dead = await Observable.Interval(25.Milliseconds()).StartWith(0L)
+            .Where(_ => Mesh.RunLevel == MessageHubRunLevel.Dead)
+            .Select(_ => true)
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence, Observable.Return(false))
+            .Await(ct);
+        dead.Should().BeTrue(
+            $"the mesh must finish disposing once the waiter's turn is released; it is still at {Mesh.RunLevel}. "
+            + "That is a wedged teardown — a different defect from the one asserted here");
+    }
+
+    /// <summary>Hands a delivery to the mesh router exactly as the mesh's routing handler does.</summary>
+    private void Deliver(IRoutingService routing, IMessageDelivery delivery)
+        => routing.DeliverMessage(delivery.Package(Mesh.JsonSerializerOptions))
+            .Subscribe(_ => { }, ex => Output.WriteLine($"[route] delivery errored: {ex.Message}"));
+
+    private IMessageDelivery Response(string marker, string? requestId)
+    {
+        var options = new PostOptions(ResponderAddress).WithTarget(WaiterAddress);
+        if (requestId is not null)
+            options = options.WithProperty(PostOptions.RequestId, requestId);
+        return new MessageDelivery<PatchDataResponse>(
+            new PatchDataResponse(true, 0L) { Error = marker }, options, Mesh.JsonSerializerOptions);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ReplyRoutedDuringMeshTeardownReachesItsWaiterTest.cs
+++ b/test/MeshWeaver.Graph.Test/ReplyRoutedDuringMeshTeardownReachesItsWaiterTest.cs
@@ -30,20 +30,26 @@ namespace MeshWeaver.Graph.Test;
 /// <c>DisposeHostedHubs</c> turn, and the ack vanished — the caller's hub then sat out its whole
 /// quiesce budget for it and the writer reported <c>OwnerUnreachable</c> after 31 s.</para>
 ///
-/// <para><b>Why this test is deterministic where that one is not.</b> That test reaches the state by
-/// racing a released merge turn against the mesh's own phase changes (2 failures in 2000 stressed
-/// local iterations). Here the state is HELD OPEN BY CONSTRUCTION: the recipient's action block is
-/// parked on an accepted turn, so the <c>ShutdownRequest</c> its disposal posts queues behind it and
-/// it stays below <c>DisposeHostedHubs</c>; and the mesh cannot leave <c>DisposeHostedHubs</c> until
-/// that recipient has disposed. Both halves of "mesh past the mark, recipient still alive" are
-/// fences, not timings. The reply is handed to the mesh's <see cref="IRoutingService"/> exactly as
-/// the mesh's routing handler hands it (<c>MeshBuilder</c>: <c>DeliverMessage(delivery.Package(…))</c>).</para>
+/// <para><b>Why these tests are deterministic where that one is not.</b> That test reaches the state
+/// by racing a released merge turn against the mesh's own phase changes (4 failures in 3,600 stressed
+/// local iterations). Here the state is HELD OPEN BY CONSTRUCTION: a mesh-hosted hub's action block
+/// is parked on an accepted turn, so the <c>ShutdownRequest</c> its disposal posts queues behind it,
+/// and the mesh cannot leave <c>DisposeHostedHubs</c> until that hub has disposed. Both halves of
+/// "mesh past the mark, recipient still alive" are fences, not timings. Deliveries are handed to the
+/// mesh's <see cref="IRoutingService"/> exactly as the mesh's routing handler hands them
+/// (<c>MeshBuilder</c>: <c>DeliverMessage(delivery.Package(…))</c>).</para>
 ///
-/// <para><b>Both controls, and why each is falsifiable.</b> The positive one fails on the unfixed
-/// router (the reply is dropped). The negative one — the SAME payload without a correlation id — fails
-/// on a fix that simply stops dropping: teardown must still refuse traffic nobody is waiting for,
-/// which is what keeps the storm class the guard was written for closed. Both are judged once the
-/// mesh is <c>Dead</c>, the instant after which nothing more can arrive — a cause, not a clock.</para>
+/// <para><b>The two recipient kinds the router serves</b> are both covered: a hosted hub, and a
+/// recipient registered with <see cref="IRoutingService.RegisterStream(Address, AsyncDelivery)"/>
+/// that has no hosted hub at all.</para>
+///
+/// <para><b>Both controls, and why each is falsifiable.</b> The positive ones fail on the unfixed
+/// router (the answer is dropped). The negative one — the SAME payload without a correlation id —
+/// fails on a fix that simply stops dropping: teardown must still refuse traffic nobody is waiting
+/// for, which is what keeps the storm class the guard was written for closed. Every route error is
+/// recorded and asserted absent, so a router that THROWS cannot pass a "not delivered" check. All are
+/// judged once the mesh is <c>Dead</c>, the instant after which nothing more can arrive — a cause,
+/// not a clock.</para>
 /// </summary>
 public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
@@ -54,9 +60,12 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
     private static readonly Address WaiterAddress = new("reply-teardown-waiter", "1");
     private static readonly Address ResponderAddress = new("reply-teardown-responder", "1");
 
+    private const string MarkerProperty = "reply-teardown-marker";
     private const string RouteProbe = "route-probe";
     private const string AnsweredMarker = "the-answer";
     private const string UncorrelatedMarker = "nobody-waits-for-this";
+
+    private readonly ConcurrentQueue<string> routeErrors = new();
 
     [Fact(Timeout = 120_000)]
     public async Task AReplyTheMeshRoutesInDisposeHostedHubs_ReachesItsLiveRecipient()
@@ -65,25 +74,80 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
         var (waiter, arrived, routing, releaseTurn, turnEntered) = CreateParkableWaiter();
         try
         {
-            await ProveTheRouteIsLive(routing, arrived, ct);
+            await ProveTheRouteIsLive(routing, WaiterAddress, () => arrived.Contains(RouteProbe), ct);
             await ParkTheWaiterAndTearDownTheMesh(waiter!, turnEntered);
 
             // Sent in this order on purpose: the waiter's queue is FIFO, so if the uncorrelated message
             // were delivered it would be processed BEFORE the answer — its absence is then conclusive.
-            Deliver(routing, Response(UncorrelatedMarker, requestId: null));
-            Deliver(routing, Response(AnsweredMarker, requestId: $"reply-teardown-{Guid.NewGuid():N}"));
+            Deliver(routing, Response(UncorrelatedMarker, requestId: null, WaiterAddress));
+            Deliver(routing, Response(AnsweredMarker, requestId: $"reply-teardown-{Guid.NewGuid():N}", WaiterAddress));
 
             Volatile.Write(ref releaseTurn.Value, 1);
             await TheMeshIsDead(ct);
 
-            arrived.Should().Contain(r => r.Error == AnsweredMarker,
+            arrived.Should().Contain(AnsweredMarker,
                 "the reply carried a correlation id and was routed while the mesh was in DisposeHostedHubs "
                 + "and its recipient was alive and below that mark; the router dropped every delivery at that "
                 + "run level — on the assumption that recipients are disposing too — which is #4023: the "
                 + "caller's hub then waits out its quiesce budget for an answer that was already minted");
-            arrived.Should().NotContain(r => r.Error == UncorrelatedMarker,
+            arrived.Should().NotContain(UncorrelatedMarker,
                 "a delivery nobody is waiting for must still be refused during teardown; only answers are "
                 + "carried, so the storm class the teardown guard exists for stays closed");
+            routeErrors.Should().BeEmpty("a refusal is a drop, never a router fault");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseTurn.Value, 1);
+        }
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task AReplyToARegisteredStreamRecipient_ReachesItDuringDisposeHostedHubs()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var (waiter, _, routing, releaseTurn, turnEntered) = CreateParkableWaiter();
+
+        // A recipient registered as a STREAM for a real node path, the framework's own seam — the
+        // node's per-node hub is never activated, so the router can only reach it through the stream.
+        var streamPath = $"{TestPartition}/reply-teardown-stream-{Guid.NewGuid():N}";
+        await NodeFactory.CreateNode(MeshNode.FromPath(streamPath) with
+            {
+                Name = "stream recipient",
+                NodeType = "Markdown",
+                State = MeshNodeState.Active,
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+        var streamAddress = new Address(streamPath);
+        var streamArrived = new ConcurrentQueue<string>();
+        using var registration = routing.RegisterStream(streamAddress, (AsyncDelivery)((d, _) =>
+        {
+            if (d.Properties.TryGetValue(MarkerProperty, out var marker) && marker?.ToString() is { } m)
+                streamArrived.Enqueue(m);
+            return Observable.Return(d.Processed());
+        }));
+        try
+        {
+            await ProveTheRouteIsLive(routing, streamAddress, () => streamArrived.Contains(RouteProbe), ct);
+            await ParkTheWaiterAndTearDownTheMesh(waiter!, turnEntered);
+
+            // 🚨 Precondition, and a control: the recipient really has no hosted hub, so a pass below
+            // can only come from the stream branch, not from the hosted-hub one.
+            Mesh.GetHostedHub(streamAddress, HostedHubCreation.Never).Should().BeNull(
+                "the stream recipient must have no hosted hub, or this fact would be measuring the hosted-hub path");
+
+            Deliver(routing, Response(UncorrelatedMarker, requestId: null, streamAddress));
+            Deliver(routing, Response(AnsweredMarker, requestId: $"reply-teardown-{Guid.NewGuid():N}", streamAddress));
+
+            Volatile.Write(ref releaseTurn.Value, 1);
+            await TheMeshIsDead(ct);
+
+            streamArrived.Should().Contain(AnsweredMarker,
+                "an answer to a recipient registered as a stream — a recipient kind that exists without a "
+                + "hosted hub — must be carried during DisposeHostedHubs just like one to a hosted hub; "
+                + "otherwise the #4023 drop survives for every stream-registered caller");
+            streamArrived.Should().NotContain(UncorrelatedMarker,
+                "a delivery nobody is waiting for must still be refused during teardown");
+            routeErrors.Should().BeEmpty("a refusal is a drop, never a router fault");
         }
         finally
         {
@@ -98,21 +162,22 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
         var (waiter, arrived, routing, releaseTurn, turnEntered) = CreateParkableWaiter();
         try
         {
-            await ProveTheRouteIsLive(routing, arrived, ct);
+            await ProveTheRouteIsLive(routing, WaiterAddress, () => arrived.Contains(RouteProbe), ct);
             await ParkTheWaiterAndTearDownTheMesh(waiter!, turnEntered);
 
             // Nothing is owed: only uncorrelated traffic crosses the router during teardown.
-            Deliver(routing, Response(UncorrelatedMarker, requestId: null));
+            Deliver(routing, Response(UncorrelatedMarker, requestId: null, WaiterAddress));
 
             Volatile.Write(ref releaseTurn.Value, 1);
             await TheMeshIsDead(ct);
 
-            arrived.Should().NotContain(r => r.Error == UncorrelatedMarker,
+            arrived.Should().NotContain(UncorrelatedMarker,
                 "an ordinary teardown with nothing owed must carry nothing: the router refuses traffic nobody "
                 + "is waiting for once the mesh is in DisposeHostedHubs, and a change that delivered it would "
                 + "reopen the teardown storm class");
-            arrived.Should().OnlyContain(r => r.Error == RouteProbe,
+            arrived.Should().OnlyContain(m => m == RouteProbe,
                 "the only delivery this waiter may ever have seen is the pre-teardown route probe");
+            routeErrors.Should().BeEmpty("a refusal is a drop, never a router fault");
         }
         finally
         {
@@ -126,12 +191,12 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
         public int Value;
     }
 
-    private (IMessageHub? Waiter, ConcurrentQueue<PatchDataResponse> Arrived, IRoutingService Routing,
+    private (IMessageHub? Waiter, ConcurrentQueue<string> Arrived, IRoutingService Routing,
         Flag ReleaseTurn, AsyncSubject<Unit> TurnEntered) CreateParkableWaiter()
     {
         // Resolved BEFORE any teardown — a disposal path never resolves from DI.
         var routing = Mesh.ServiceProvider.GetRequiredService<IRoutingService>();
-        var arrived = new ConcurrentQueue<PatchDataResponse>();
+        var arrived = new ConcurrentQueue<string>();
         var releaseTurn = new Flag();
         var turnEntered = new AsyncSubject<Unit>();
 
@@ -149,7 +214,8 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
                 })
                 .WithHandler<PatchDataResponse>((_, d) =>
                 {
-                    arrived.Enqueue(d.Message);
+                    if (d.Properties.TryGetValue(MarkerProperty, out var marker) && marker?.ToString() is { } m)
+                        arrived.Enqueue(m);
                     return d.Processed();
                 }),
             HostedHubCreation.Always);
@@ -163,13 +229,13 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
     /// an address that was never reachable.
     /// </summary>
     private async Task ProveTheRouteIsLive(
-        IRoutingService routing, ConcurrentQueue<PatchDataResponse> arrived, CancellationToken ct)
+        IRoutingService routing, Address recipient, Func<bool> probeArrived, CancellationToken ct)
     {
-        Deliver(routing, Response(RouteProbe, requestId: "probe-nobody-armed"));
+        Deliver(routing, Response(RouteProbe, requestId: "probe-nobody-armed", recipient));
         await Observable.Interval(25.Milliseconds()).StartWith(0L)
-            .Where(_ => arrived.Any(r => r.Error == RouteProbe))
+            .Where(_ => probeArrived())
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
-        Output.WriteLine("[probe] the mesh router delivers to the waiter while nothing is shutting down");
+        Output.WriteLine($"[probe] the mesh router delivers to {recipient} while nothing is shutting down");
     }
 
     private async Task ParkTheWaiterAndTearDownTheMesh(IMessageHub waiter, AsyncSubject<Unit> turnEntered)
@@ -188,12 +254,12 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
             .Where(_ => Mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs
                         && waiter.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await(TestContext.Current.CancellationToken);
-        Output.WriteLine($"[fence] mesh={Mesh.RunLevel} waiter={waiter.RunLevel} — the router is past the mark, the recipient is alive");
+        Output.WriteLine($"[fence] mesh={Mesh.RunLevel} waiter={waiter.RunLevel} — the router is past the mark, the waiter is alive");
     }
 
     /// <summary>
     /// The causal judgment point: once the mesh is Dead every hosted hub has disposed, so every
-    /// delivery that was going to reach the waiter has reached it. The bound is a liveness guard on
+    /// delivery that was going to reach a recipient has reached it. The bound is a liveness guard on
     /// that precondition, not a budget for the answer.
     /// </summary>
     private async Task TheMeshIsDead(CancellationToken ct)
@@ -209,17 +275,18 @@ public class ReplyRoutedDuringMeshTeardownReachesItsWaiterTest(ITestOutputHelper
             + "That is a wedged teardown — a different defect from the one asserted here");
     }
 
-    /// <summary>Hands a delivery to the mesh router exactly as the mesh's routing handler does.</summary>
+    /// <summary>Hands a delivery to the mesh router exactly as the mesh's routing handler does, and
+    /// records any fault so it reaches an assertion instead of only the test output.</summary>
     private void Deliver(IRoutingService routing, IMessageDelivery delivery)
         => routing.DeliverMessage(delivery.Package(Mesh.JsonSerializerOptions))
-            .Subscribe(_ => { }, ex => Output.WriteLine($"[route] delivery errored: {ex.Message}"));
+            .Subscribe(_ => { }, ex => routeErrors.Enqueue($"{ex.GetType().Name}: {ex.Message}"));
 
-    private IMessageDelivery Response(string marker, string? requestId)
+    private IMessageDelivery Response(string marker, string? requestId, Address target)
     {
-        var options = new PostOptions(ResponderAddress).WithTarget(WaiterAddress);
+        var options = new PostOptions(ResponderAddress).WithTarget(target).WithProperty(MarkerProperty, marker);
         if (requestId is not null)
             options = options.WithProperty(PostOptions.RequestId, requestId);
         return new MessageDelivery<PatchDataResponse>(
-            new PatchDataResponse(true, 0L) { Error = marker }, options, Mesh.JsonSerializerOptions);
+            new PatchDataResponse(true, 0L), options, Mesh.JsonSerializerOptions);
     }
 }


### PR DESCRIPTION
Fixes #4023.

## Summary

`NackReachesTheWaiterDuringTeardownTest` failed in CI twice (core run 34513634943 shard 4; Plugins run 34581527040 shard 2) naming the #2778 defect. It was **not** #2778. The answer the caller was waiting for was **dropped by the mesh's router**: `RoutingServiceBase.RouteInMesh` threw away every delivery once the mesh reached `DisposeHostedHubs` (no NACK, no log, `Forwarded` returned) because "recipients are likely also disposing". That is the #2778 assumption ("nobody is waiting") at its **third** site, after the owner's disposal NACK (#2868) and `HierarchicalRouting`'s route-up refusal (#3303).

## Why #2778's fix "stopped holding": it did not — the test moved off it

- **#2868's direct `Dispatch` never failed.** Every iteration in which the ShutDown-phase registrant claimed the ack gate dispatched and the watch was consumed (41 of 200 unstressed, 42 of 400 stressed).
- **#3291 (`f92305ae1`, 2026-09-04) moved the test onto another path.** The parked merge turn releases on `owner.IsShuttingDown`, which flips at the first instant of `Mesh.Dispose()` while the owner is still `Started`. The merge then COMMITS, the live ack claims the gate, and the registrant stands down with `claimed=False`. In every failing iteration **no `OwnerDisposing` NACK was minted**, so the assertion's premise was false every time it failed.
- The registrant-ran elimination held (no `Error during shutdown`, the registrant is on every failing trail at `runLevel=ShutDown`), but it proves nothing about a NACK: read `claimed=`.

How the answer reached the armed watch, over 400 stressed iterations: 347 via 97a0284f5's route-up sink, 42 via #2868's registrant, 10 via #3196's refused-post fallthrough, **1 FAIL on the ordinary route** (owner → mesh → caller's hub).

## The failing trail (two identical captures, i=335 and i=927)

```
PATCH_ACK ok                          @owner  +50ms
RESPONSE_POSTED target=cache/…        @owner  +50ms
RECEIVED runLevel=Quiescing           @mesh   +50ms   (replies are exempt at the Quiescing tier)
ROUTED onTarget=False state=Forwarded @mesh   +67ms   (after the mesh's own DisposeHostedHubs turn)
  — never RECEIVED @cache —
```

At the owner's `Dead`: mesh at `DisposeHostedHubs`; `cache/…` Quiescing, queue empty, `PendingCallbacks=1[PatchDataRequest@…]`. The watch was still armed 5,001 ms later: the caller's 2 s response wait expires before the cache hub's quiesce cancel and deliberately leaves the watch armed, so the writer reports `OwnerUnreachable` after 31 s for an applied write. Remaining teardown: 1,849 ms locally, 1,948/1,949 ms in both CI failures, against a passing maximum of 69–107 ms.

## The fix

`RouteReplyDuringMeshTeardown`, scoped exactly as #3303 scoped its seam. At `DisposeHostedHubs` a delivery carrying `PostOptions.RequestId` (an answer) is still delivered to a recipient that **already exists**, in the live path's order: a hosted hub (`HostedHubCreation.Never`; nothing is built during teardown), then a recipient registered with the router as a stream (`TryDeliverToRegisteredStream`, implemented by `MonolithRoutingService`; portal and session hubs register this way). Ordering is the live path's: while an activation serializer for the address is draining, the answer joins its queue, and the serializer's `RouteOne` carries it on at that run level instead of dropping it. Everything else keeps the historical drop. The recipient's own intake gate still decides admission. **Monolith/CI only**: `RoutingServiceBase` has exactly one subclass (`MonolithRoutingService`), and `OrleansRoutingService` has no such guard.

## Controls (`ReplyRoutedDuringMeshTeardownReachesItsWaiterTest`), each falsified locally

The second commit addresses the Copilot review: FIFO parity with the activation serializer, registered-stream recipients (a third fact), and route errors are now asserted rather than only logged.

| build | positive: reply reaches its live recipient | negative: uncorrelated traffic still refused |
|---|---|---|
| unfixed router | **fails** ("Expected collection to contain … the reply carried a correlation id and was routed while the mesh was in DisposeHostedHubs …") | passes |
| this fix | passes | passes |
| over-broad fix (carry everything) | fails on its embedded uncorrelated check | **fails** ("Did not expect collection to contain … an ordinary teardown with nothing owed must carry nothing …") |

State is held open by construction (a parked recipient turn; fences on run levels) and judged at the mesh's `Dead`, not on a clock.

## Evidence

Before: **4 failures in 3,600** stressed iterations (`DOTNET_PROCESSOR_COUNT=2` + 18 spinning processes), all consistent with this drop; the two fully instrumented captures show it directly. After: see the PR comments (stressed run and suite timing base vs branch).

## Still open (not in this change)

Judging the ordinary route at the owner's `Dead` is a race: once, the reply was in the caller's hub queue and delivered 12 ms after the assertion (1 in 3,600 stressed, never in CI). Closing it changes what BOTH twins assert (break shape 7, Plugins pin bump), so it is left out here and documented (`TeardownVerdictsAreCausal` correction).

## Docs

`DisposalStallVerdicts` → "Resolved 2026-09-11"; `TeardownVerdictsAreCausal` correction; What's New (`Category: Fix`).

No public surface removed or added (one private method). No i18n keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
