### PR TITLE
fix(Plugins#1605): the next mesh starts only after the previous one's collectible contexts REALLY unloaded

### DIFF
--- a/.claude/skills/sigsegv/SKILL.md
+++ b/.claude/skills/sigsegv/SKILL.md
@@ -118,7 +118,14 @@ every retained FutuRe dump (#12–#16) held **3–7 `NodeAssemblyLoadContext`s m
 instance was built or run, and the zeroed object is the **garbage of a disposed hub** (Autofac child
 registry, STJ polymorphic metadata, `TypeRegistry`) — see DebuggingNativeCrashes.md, *"the MANAGED view
 of sightings #11–#16"*. The GitSync pair (#10/#11, `GetCodeInfo`) is a different branch: no collectible
-context at all, an interior stale reference. And **do not "fix" it by disabling concurrent GC** — that was tried
+context at all, an interior stale reference. 🚨 **When an unload does not finish, gcroot the
+`LoaderAllocator`, never the context** (the runtime's own strong handle always holds an unloading context).
+Measured 2026-09-11: the one strong holder of FutuRe's unfinished unloads was **System.Text.Json's static
+`ReflectionEmitCachingMemberAccessor` cache** (a `DynamicMethod` accessor's scope holds the collectible
+type; 1 s sliding expiry on a 200 ms timer), so contexts were freed when STJ's timer fired — during the
+next mesh. Evicted now on `Unloading` (`JsonMemberAccessorCacheEviction`), like Autofac's. Handle type
+`(10)` in gcroot output is `HNDTYPE_WEAK_INTERIOR_POINTER` — weak, not a root. And **do not "fix" it by
+disabling concurrent GC** — that was tried
 (#1274), changed nothing measurable, and was removed. Read the instruction + registers, not the
 function name: the frame moved across `background_sweep` → `plan_phase` → `find_first_object` →
 `background_mark_simple1` (2026-09-03) while the fault did not. 🚨 **And sighting #10 (2026-09-06)

--- a/.claude/skills/sigsegv/SKILL.md
+++ b/.claude/skills/sigsegv/SKILL.md
@@ -108,10 +108,17 @@ Both are SIGSEGV. They are different bugs and the dump distinguishes them in one
 field the faulting code happened to read. Sighting #10 faults at `si_addr = 0x4` and is the same bug.
 Match on *"a MethodTable word that is exactly zero"*, never on the literal address.
 
-The second one is the FutuRe family — **fifteen sightings, and the collectible-ALC hypothesis has been
-falsified three separate ways** (RIP is in file-backed runtime code; a freed `LoaderAllocator` yields
-a non-null *unmapped* pointer, never `0x0`; a free-list item has no ALC at all). Do not keep paying
-that hypothesis forward, and **do not "fix" it by disabling concurrent GC** — that was tried
+The second one is the FutuRe family. 🚨 **Corrected 2026-09-11: the "collectible-ALC hypothesis
+falsified three ways" line that stood here was unsound.** Its three arguments (RIP in file-backed
+runtime code; a freed `LoaderAllocator` yields a non-null *unmapped* pointer; a free-list item has no
+ALC) exclude only a freed collectible *MethodTable* being dereferenced — the zeroed word is the header
+of an ordinary default-context object — and its `alc=1` support counts `AssemblyLoadContext.All`, which
+drops a context the moment `Unload()` is called. Read for the MANAGED state (ClrMD, not native SOS),
+every retained FutuRe dump (#12–#16) held **3–7 `NodeAssemblyLoadContext`s mid-unload** while the next
+instance was built or run, and the zeroed object is the **garbage of a disposed hub** (Autofac child
+registry, STJ polymorphic metadata, `TypeRegistry`) — see DebuggingNativeCrashes.md, *"the MANAGED view
+of sightings #11–#16"*. The GitSync pair (#10/#11, `GetCodeInfo`) is a different branch: no collectible
+context at all, an interior stale reference. And **do not "fix" it by disabling concurrent GC** — that was tried
 (#1274), changed nothing measurable, and was removed. Read the instruction + registers, not the
 function name: the frame moved across `background_sweep` → `plan_phase` → `find_first_object` →
 `background_mark_simple1` (2026-09-03) while the fault did not. 🚨 **And sighting #10 (2026-09-06)
@@ -123,11 +130,13 @@ dereferences it. 🚨 **And the frame REVISITS — it is not a progression.** Si
 inside the JIT, the other is back in `background_sweep()+0xa61` with `si_addr = 0x0` on a dedicated
 BGC thread — same runtime binary, 33 hours apart, `[R15]` reading zero in both. So do not read #10's
 move out of `gc_heap` as the family migrating toward the LCG/serialization workload; that was a
-sample of one. 🚨 **Nor is it a property of one runtime build, and the zeroed block can be a LIVE
-object somebody POINTS AT.** Sighting #15 (2026-09-10) ran on **`10.0.12`**, libcoreclr build-id
-`79945f51…` — a different binary from #4–#14's `10.0.11` / `989b56df…` — so "wait for the next patch"
-is not a plan; and a whole-core scan for its cursor found the address in a field of a live,
-well-formed 96-byte heap object, not only on a free list.
+sample of one. 🚨 **Nor is it a property of one runtime build.** Sighting #15 (2026-09-10) ran on
+**`10.0.12`**, libcoreclr build-id `79945f51…` — a different binary from #4–#14's `10.0.11` /
+`989b56df…` — so "wait for the next patch" is not a plan. (Its "live, referenced" block was later shown
+to be garbage: the 96-byte referrer is itself reachable from no GC root.) 🚨 **Read a dump for who was
+ACTIVE, not only for the faulting frame:** the evidence of an overlap is on the other threads and in
+the ALC census (`AssemblyLoadContext._state` through the GC handles), never in the GC thread that
+trips over the result.
 Measured base rate on Plugins CI: **0.74 %** over 1,197 runs (2026-08-29 → 09-03,
 denominator = non-cancelled runs) and **1.17 %** over 343 runs (2026-09-06 → 09-08, denominator =
 runs whose portal-host shard reached a verdict) — **different denominators, so not a trend**; both

--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -9,6 +9,7 @@ using System.Runtime.Loader;
 using MeshWeaver.Compiler;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh.Persistence;
+using MeshWeaver.Mesh.Threading;
 using MeshWeaver.ServiceProvider;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -598,6 +599,38 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         public void Dispose() { }
     }
 
+    // 🚨 Plugins#1605 — the point at which this context has REALLY unloaded. Unload() only starts
+    // an unload (and calls GC.SuppressFinalize on the context, so a finalizer here would never run);
+    // the runtime keeps the context alive through a strong handle until it destroys the
+    // LoaderAllocator. So the signal is a separate sentinel referenced ONLY by this field: it
+    // becomes unreachable in the same collection as the context — which the runtime allows only
+    // after phase two of the unload — and its finalizer reports the retirement collected. Set once,
+    // at retirement: a context aliased under two cache keys is ONE generation and must be tracked
+    // once, or its second retirement would never complete.
+    private CollectibleContextUnloads.Retirement? _retirement;
+    private RetirementSentinel? _retirementSentinel;
+
+    /// <summary>
+    /// Records this context on <paramref name="unloads"/> as asked to unload, so the mesh can wait
+    /// until it has really been collected (<see cref="CollectibleContextUnloads.AllCollected"/>).
+    /// Call BEFORE <see cref="Dispose"/>; a second call is a no-op.
+    /// </summary>
+    internal void RetireInto(CollectibleContextUnloads unloads)
+    {
+        lock (_loadLock)
+        {
+            if (_retirement is not null)
+                return;
+            _retirement = unloads.Retire(Name ?? _nodeName);
+            _retirementSentinel = new RetirementSentinel(_retirement);
+        }
+    }
+
+    private sealed class RetirementSentinel(CollectibleContextUnloads.Retirement retirement)
+    {
+        ~RetirementSentinel() => retirement.Collected();
+    }
+
     public NodeAssemblyLoadContext(string nodeName, string? dllPath, ILogger? logger = null)
         : base(name: $"DynamicNode_{nodeName}", isCollectible: true)
     {
@@ -856,6 +889,12 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
                     "Drain signal for AssemblyLoadContext {ContextName} faulted — KEEPING its load "
                     + "context rather than unloading an assembly a scan may still be reading",
                     Name);
+                // Kept means this unload will never finish: say so to whoever waits for it. This arm
+                // also receives an Unload() that threw inside CompleteUnload (the drain subscription
+                // reaches the completed subject through Rx's SubscribeSafe); CompleteUnload has
+                // already reported that exact exception, and the first fault is the one signalled.
+                _retirement?.Faulted(new InvalidOperationException(
+                    $"AssemblyLoadContext {Name} was KEPT loaded: its unload faulted", ex));
                 return Observable.Empty<Unit>();
             })
             .Subscribe(_ => CompleteUnload());
@@ -875,7 +914,17 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         _loadedAssembly = null;
 
         // Initiate unload outside the lock — the context is collected once all references release.
-        Unload();
+        // An Unload() that throws (an Unloading handler, raised first, faulting) leaves the context
+        // loaded: report that to whoever waits for it, then let the fault propagate as before.
+        try
+        {
+            Unload();
+        }
+        catch (Exception ex)
+        {
+            _retirement?.Faulted(ex);
+            throw;
+        }
 
             // Diagnostic probe (opt-in, off by default): drive a collection right after the unload so a
             // use-after-unload dangling native pointer trips at THIS unload — naming the culprit node
@@ -921,9 +970,18 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
 /// </summary>
 internal class CompilationCacheService(
     IOptions<CompilationCacheOptions> options,
-    ILogger<CompilationCacheService> logger)
+    ILogger<CompilationCacheService> logger,
+    CollectibleContextUnloads? unloads = null)
     : ICompilationCacheService, IDisposable
 {
+    /// <summary>Records <paramref name="context"/> as retired on the mesh's tracker (if any) so the
+    /// mesh can wait until it has REALLY been collected — Plugins#1605.</summary>
+    private void Retire(NodeAssemblyLoadContext context)
+    {
+        if (unloads is not null)
+            context.RetireInto(unloads);
+    }
+
     private readonly CompilationCacheOptions _options = options.Value ?? new CompilationCacheOptions();
     private readonly ConcurrentDictionary<string, NodeAssemblyLoadContext> _loadContexts = new();
     private readonly ConcurrentDictionary<string, System.Collections.Immutable.ImmutableArray<string>> _probingDirs = new();
@@ -1492,6 +1550,7 @@ internal class CompilationCacheService(
         if (_loadContexts.TryRemove(nodeName, out var context))
         {
             logger.LogDebug("Unloading AssemblyLoadContext for {NodeName}", nodeName);
+            Retire(context);
             context.Dispose();
         }
     }
@@ -1637,6 +1696,7 @@ internal class CompilationCacheService(
             {
                 try
                 {
+                    Retire(context);
                     context.Dispose();
                 }
                 catch (Exception ex)

--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -647,6 +647,11 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         // Autofac does this automatically for BeginLoadContextLifetimeScope; we manage the context
         // by hand, so we mirror it. Static handler ⇒ no self-reference that would defeat collection.
         Unloading += ReflectionCacheEviction.EvictFor;
+        // …and System.Text.Json's process-static member-accessor cache, the one strong root of the
+        // contexts a FutuRe teardown could not collect (Plugins#1605, gcroot): without this, a context
+        // whose types were serialised is freed whenever STJ's 1 s eviction timer fires — while the NEXT
+        // mesh is already starting. See JsonMemberAccessorCacheEviction.
+        Unloading += JsonMemberAccessorCacheEviction.EvictFor;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs
@@ -920,15 +920,20 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
 
         // Initiate unload outside the lock — the context is collected once all references release.
         // An Unload() that throws (an Unloading handler, raised first, faulting) leaves the context
-        // loaded: report that to whoever waits for it, then let the fault propagate as before.
+        // LOADED. This runs as the OnNext of the drain subscription — synchronously inside Dispose
+        // when the drain was already quiet, but on the thread of the LAST scan's pin release when it
+        // was not — so a rethrow would escape into that scan's Dispose (Copilot review, #4042). It is
+        // handled here instead: logged at Error, and reported to whoever waits for the unload, which
+        // fails the teardown that expected it (DISPOSE_UNLOAD_FAULTED).
         try
         {
             Unload();
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex,
+                "Unload() of AssemblyLoadContext {ContextName} threw — the context stays LOADED", Name);
             _retirement?.Faulted(ex);
-            throw;
         }
 
             // Diagnostic probe (opt-in, off by default): drive a collection right after the unload so a

--- a/src/MeshWeaver.Compiler.Pipeline/JsonMemberAccessorCacheEviction.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/JsonMemberAccessorCacheEviction.cs
@@ -1,0 +1,56 @@
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Runtime.Loader;
+using System.Text.Json;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Empties System.Text.Json's PROCESS-STATIC member-accessor cache when a collectible node context
+/// starts unloading — the System.Text.Json twin of <c>ReflectionCacheEviction</c> (Autofac).
+///
+/// <para><b>Why (Plugins#1605, measured).</b> On CoreCLR, STJ builds property getters/setters and
+/// constructors as <see cref="System.Reflection.Emit.DynamicMethod"/>s and keeps them in a static
+/// cache with a 1-second sliding expiry, evicted by a 200 ms timer
+/// (<c>ReflectionEmitCachingMemberAccessor</c>). A dynamic method's scope holds the
+/// <see cref="System.RuntimeTypeHandle"/> of every type its IL touches, so serialising ONE instance of
+/// a NodeType-compiled type roots that type's <c>LoaderAllocator</c> from a static field. A heap dump
+/// taken at the end of a FutuRe teardown (gcroot, 2026-09-11) shows exactly that as the ONLY strong
+/// root of both contexts that teardown could not collect: <c>ReflectionEmitCachingMemberAccessor</c>
+/// → <c>Cache</c> → <c>CacheEntry</c> → <c>Action&lt;object, string&gt;</c> → <c>DynamicMethod</c>
+/// → <c>DynamicResolver</c> → <c>DynamicScope</c> → <c>RuntimeTypeHandle</c> → the collectible
+/// <c>RuntimeType</c> → <c>LoaderAllocator</c>. So an unload "completed" whenever STJ's timer happened
+/// to fire — typically a second later, while the NEXT mesh was already being built — which is the
+/// disposal-in-progress-while-the-next-instance-starts overlap every readable crash dump caught.</para>
+///
+/// <para><b>How.</b> Through STJ's own published hook, not its internals: the assembly declares a
+/// <see cref="MetadataUpdateHandlerAttribute"/> whose handler exposes the static
+/// <c>ClearCache(Type[]?)</c> the hot-reload agent calls after a metadata update. It clears the
+/// member-accessor cache (and the per-options caches STJ tracks only while hot reload is on). Clearing
+/// drops shared accessors for every type, not only the unloading one; the cost is a re-emit the next
+/// time a NEW options instance resolves a type — live options keep the accessors they already hold.</para>
+///
+/// <para>Runs inside <c>Unloading</c>, i.e. synchronously within <c>Unload()</c>, before the context
+/// is released — the same moment Autofac's cache is purged. Holds no state: the resolved method is an
+/// immutable lookup computed once (NoStaticState allows <c>static readonly</c> constants).</para>
+/// </summary>
+internal static class JsonMemberAccessorCacheEviction
+{
+    private static readonly MethodInfo? ClearCache = typeof(JsonSerializer).Assembly
+        .GetCustomAttributes<MetadataUpdateHandlerAttribute>()
+        .Select(attribute => attribute.HandlerType.GetMethod(
+            "ClearCache",
+            BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static,
+            [typeof(Type[])]))
+        .FirstOrDefault(method => method is not null);
+
+    /// <summary>
+    /// Whether this runtime's System.Text.Json publishes the hook. Pinned true by a control: if a
+    /// future STJ drops it, the eviction must fail a test, not silently stop happening.
+    /// </summary>
+    public static bool IsAvailable => ClearCache is not null;
+
+    /// <summary>The <c>Unloading</c> handler. Static, so it roots nothing.</summary>
+    public static void EvictFor(AssemblyLoadContext loadContext)
+        => ClearCache?.Invoke(null, [null]);
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1682,6 +1682,69 @@ Nothing is cancelled and nothing unloads earlier or later than before — teardo
 
 Pinned by `test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs`: a start sequenced on the signal does not run while the context is only `Unload()`-requested, and runs after it is collected; the context **is** collected (so the fix cannot pass by retaining); a faulted unload releases its waiter with the fault; nothing retired means no delay.
 
+#### What held the contexts — System.Text.Json's static accessor cache, measured with gcroot
+
+The first version of the fix waited for every retired context to be collected, and the real suite showed that
+this was not enough. Across three `MeshWeaver.FutuRe.Test` runs, **84** teardowns ended `DISPOSE_ALC_RETAINED`,
+against 81 `DISPOSE_UNLOADS_COLLECTED`. In half the fixtures, three rounds of full collections freed nothing,
+and the next mesh still started over contexts that were only unloading.
+
+**How the holder was found.** A heap dump was taken (`dotnet-dump collect --type Heap`, macOS-native, so SOS
+runs natively) the instant a teardown wrote `DISPOSE_ALC_RETAINED` for `BusinessUnit` and `LocalAnalysis`.
+`gcroot` was then run on each **`LoaderAllocator`** — not on the `AssemblyLoadContext`. An unloading context is
+always strongly held by the runtime's own handle, so its gcroot answers nothing. What decides whether an unload
+can finish is what keeps its `LoaderAllocator` alive.
+
+**What held both.** Both have exactly one strong root, and it is the same one:
+
+```
+HandleTable (strong handle)
+  -> System.Text.Json.Serialization.Metadata.ReflectionEmitCachingMemberAccessor      (static)
+  -> ReflectionEmitCachingMemberAccessor+Cache<(string, Type, MemberInfo)>
+  -> ConcurrentDictionary<…> -> …CacheEntry
+  -> System.Action<object, string>                  (an emitted property setter)
+  -> System.Reflection.Emit.DynamicMethod -> DynamicResolver -> DynamicScope -> List<object>
+  -> System.RuntimeTypeHandle -> System.RuntimeType (the collectible node type)
+  -> System.Reflection.LoaderAllocator
+```
+
+Every other root `gcroot` lists is handle type **10**, which is `HNDTYPE_WEAK_INTERIOR_POINTER` in
+`gcinterface.h`. It is weak and keeps nothing alive; SOS prints it without a name.
+
+**Why the cache has this effect.** On CoreCLR, System.Text.Json emits property accessors and constructors as
+`DynamicMethod`s and shares them through a process-static cache with a **1 s sliding expiry, evicted by a
+200 ms timer**. A dynamic method's scope holds the handle of every type its IL touches. So serialising a
+NodeType-compiled instance even once roots that type's LoaderAllocator from a static field until STJ's timer
+drops the entry.
+
+The unload therefore *finished* whenever that timer fired: typically a second after teardown, while the next
+mesh was already being built. That is the maintainer's "disposal in progress while new instance starting",
+and a timer decided it.
+
+**This is the brief's prime lead, confirmed.** A process-wide library cache holds delegates over types from a
+collectible context, with no eviction on `Unloading`. It has the same shape as the Autofac cache that
+`ReflectionCacheEviction` already purges.
+
+**The fix.** `NodeAssemblyLoadContext` now also registers `JsonMemberAccessorCacheEviction` on `Unloading`. It
+calls STJ's own published hook: the `MetadataUpdateHandler` declared on the assembly, whose static
+`ClearCache(Type[]?)` is what the hot-reload agent calls. That hook clears the member-accessor cache; the
+per-options caches it also clears exist only under hot reload. Live options keep the accessors they already
+hold; the cost is a re-emit when a *new* options instance resolves a type.
+
+**Pinned by** `ATypeSerializedThroughSystemTextJson_IsCollectedAtTeardown_NotWhenStjsTimerFires`, which also
+asserts that the hook still exists, so a future STJ that drops it fails a test instead of silently resuming
+the retention.
+
+**Measured after this fix.** STJ was one holder among several. Over three FutuRe runs with the eviction
+(macOS arm64), **93** teardowns ended `DISPOSE_UNLOADS_COLLECTED` and **45** ended `DISPOSE_ALC_RETAINED`,
+against 81 and 84 before it:
+- 48 teardowns had nothing to wait for;
+- 43 collected everything in 2 rounds;
+- 2 collected everything in 3 rounds.
+
+The contexts still retained are `LocalAnalysis`, `BusinessUnit` and `GroupAnalysis`. What holds them is the
+subject of the next gcroot, below.
+
 ## Reading the result honestly
 
 The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1660,6 +1660,28 @@ crashes that could be read. In this workload that state is also the steady state
 its presence at the crash is necessary for the hypothesis and not by itself sufficient; the repro below
 is what separates the two.
 
+#### The forced overlap, and what it did not reproduce
+
+A crash needs a deterministic repro before a fix, so the overlap was forced first, in two workloads.
+
+- **No MeshWeaver code at all.** Six workers loop: load a fresh collectible context, build six Autofac child scopes over its types (constructor lambdas are LCG), serialise and deserialise through `System.Text.Json` (reflection-emit accessors), dispose, `Unload()` — and start the next iteration **immediately**, while a hammer thread interleaves background gen2, gen0/gen1 and finalizer passes with a 2 MiB gen0 budget. It ran **16,112** overlapped iterations on macOS arm64 (`10.0.11`) and **11,289** on linux-arm64 (`10.0.12`), 180 s each, exit 0. The runtime, Autofac and STJ do not corrupt the heap on this overlap alone, at this scale, on arm64.
+- **The real suite.** `MeshWeaver.FutuRe.Test`, built against core `main`, run 20 times back to back through its native xUnit host with a 4 MiB gen0 budget: **1,180 fixtures, 20 of 20 green**, no signal death, on macOS arm64.
+
+At the measured CI rate — about 1 % of x64 runs, i.e. about one crash per 4,500 fixtures — neither could be expected to crash, so these are not evidence of absence, and they are recorded so the next reader does not re-run them expecting otherwise. What they do settle is that the state is not *sufficient* on arm64 at this scale: whatever writes the zero needs more than a context unloading while the next instance builds.
+
+#### The fix — teardown finishes when the unload has finished
+
+The maintainer's design (2026-09-11): *"we need to wait (reactively, i.e. observable.Subscribe()) until all is really finished disposing"*. "Really finished" for a collectible context is not `Unload()` returning and not `DISPOSE_DONE`: it is the runtime releasing the context after destroying its LoaderAllocator, over later collections, on the finalizer thread.
+
+- **`CollectibleContextUnloads`** (`MeshWeaver.Mesh.Contract`, a mesh-scoped singleton next to `MeshTeardownSignal`) records every context the mesh retires — by its signal, never by reference, so it cannot root what it waits for. `AllCollected` completes when every context retired before the subscription has been collected, **errors** when an unload was abandoned (the drain faulted, or `Unload()` threw — an `Unloading` handler raising), and emits synchronously when nothing is pending.
+- **How "collected" is observed.** `Unload()` calls `GC.SuppressFinalize` on the context, so a finalizer on `NodeAssemblyLoadContext` would never run. `RetireInto` instead gives the context a finalizable sentinel that only the context references; the context stays reachable through the runtime's strong handle until the LoaderAllocator is destroyed, so the sentinel's finalizer runs only after that. It stops the entry counting as pending synchronously and releases subscribers on the thread pool — never on the finalizer thread.
+- **`CompilationCacheService`** retires every context it disposes (`UnloadContext` and `Dispose`), once per context even when one generation is aliased under two keys.
+- **The test bases** (`MonolithMeshTestBase`, `HubTestBase`, and MeshWeaver.Plugins' `MonolithMeshTestBase`) end teardown with `CollectibleUnloadDrain`: drive full collections — an idle test host allocates nothing, so nothing would ever collect — then observe `AllCollected`. xUnit does not construct the next fixture until `DisposeAsync` returns. A faulted unload fails the class (`DISPOSE_UNLOAD_FAULTED`); a context still rooted after collections stop freeing anything is **reported** (`DISPOSE_ALC_RETAINED`, naming it), never waited on; the ordinary case writes `DISPOSE_UNLOADS_COLLECTED` with the round count.
+
+Nothing is cancelled and nothing unloads earlier or later than before — teardown lets the work finish, and simply stops claiming to be finished before it has. In-process recompiles on a live portal (a superseded generation evicted while other hubs keep running) are **not** sequenced by this; that belongs with the retention work of #4017/#4029.
+
+Pinned by `test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs`: a start sequenced on the signal does not run while the context is only `Unload()`-requested, and runs after it is collected; the context **is** collected (so the fix cannot pass by retaining); a faulted unload releases its waiter with the fault; nothing retired means no delay.
+
 ## Reading the result honestly
 
 The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1546,6 +1546,98 @@ run `10.0.12`. So production does not yet carry dotnet/runtime#131708. Rolling i
 `gh workflow run base-image-acr.yml --ref main` followed by the next `main-cd` roll: an operator
 decision, not taken in this entry. What `10.0.12` is worth is what the measurement above says.
 
+### 2026-09-11: the MANAGED view of sightings #11–#16 — the zeroed header is in a DISPOSED hub's garbage, and collectible contexts were mid-unload at every FutuRe crash
+
+Every entry above read these dumps for the faulting **native** frame. This one reads them for what the
+fault registers cannot say: **what the zeroed object was, who could still reach it, what every managed
+thread was doing, and which collectible contexts existed at the moment of death.** The maintainer's
+reading (2026-09-11) was *"not due to dotnet but due to disposal being in progress while new instance
+starting"*; this read tests that against six dumps, and it corrects three claims made on this page.
+
+**How it was read — no native SOS.** `dotnet-dump analyze` (SOS 10.0.745401) under an amd64 container on
+an arm64 host segfaults in `dumpobj`, in `clrstack -all` at the first native frame, and ClrMD's own heap
+walk AVs on the zeroed header. What worked, all read-only against the `.dmp`:
+
+- `setthread N` + `clrstack` **one process per thread**, so an analyzer crash costs one thread, not all later
+  ones; `lno`/`gcwhere` (ClrMD-backed) for the neighbourhood.
+- a ~250-line ClrMD 3.1 probe (`DataTarget.LoadDump`; `CreateRuntime(dac, ignoreMismatch: true)` for the
+  `10.0.11` dumps, whose DAC version the core does not carry): `FindPreviousObjectOnSegment` for
+  neighbours; a byte scan of every committed heap segment for the cursor value; a **BFS from
+  `heap.EnumerateRoots()`** over `EnumerateReferenceAddresses(carefully: true)` — never building a
+  `ClrObject` for an MT-zero child — for reachability; `runtime.EnumerateHandles()` for the ALC census,
+  reading each `AssemblyLoadContext._state` (`0` Alive, `1` Unloading).
+- the native stacks of the non-managed threads (finalizer, tiered-compilation worker) by scanning each
+  `NT_PRSTATUS` thread's stack for `libcoreclr` return addresses, symbolized against the build-id `.debug`.
+
+The fault cursor of each dump comes from the kernel `ucontext` exactly as in the entries above.
+
+#### What the six dumps show
+
+| # | suite / runtime | frame | cursor | the zeroed object and its neighbourhood | reachable? | collectible contexts at death |
+|---|---|---|---|---|---|---|
+| 11 | GitSync / `10.0.11` | `GetCodeInfo` | `R15 0x7f111956ffe8` | an **interior** address — element 0 of a `ConcurrentDictionary<(string, Type), object>`'s `Int32[]` lock-count array, next to Autofac `ServiceRegistrationInfo` / `ExternalComponentRegistration` objects | — | **none** (`Default` only) |
+| 12 | FutuRe / `10.0.11` | `background_sweep` | `R15 0x7f1c8a0c5c10` | STJ polymorphic metadata: `JsonPolymorphismOptions`, `PolymorphicTypeResolver`, a fresh `ConcurrentDictionary<Type, DerivedJsonTypeInfo>` | not run | **7 Unloading**, 3 Alive |
+| 13 | FutuRe / `10.0.11` | `background_sweep` | `R15 0x7f02a14f6df0` | persistence/query closures (`StorageAdapterMeshQueryProvider`, `PersistenceService`, `LegacyUserPartitionRepair` display classes and `Func<>`s) | not run | **4 Unloading**, 3 Alive |
+| 14 | FutuRe / `10.0.11` | `revisit_written_page` | `RSI 0x7f59b4ddca00` | `TypeRegistry` state: `ConcurrentDictionary<string, TypeDefinition>` node, `TypeDefinition`, `Func<KeyFunction>` | not run | **7 Unloading**, 3 Alive |
+| 15 | FutuRe / `10.0.12` | `find_first_object` | `R10→0x7f5dd6e057a0` | `List<IComponentRegistration>` = the `_sourceImplementations` of an Autofac `ServiceRegistrationInfo` for `ILogger<HierarchicalRouting>`, among `HierarchicalRouting`, `SyncDelivery`, `ExternalComponentRegistration` | **no** — BFS over 374,060 objects from 722 roots | **5 Unloading**, 0 Alive |
+| 16 | FutuRe / `10.0.12` | `background_sweep` | `R15 0x7fa33ca0b6d0` | the Autofac `ServiceRegistrationInfo` itself, for `ILogger<PolymorphicTypeInfoResolver>`, among that hub's `JsonSerializerOptions`, `PolymorphicTypeInfoResolver` and converter list | **no** — BFS over 644,761 objects from 843 roots; the only word in the heap equal to it is inside the object right after it | **3 Unloading**, 1 Alive |
+
+- **The victim is never a collectible type and never a native wrapper.** Every object around every cursor is
+  an ordinary default-context type (Autofac, System.Text.Json, CoreLib collections, MeshWeaver.Hosting /
+  Messaging / Layout). No SkiaSharp, SQLite, libgit2 or other native-handle wrapper is anywhere near one.
+- **It is what a HUB BUILDS**: its Autofac child-scope registry, its `JsonSerializerOptions` polymorphic
+  metadata, its `TypeRegistry`, its persistence closures. Where reachability was measured (#15, #16) the
+  object is **garbage** — reachable from no root — i.e. the leftovers of a hub that has already been
+  disposed. A GC walks dead objects linearly (sweep, plan, card scan, write-watch revisit), which is why
+  it is the collector that trips over the zeroed word, on whatever thread happens to be walking.
+- **At every FutuRe crash, several `NodeAssemblyLoadContext`s were mid-unload** — `Unload()` called,
+  `_state = 1`, held by the runtime's strong handle, their `LoaderAllocator` objects still present — while
+  the next instance was being built (#15: 5 Unloading and **0** Alive, 12 ms after the previous
+  `DISPOSE_DONE`, the crashing thread inside the new mesh's `HostedHubsCollection.CreateHub` →
+  `MessageHubConfiguration.Build` → an Autofac resolve) or running (#16: 3 Unloading beside the live
+  test's 1 Alive).
+- **Nothing was executing disposal code at the instant of death.** No managed thread is in a `Dispose`,
+  in `AssemblyLoadContext.Unload` or in teardown in any of the six; the finalizer thread sits in
+  `FinalizerThread::WaitForFinalizerEvent` in #15 and #16 (so no `LoaderAllocator` was being destroyed at
+  that instant) and thread 6 is the tiered-compilation worker. The unloads were *pending in the GC*: a
+  collectible context is only freed over the following collections, on the finalizer thread, after
+  `Unload()` returns.
+- **#11 is a different branch.** GitSync ran no dynamic NodeType at all, and its "object" is an interior
+  address in a live array — the stale-reference shape of dotnet/runtime#131267's hijack GC hole, which
+  `10.0.12` fixes. It is not evidence for or against the unload overlap.
+
+#### What this corrects on this page
+
+1. **`alc=1` never measured what it was read as.** `MonolithMeshTestBase.TestMemTrace` counts
+   `AssemblyLoadContext.All`, and the runtime removes a context from that set inside `InitiateUnload` —
+   the moment `Unload()` is called (`AllContexts.Remove(_id)`, `AssemblyLoadContext.cs`, `release/10.0`).
+   A context that is still unloading, types and `LoaderAllocator` intact, is therefore invisible to it.
+   And the checkpoints are **not** after a forced GC on CI: the forced collection is gated on
+   `MESHWEAVER_TEST_FORCE_GC`, which no workflow sets. So "`alc=1` at every checkpoint — no collectible
+   context survived any teardown" (entries #13/#14, #15, #16) is unsupported: the same processes held 3–7
+   contexts mid-unload when they died.
+2. **#15's "live, REFERENCED object" is wrong.** The 96-byte object whose `+0x20` field points at the
+   cursor is an Autofac `ServiceRegistrationInfo`; it is itself reachable from no GC root. Both are the
+   garbage of a disposed hub's registry. "A published, referenced managed object lost its type slot" — and
+   the conclusion drawn from it that the zeroing cannot be free-space housekeeping — does not follow.
+3. **Eliminations 1 and 2 of "What the sixteen have already eliminated" are unsound as written.** The
+   three arguments of #1 only exclude *a freed collectible MethodTable being dereferenced* — the zeroed
+   word here is a default-context object's header, so they say nothing about whether an unload *in
+   progress* is involved — and its `alc=1` support is item 1 above. #2 rests on every `DISPOSE_DONE`
+   being clean, but `DISPOSE_DONE` is written when `Unload()` has been *requested*, before any context has
+   been freed; a clean teardown log is exactly what the overlap looks like.
+
+#### What it does NOT show
+
+No dump names the writer of the zero. The write happened before the collection that found it, so the
+thread that made it is long gone from the stack; nothing in either repository writes the heap through
+`Unsafe`, `MemoryMarshal`, `GCHandle` or `Marshal` (the one `MemoryMarshal.AsBytes` is a read-only hash
+input). What the dumps establish is the **state** the maintainer described — a disposed instance whose
+collectible contexts are still being unloaded while the next instance builds and runs — at 5 of 5 FutuRe
+crashes that could be read. In this workload that state is also the steady state after every fixture, so
+its presence at the crash is necessary for the hypothesis and not by itself sufficient; the repro below
+is what separates the two.
+
 ## Reading the result honestly
 
 The trap in this class of bug is confirmation: the stack shows *a* plausible culprit and it is

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1007,7 +1007,11 @@ Two facts about the fixture that matter for reading the rest: `FutuReAnalysisTes
 `ShareMeshAcrossTests => true`, but no `DISPOSE_SHARED_SKIP` was ever written — the cluster kill-switch
 had sharing off, so **every `[Fact]` built and disposed its own mesh** (30 full teardowns in 47 s in #13).
 And `alc=1` at every checkpoint — each `INIT_MEM`/`DISPOSE_MEM` line is written after a forced full
-GC — means **no collectible `AssemblyLoadContext` survived any teardown** in either process. It does
+GC — means **no collectible `AssemblyLoadContext` survived any teardown** in either process.
+🚨 *Corrected 2026-09-11 (see the entry “the MANAGED view of sightings #11–#16”): both halves of that sentence are wrong.
+The count is `AssemblyLoadContext.All`, which drops a context the moment `Unload()` is called, and CI
+never sets the `MESHWEAVER_TEST_FORCE_GC` that gates the forced collection — #13 died holding 4
+contexts mid-unload and #14 held 7.* It does
 NOT mean none existed: `asm` moves 127 → 129 → 127 → 128 → 130 → 131 → 128 → 130 → 129 … → 133 across
 #13's checkpoints, so contexts (the per-node `DynamicNode_*` / `node-config-script:*` ones) were being
 created inside tests and fully reclaimed by the next checkpoint. Unloads therefore DO happen in this
@@ -1102,7 +1106,7 @@ Plugins #1507 (`fix/1390-teardown-resolve-guard`, merged 13:13Z) converts 22 Rx 
 (shard 1)` passing on the 13:13 push run `34230683846` is one green sample at a low-single-digit-percent
 rate — the reading the base-rate section above already warns against — not the fix working.
 
-### 2026-09-10: sighting #15 — a NEW RUNTIME BUILD (`10.0.12`), and the corrupt block is a LIVE, REFERENCED object
+### 2026-09-10: sighting #15 — a NEW RUNTIME BUILD (`10.0.12`), and the corrupt block is a LIVE, REFERENCED object *(corrected 2026-09-11: it is garbage — reachable from no root)*
 
 `MeshWeaver.Futu-51647.dmp` (MeshWeaver.Plugins run
 [`34476948303`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34476948303), job
@@ -1138,6 +1142,11 @@ builds apart.
 binary whose build-id (`79945f51…`) differs — verified as mapped *inside the crashed process*, not
 merely as shipped. So "wait for the next runtime patch" is not a plan, and any upstream report should
 be written against three patch releases rather than one.
+
+🚨 *Corrected 2026-09-11 — the paragraph below does not hold. The 96-byte referrer is an Autofac
+`ServiceRegistrationInfo`, and a BFS from every GC root (374,060 objects) never reaches it: referrer and
+cursor are both the garbage of a disposed hub's registry. "Well-formed" was read as "live". See the
+entry “the MANAGED view of sightings #11–#16”.*
 
 **2. The corrupt block is a live object that something POINTS AT.** The 2026-08-17 entry established
 the free-list shape by finding that *no managed object points at the cursor*. Run the same scan here
@@ -1226,6 +1235,8 @@ The last five records are `CTOR 12:45:24.607`, `INIT_START .607`, `INIT_BASE_DON
 fixture 18, not tearing down fixture 17**, which had completed cleanly 18 ms earlier. Read the bottom
 of the stack, not the top: this is construction, exactly as in sightings #1 and #3, and no teardown
 guard could have been in the path. `alc=1` throughout — no collectible context survived any teardown.
+🚨 *Corrected 2026-09-11: `alc` cannot see a context that is unloading; this process died with **5**
+`NodeAssemblyLoadContext`s mid-unload and none alive, 12 ms after the previous teardown.*
 
 The truncation machinery did its job: the trx carries **18** results — 17 `Passed` plus
 `MeshWeaver.FutuRe.Test.HOST_CRASHED` `Failed` — so the `Passed! … Passed: 17` console line is
@@ -1481,18 +1492,29 @@ Every crash is `Portal hosts (shard 1)`:
 
 #### What the sixteen have already eliminated — do not re-open these
 
-1. **Use-after-unload of a collectible ALC** — falsified three ways (`RIP` in file-backed runtime code;
-   a freed `LoaderAllocator` yields a non-null *unmapped* pointer, never a zero word at a mapped
-   address; a free-list item has no ALC), and `alc=1` at every checkpoint of #11–#15.
-2. **A teardown-ordering race** — every `DISPOSE_DONE` in every complete record reads
-   `teardown clean`, zero `DISPOSE_QUIESCE_LEAK` / `DISPOSE_DIRTY_TEARDOWN`; and the phase at death
-   varies (construction in #1, #3, #15; inside a test in #11–#13; inside a teardown in #2, #14).
+1. ⚠️ **Unsound as written (2026-09-11).** *Use-after-unload of a collectible ALC* — falsified three
+   ways (`RIP` in file-backed runtime code; a freed `LoaderAllocator` yields a non-null *unmapped*
+   pointer, never a zero word at a mapped address; a free-list item has no ALC), and `alc=1` at every
+   checkpoint of #11–#15. The three arguments exclude only *a freed collectible MethodTable being
+   dereferenced* — the zeroed word is a default-context object's header, so they are silent on an
+   unload IN PROGRESS — and `alc=1` cannot see a context that is unloading: every readable FutuRe dump
+   held 3–7 of them. See the entry “the MANAGED view of sightings #11–#16”.
+2. ⚠️ **Unsound as written (2026-09-11).** *A teardown-ordering race* — every `DISPOSE_DONE` in every
+   complete record reads `teardown clean`, zero `DISPOSE_QUIESCE_LEAK` / `DISPOSE_DIRTY_TEARDOWN`; and
+   the phase at death varies (construction in #1, #3, #15; inside a test in #11–#13; inside a teardown
+   in #2, #14). A clean `DISPOSE_DONE` proves every teardown FINISHED; it says nothing about whether
+   one instance's unload OVERLAPPED the next instance's start, because `DISPOSE_DONE` is written when
+   `Unload()` has been requested, before any context is freed. A clean log is exactly what the overlap
+   looks like.
 3. **Concurrent GC as the mechanism** — #1274 disabled it; the rate did not move (4.2 % → 3.8 %) and
    `plan_phase` runs in blocking GCs; removed again.
 4. **An unhandled managed exception routed through `createdump`** — no `Unwind: exception type` in any.
 5. **The ClrMD DAC `pthread_key` teardown** — no `libmscordaccore.so` mapped (#15).
 6. **MeshWeaver code writing the heap** — zero `AllowUnsafeBlocks` in either repository; every mapped
-   native module is the runtime's or the OS's.
+   native module is the runtime's or the OS's. *(2026-09-11: `AllowUnsafeBlocks` alone does not prove
+   it — `Unsafe.*`, `MemoryMarshal`, `GCHandle` and `Marshal.Write*` need no unsafe block. A direct grep
+   of both `src/` trees finds none of them writing; the one `MemoryMarshal.AsBytes` is a read-only
+   hash input. The conclusion stands on that grep.)*
 7. **Disk pressure** — #15 wrote a complete 849 MiB core and nine suites ran after it.
 8. **Re-entrant hub construction** — 1,350 per green run; on non-faulting threads in #8.
 9. **The quiescing-leak family (#981)** — never co-occurs with the signal death.

--- a/src/MeshWeaver.Mesh.Contract/Threading/CollectibleContextUnloads.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/CollectibleContextUnloads.cs
@@ -1,0 +1,148 @@
+using System.Collections.Concurrent;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Mesh.Threading;
+
+/// <summary>
+/// The mesh's record of collectible load contexts it has RETIRED (asked to unload) whose unload has
+/// not yet REALLY finished — and the reactive signal for when every one of them has.
+///
+/// <para><b>Why "really finished" is a separate signal (Plugins#1605).</b>
+/// <c>AssemblyLoadContext.Unload()</c> only <i>starts</i> an unload: the runtime keeps the context
+/// alive through a strong handle, and frees it over the following collections, on the finalizer
+/// thread, once nothing references its types. <see cref="MeshTeardownSignal"/> fires when teardown
+/// has <i>requested</i> those unloads, so a mesh that starts on it starts while the previous mesh's
+/// contexts are still being torn down. Every readable FutuRe crash dump (#12–#16) caught exactly
+/// that state — 3 to 7 contexts with <c>_state = Unloading</c> while the next instance was being
+/// built or run. <see cref="AllCollected"/> is the point after that: it completes only when every
+/// context retired so far has been collected.</para>
+///
+/// <para><b>How "collected" is observed.</b> A retired context holds a finalizable sentinel that
+/// nothing else references; the runtime releases the context's strong handle when it destroys the
+/// LoaderAllocator (unloadability phase two), so the sentinel is finalized only after that. Its
+/// finalizer calls <see cref="Retirement.Collected"/>, which stops the entry counting as pending
+/// synchronously and completes the signal on the thread pool — never on the finalizer thread, which
+/// destroys every other LoaderAllocator in the process and must not run subscribers.</para>
+///
+/// <para><b>It always terminates for a context that can terminate.</b> An unload that is abandoned
+/// — the drain signal faulted and the context was deliberately KEPT, or <c>Unload()</c> threw —
+/// ERRORS the signal (<see cref="Retirement.Faulted"/>), and the entry stays so a waiter that
+/// subscribes after the fault still receives it. A context that is merely still referenced never
+/// "arrives": that is a retention, and a caller that drives collections detects it as a full
+/// collection that frees nothing (<see cref="Pending"/> does not shrink), not by waiting.</para>
+///
+/// <para>Mesh-scoped instance state, never static (NoStaticState). It holds each context's signal
+/// and name, never the context — a map of contexts would root the very generations it waits for.
+/// </para>
+/// </summary>
+public sealed class CollectibleContextUnloads
+{
+    private readonly ConcurrentDictionary<long, Retirement> pending = new();
+    private long sequence;
+
+    /// <summary>
+    /// Records that the context named <paramref name="contextName"/> has been asked to unload, and
+    /// returns the handle its sentinel reports through.
+    /// </summary>
+    public Retirement Retire(string contextName)
+    {
+        var retirement = new Retirement(this, Interlocked.Increment(ref sequence), contextName);
+        pending[retirement.Id] = retirement;
+        return retirement;
+    }
+
+    /// <summary>
+    /// Retired contexts not yet collected, including those whose unload faulted. Exact the moment
+    /// finalizers have run — a collected context stops counting inside its sentinel's finalizer,
+    /// before its signal is delivered — so a caller driving collections can measure progress.
+    /// </summary>
+    public int Pending => pending.Values.Count(r => !r.IsCollected);
+
+    /// <summary>Names of the retired contexts not yet collected — for a retention report.</summary>
+    public IReadOnlyList<string> PendingContextNames =>
+        pending.Values.Where(r => !r.IsCollected).Select(r => r.ContextName).ToArray();
+
+    /// <summary>Faults of retired contexts whose unload was abandoned; empty when none was.</summary>
+    public IReadOnlyList<Exception> Faults =>
+        pending.Values.Select(r => r.Fault).OfType<Exception>().ToArray();
+
+    /// <summary>
+    /// Emits once and completes when every context retired BEFORE the subscription has been
+    /// collected; errors if any of them faulted. Emits synchronously on subscribe when nothing is
+    /// outstanding, so a start with nothing to wait for is not delayed.
+    ///
+    /// <para>The contract is ordering against the COLLECTION, not between subscribers: no subscriber
+    /// is released while a context it waits for is alive. Two independent subscribers may be
+    /// released in either order — an <see cref="AsyncSubject{T}"/> replays at once to a subscriber
+    /// that arrives while it is still notifying the earlier ones — so a caller that must start
+    /// "after the unload" sequences on its OWN subscription, never on someone else's.</para>
+    /// </summary>
+    public IObservable<Unit> AllCollected => Observable.Defer(() =>
+    {
+        var snapshot = pending.Values.Select(r => r.Signal).ToArray();
+        return snapshot.Length == 0
+            ? Observable.Return(Unit.Default)
+            : snapshot.Merge().IgnoreElements().Concat(Observable.Return(Unit.Default));
+    });
+
+    /// <summary>One retired context's completion.</summary>
+    public sealed class Retirement
+    {
+        private readonly CollectibleContextUnloads owner;
+        private readonly AsyncSubject<Unit> signal = new();
+        private Exception? fault;
+        private int collected;
+
+        internal Retirement(CollectibleContextUnloads owner, long id, string contextName)
+        {
+            this.owner = owner;
+            Id = id;
+            ContextName = contextName;
+        }
+
+        internal long Id { get; }
+
+        /// <summary>The retired context's name.</summary>
+        public string ContextName { get; }
+
+        internal IObservable<Unit> Signal => signal.AsObservable();
+
+        internal Exception? Fault => Volatile.Read(ref fault);
+
+        internal bool IsCollected => Volatile.Read(ref collected) != 0;
+
+        /// <summary>
+        /// The context has really been collected. Called from the sentinel's FINALIZER: it stops
+        /// counting as <see cref="Pending"/> synchronously (so a collection driver sees progress the
+        /// moment finalizers have run); its subscribers are released on the thread pool, never on
+        /// the finalizer thread; and only then does the entry leave the map.
+        /// </summary>
+        public void Collected()
+        {
+            if (Interlocked.Exchange(ref collected, 1) != 0)
+                return;
+            ThreadPool.UnsafeQueueUserWorkItem(static r =>
+            {
+                r.signal.OnNext(Unit.Default);
+                r.signal.OnCompleted();
+                r.owner.pending.TryRemove(r.Id, out _);
+            }, this, preferLocal: false);
+        }
+
+        /// <summary>
+        /// The unload was abandoned and the context is being KEPT. Errors the signal; the entry
+        /// stays, so a waiter subscribing afterwards is released with the same fault. The FIRST
+        /// fault wins and is the only one signalled — two hops racing on the pool would otherwise
+        /// decide which exception a waiter sees.
+        /// </summary>
+        public void Faulted(Exception exception)
+        {
+            if (Interlocked.CompareExchange(ref fault, exception, null) is not null)
+                return;
+            ThreadPool.UnsafeQueueUserWorkItem(static s => s.subject.OnError(s.exception),
+                (subject: signal, exception), preferLocal: false);
+        }
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Threading/CollectibleContextUnloads.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/CollectibleContextUnloads.cs
@@ -93,7 +93,11 @@ public sealed class CollectibleContextUnloads
         private readonly CollectibleContextUnloads owner;
         private readonly AsyncSubject<Unit> signal = new();
         private Exception? fault;
-        private int collected;
+        // ONE terminal transition: 0 pending → Collected (1) or Faulted (2), whichever comes first.
+        // A kept (faulted) context can still be collected later if everyone drops it; that must not
+        // turn the abandoned unload into a success or erase the fault (Copilot review, #4042).
+        private int terminal;
+        private const int Pending0 = 0, CollectedState = 1, FaultedState = 2;
 
         internal Retirement(CollectibleContextUnloads owner, long id, string contextName)
         {
@@ -109,9 +113,9 @@ public sealed class CollectibleContextUnloads
 
         internal IObservable<Unit> Signal => signal.AsObservable();
 
-        internal Exception? Fault => Volatile.Read(ref fault);
+        internal Exception? Fault => Volatile.Read(ref terminal) == FaultedState ? Volatile.Read(ref fault) : null;
 
-        internal bool IsCollected => Volatile.Read(ref collected) != 0;
+        internal bool IsCollected => Volatile.Read(ref terminal) == CollectedState;
 
         /// <summary>
         /// The context has really been collected. Called from the sentinel's FINALIZER: it stops
@@ -121,7 +125,7 @@ public sealed class CollectibleContextUnloads
         /// </summary>
         public void Collected()
         {
-            if (Interlocked.Exchange(ref collected, 1) != 0)
+            if (Interlocked.CompareExchange(ref terminal, CollectedState, Pending0) != Pending0)
                 return;
             ThreadPool.UnsafeQueueUserWorkItem(static r =>
             {
@@ -139,7 +143,11 @@ public sealed class CollectibleContextUnloads
         /// </summary>
         public void Faulted(Exception exception)
         {
+            // The first fault is the one recorded; the terminal transition then decides whether it
+            // counts — a context already collected stays collected (the fault is then moot).
             if (Interlocked.CompareExchange(ref fault, exception, null) is not null)
+                return;
+            if (Interlocked.CompareExchange(ref terminal, FaultedState, Pending0) != Pending0)
                 return;
             ThreadPool.UnsafeQueueUserWorkItem(static s => s.subject.OnError(s.exception),
                 (subject: signal, exception), preferLocal: false);

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
@@ -41,6 +41,10 @@ public static class IoPoolServiceCollectionExtensions
         // TeardownReport. Subscribe to this (never to DisposalCompleted alone) before
         // disposing the scope / unloading node ALCs / starting the next mesh.
         services.TryAddSingleton<MeshTeardownSignal>();
+        // …and the point AFTER it: every collectible load context this mesh retired has really been
+        // collected (Plugins#1605). The signal above fires when teardown has REQUESTED the unloads;
+        // the next mesh must not start until they have happened — see CollectibleContextUnloads.
+        services.TryAddSingleton<CollectibleContextUnloads>();
         // Closes a hosted hub's OWN lifetime scope in teardown ORDER: now on a live mesh, after the
         // drains above (DrainAll → AsyncDisposeQueue → the signal) while the mesh is tearing down.
         // HostedHubsCollection sits BELOW this assembly and resolves the abstraction; without it a

--- a/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
@@ -69,10 +69,10 @@ public class RetiredContextCollectedSignalTest
         var unloads = new CollectibleContextUnloads();
         using var cache = NewCache(unloads);
 
-        // Unload() throws out of the context's Unloading handler. The drain subscription meets it
-        // through Rx's SubscribeSafe, so it lands in the drain's Catch arm: logged at Error, the
-        // context KEPT, nothing thrown at the caller — that behaviour is unchanged here. What this
-        // pins is that the one party WAITING for the unload is told, instead of waiting forever.
+        // Unload() throws out of the context's Unloading handler. CompleteUnload handles it where it
+        // happens — logged at Error, the context KEPT, nothing thrown at the caller (a rethrow would
+        // escape into whichever scan released the last pin). What this pins is that the one party
+        // WAITING for the unload is told, instead of waiting forever.
         LoadHookAndRetire(cache, "Fault1605");
 
         // Awaited with a budget only so a regression FAILS instead of hanging the suite; the

--- a/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
@@ -1,0 +1,159 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Plugins#1605 — the next instance starts only when the previous one's collectible contexts have
+/// REALLY unloaded. <c>Unload()</c> only requests an unload; every readable FutuRe crash dump caught
+/// 3–7 contexts still <c>Unloading</c> while the next mesh was being built or run. These pin the
+/// signal the next start is sequenced on: it fires strictly after the context has been collected,
+/// a faulted unload releases the waiter with the fault instead of hanging it, and a start with
+/// nothing retired is not delayed.
+/// </summary>
+public class RetiredContextCollectedSignalTest
+{
+    private const string Source =
+        "namespace Dyn1605 { public sealed class Widget { public int Value { get; set; } = 42; } }";
+
+    [Fact]
+    public async Task NextStart_RunsOnlyAfterTheRetiredContextIsCollected_AndTheContextIsCollected()
+    {
+        var unloads = new CollectibleContextUnloads();
+        using var cache = NewCache(unloads);
+
+        var weakContext = LoadUseAndRetire(cache, "Signal1605");
+
+        // A start sequenced on the signal records whether the retired context still existed at the
+        // moment it was released. (Independent subscribers are not ordered against each other —
+        // only against the collection — so this waits for ITS release, not for anyone else's.)
+        var aliveWhenReleased = new ReplaySubject<bool>(1);
+        using var subscription = unloads.AllCollected
+            .Select(_ => weakContext.IsAlive)
+            .Subscribe(aliveWhenReleased);
+
+        var releasedEarly = false;
+        using (aliveWhenReleased.Subscribe(_ => releasedEarly = true)) { }
+        releasedEarly.Should().BeFalse(
+            "Unload() has only been REQUESTED — the runtime still holds the context and its "
+            + "LoaderAllocator — so a start sequenced on the signal must not have run yet; running it "
+            + "here is the overlap every FutuRe crash dump shows");
+        unloads.Pending.Should().Be(1, "the retired context is tracked until it is collected");
+
+        var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+
+        // The line after the driver IS the next instance's start in a test base.
+        outcome.Collected.Should().BeTrue($"nothing roots the context, so it must be collected ({outcome})");
+        weakContext.IsAlive.Should().BeFalse(
+            "the next start runs after the driver returns, and by then the context must be GONE — the "
+            + "fix must not simply keep contexts loaded, which is the #4017 retention failure");
+        var alive = await aliveWhenReleased.FirstAsync().Timeout(TimeSpan.FromSeconds(10)).Await();
+        alive.Should().BeFalse(
+            "a start sequenced on the signal must be released only AFTER the context is collected — a "
+            + "signal that fires while the context is alive is the unload-in-progress overlap itself");
+        unloads.Pending.Should().Be(0, "a collected retirement stops counting as pending");
+    }
+
+    [Fact]
+    public async Task AFaultedUnload_ReleasesTheWaiterWithTheFault_NeverHangsIt()
+    {
+        var unloads = new CollectibleContextUnloads();
+        using var cache = NewCache(unloads);
+
+        // Unload() throws out of the context's Unloading handler. The drain subscription meets it
+        // through Rx's SubscribeSafe, so it lands in the drain's Catch arm: logged at Error, the
+        // context KEPT, nothing thrown at the caller — that behaviour is unchanged here. What this
+        // pins is that the one party WAITING for the unload is told, instead of waiting forever.
+        LoadHookAndRetire(cache, "Fault1605");
+
+        // Awaited with a budget only so a regression FAILS instead of hanging the suite; the
+        // expectation is an immediate fault, and a TimeoutException is the regression.
+        var wait = async () => await unloads.AllCollected.Timeout(TimeSpan.FromSeconds(10)).Await();
+        (await wait.Should().ThrowAsync<InvalidOperationException>(
+                "an abandoned unload must ERROR the signal so the next start is released with the "
+                + "fault — a waiter left hanging on a context that will never unload is the failure"))
+            .WithMessage("*unloading handler fault 1605*");
+
+        var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+        outcome.Fault.Should().NotBeNull($"teardown must report the fault, not wait on it ({outcome})");
+    }
+
+    [Fact]
+    public void WithNothingRetired_TheNextStartIsNotDelayed()
+    {
+        var unloads = new CollectibleContextUnloads();
+
+        var started = false;
+        using var subscription = unloads.AllCollected.Subscribe(_ => started = true);
+
+        started.Should().BeTrue(
+            "with no retired context the signal must emit synchronously on subscribe — an ordinary "
+            + "start must not wait for a collection that has nothing to collect");
+    }
+
+    [Fact]
+    public async Task ACollectedRetirement_LeavesNothingBehind_SoTheNextWaitIsImmediate()
+    {
+        var unloads = new CollectibleContextUnloads();
+        using var cache = NewCache(unloads);
+        _ = LoadUseAndRetire(cache, "Cleared1605");
+        (await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads)).Collected.Should().BeTrue();
+
+        unloads.Pending.Should().Be(0,
+            "a collected retirement must remove itself — a lingering entry would make every later "
+            + "start wait on a generation that is long gone");
+        var started = false;
+        using var subscription = unloads.AllCollected.Subscribe(_ => started = true);
+        started.Should().BeTrue("the next start after a completed unload is not delayed");
+    }
+
+    private static CompilationCacheService NewCache(CollectibleContextUnloads unloads) =>
+        new(Options.Create(new CompilationCacheOptions { EnableDiskCache = false }),
+            NullLogger<CompilationCacheService>.Instance, unloads);
+
+    // Out-of-line and non-inlined so no local keeps the assembly, type or instance rooted on the
+    // caller's frame — otherwise the context could never be collected, fix or no fix.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference LoadUseAndRetire(CompilationCacheService cache, string nodeName)
+    {
+        var assembly = cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
+        var widget = Activator.CreateInstance(assembly.GetType("Dyn1605.Widget")!);
+        widget!.GetType().GetProperty("Value")!.GetValue(widget).Should().Be(42);
+        var weak = new WeakReference(cache.GetOrCreateLoadContext(nodeName));
+        cache.UnloadContext(nodeName);
+        return weak;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LoadHookAndRetire(CompilationCacheService cache, string nodeName)
+    {
+        cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
+        cache.GetOrCreateLoadContext(nodeName).Unloading +=
+            _ => throw new InvalidOperationException("unloading handler fault 1605");
+        cache.UnloadContext(nodeName);
+    }
+
+    private static byte[] Compile()
+    {
+        var compilation = CSharpCompilation.Create(
+            $"Dyn1605_{Guid.NewGuid():N}",
+            [CSharpSyntaxTree.ParseText(Source)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+             MetadataReference.CreateFromFile(Path.Combine(
+                 Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Runtime.dll"))],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        result.Success.Should().BeTrue(string.Join("; ", result.Diagnostics));
+        return ms.ToArray();
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/RetiredContextCollectedSignalTest.cs
@@ -116,6 +116,27 @@ public class RetiredContextCollectedSignalTest
         started.Should().BeTrue("the next start after a completed unload is not delayed");
     }
 
+    [Fact]
+    public async Task ATypeSerializedThroughSystemTextJson_IsCollectedAtTeardown_NotWhenStjsTimerFires()
+    {
+        // The measured holder (gcroot of a FutuRe teardown, Plugins#1605): STJ's static member-accessor
+        // cache keeps a DynamicMethod whose scope holds the collectible type, for ~1 s after last use.
+        JsonMemberAccessorCacheEviction.IsAvailable.Should().BeTrue(
+            "System.Text.Json must still publish its MetadataUpdateHandler.ClearCache hook — without it "
+            + "the eviction silently stops and every serialised NodeType outlives its teardown again");
+
+        var unloads = new CollectibleContextUnloads();
+        using var cache = NewCache(unloads);
+        var weakContext = LoadSerializeAndRetire(cache, "Json1605");
+
+        var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+
+        outcome.Collected.Should().BeTrue(
+            "a context whose types went through System.Text.Json must be collectable the moment its "
+            + $"unload is requested — not when STJ's 1 s eviction timer happens to fire ({outcome})");
+        weakContext.IsAlive.Should().BeFalse("and it must actually be gone before the next start");
+    }
+
     private static CompilationCacheService NewCache(CollectibleContextUnloads unloads) =>
         new(Options.Create(new CompilationCacheOptions { EnableDiskCache = false }),
             NullLogger<CompilationCacheService>.Instance, unloads);
@@ -128,6 +149,21 @@ public class RetiredContextCollectedSignalTest
         var assembly = cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
         var widget = Activator.CreateInstance(assembly.GetType("Dyn1605.Widget")!);
         widget!.GetType().GetProperty("Value")!.GetValue(widget).Should().Be(42);
+        var weak = new WeakReference(cache.GetOrCreateLoadContext(nodeName));
+        cache.UnloadContext(nodeName);
+        return weak;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference LoadSerializeAndRetire(CompilationCacheService cache, string nodeName)
+    {
+        var assembly = cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
+        var type = assembly.GetType("Dyn1605.Widget")!;
+        var widget = Activator.CreateInstance(type)!;
+        var json = System.Text.Json.JsonSerializer.Serialize(widget, type, new System.Text.Json.JsonSerializerOptions());
+        json.Should().Contain("42");
+        System.Text.Json.JsonSerializer.Deserialize(json, type, new System.Text.Json.JsonSerializerOptions())
+            .Should().NotBeNull();
         var weak = new WeakReference(cache.GetOrCreateLoadContext(nodeName));
         cache.UnloadContext(nodeName);
         return weak;

--- a/test/MeshWeaver.Fixture/CollectibleUnloadDrain.cs
+++ b/test/MeshWeaver.Fixture/CollectibleUnloadDrain.cs
@@ -1,0 +1,97 @@
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Fixture;
+
+/// <summary>What waiting for a mesh's retired collectible contexts ended with.</summary>
+/// <param name="Rounds">Collection rounds driven (0 when nothing was pending).</param>
+/// <param name="RetainedContexts">Contexts that a full collection could not free — rooted by
+/// something live. Empty unless <see cref="Retained"/>.</param>
+/// <param name="Fault">The fault of an unload that was abandoned, when one was.</param>
+public sealed record CollectibleUnloadOutcome(
+    int Rounds, IReadOnlyList<string> RetainedContexts, Exception? Fault)
+{
+    /// <summary>Every retired context was collected.</summary>
+    public bool Collected => Fault is null && RetainedContexts.Count == 0;
+
+    /// <summary>Some retired context is still referenced after full collections freed nothing.</summary>
+    public bool Retained => RetainedContexts.Count > 0;
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        Fault is not null
+            ? $"unload FAULTED after {Rounds} round(s): {Fault.GetType().Name}: {Fault.Message}"
+            : Retained
+                ? $"{RetainedContexts.Count} context(s) RETAINED after {Rounds} round(s) freed nothing: "
+                  + string.Join(", ", RetainedContexts)
+                : $"all retired contexts collected after {Rounds} round(s)";
+}
+
+/// <summary>
+/// Teardown's last step (Plugins#1605): wait until every collectible load context the mesh retired
+/// has REALLY been unloaded, so the next mesh never starts while the previous one's contexts are
+/// still being torn down.
+///
+/// <para>The wait itself is the reactive <see cref="CollectibleContextUnloads.AllCollected"/>
+/// signal. What this adds is the one thing that signal cannot do for itself: a collectible context
+/// is freed only by collections, and a test host waiting on it allocates nothing, so nothing would
+/// ever collect. Each round is therefore one full blocking collection, a finalizer pass (where the
+/// runtime destroys dead LoaderAllocators and releases their contexts), a second collection that
+/// finds the released contexts, and a second finalizer pass that runs their sentinels.</para>
+///
+/// <para>🚨 There is no timer here. The loop ends on the signal, on a fault, or on a round that frees
+/// nothing: once full collections stop shrinking <see cref="CollectibleContextUnloads.Pending"/>,
+/// what remains is rooted by something live, and more collections cannot free it. That is reported
+/// as RETAINED, never waited on. <see cref="NoProgressRounds"/> consecutive rounds are required
+/// because one unload spans several finalizer passes (a LoaderAllocator's scout, then the
+/// LCG resolvers that re-register for finalization, then the context itself).</para>
+/// </summary>
+public static class CollectibleUnloadDrain
+{
+    /// <summary>Consecutive rounds that free nothing before what is left counts as retained.</summary>
+    public const int NoProgressRounds = 3;
+
+    /// <summary>
+    /// Drives collections until every context retired on <paramref name="unloads"/> is collected,
+    /// one has faulted, or the rest are shown to be retained; then observes the completion signal.
+    /// </summary>
+    public static async ValueTask<CollectibleUnloadOutcome> WaitUntilCollectedAsync(
+        CollectibleContextUnloads? unloads)
+    {
+        if (unloads is null || unloads.Pending == 0)
+            return new CollectibleUnloadOutcome(0, [], null);
+
+        var rounds = 0;
+        var stalled = 0;
+        var before = unloads.Pending;
+        while (unloads.Pending > 0 && unloads.Faults.Count == 0 && stalled < NoProgressRounds)
+        {
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            GC.Collect();
+            GC.WaitForPendingFinalizers();
+            rounds++;
+            var now = unloads.Pending;
+            stalled = now < before ? 0 : stalled + 1;
+            before = now;
+        }
+
+        if (unloads.Faults.Count > 0)
+            return new CollectibleUnloadOutcome(rounds, [], unloads.Faults[0]);
+        if (unloads.Pending > 0)
+            return new CollectibleUnloadOutcome(rounds, unloads.PendingContextNames, null);
+
+        // Every sentinel has run; its release is queued on the pool. Observe it — the signal, not
+        // the count, is what says the unload finished. Through the sanctioned bridge: awaiting the
+        // observable directly would resume this teardown inline on the pool thread that signalled.
+        try
+        {
+            await unloads.AllCollected.Await();
+            return new CollectibleUnloadOutcome(rounds, [], null);
+        }
+        catch (Exception ex)
+        {
+            return new CollectibleUnloadOutcome(rounds, [], ex);
+        }
+    }
+}

--- a/test/MeshWeaver.Fixture/HubTestBase.cs
+++ b/test/MeshWeaver.Fixture/HubTestBase.cs
@@ -150,6 +150,9 @@ public class HubTestBase : TestBase
         if (Mesh is null)
             return;
         var disposalId = Guid.NewGuid().ToString("N")[..8];
+        // Plugins#1605 — waited on LAST (see the finally): the next test's mesh must not be built
+        // while this one's collectible contexts are still unloading.
+        CollectibleContextUnloads? collectibleUnloads = null;
 
         Logger.LogInformation("[{DisposalId}] Starting disposal of router {RouterAddress}", disposalId, Mesh.Address);
 
@@ -168,6 +171,7 @@ public class HubTestBase : TestBase
             var ioPools = Mesh.ServiceProvider.GetService<IoPoolRegistry>();
             var asyncDisposeQueue = Mesh.ServiceProvider.GetService<AsyncDisposeQueue>();
             var teardownSignal = Mesh.ServiceProvider.GetService<MeshTeardownSignal>();
+            collectibleUnloads = Mesh.ServiceProvider.GetService<CollectibleContextUnloads>();
 
             if (!Mesh.IsDisposing)
             {
@@ -218,6 +222,11 @@ public class HubTestBase : TestBase
         {
             await base.DisposeAsync();
             Mesh = null!;
+            var unloadOutcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(collectibleUnloads);
+            Logger.LogInformation("[{DisposalId}] Collectible contexts: {Outcome}", disposalId, unloadOutcome);
+            if (unloadOutcome.Fault is not null)
+                throw new InvalidOperationException(
+                    $"Teardown: a collectible context's unload was abandoned — {unloadOutcome}", unloadOutcome.Fault);
         }
     }
 

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1,3 +1,4 @@
+using MeshWeaver.Fixture;
 ﻿using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Concurrency;
@@ -1463,6 +1464,10 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         // more deterministic (no race against the Mesh's own dispose).
         await DisposeTestClientsAsync(testName, sw);
 
+        // Plugins#1605 — the mesh's record of the collectible contexts it retires. Resolved here,
+        // while the scope is alive; waited on LAST, after the scope (and with it the compilation
+        // cache, which retires every context it still holds) has been disposed.
+        CollectibleContextUnloads? collectibleUnloads = null;
         try
         {
             // Stop the hosted services InitializeAsync started — in reverse order, BEFORE
@@ -1529,6 +1534,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             var ioPools = Mesh.ServiceProvider.GetService<IoPoolRegistry>();
             var asyncDisposeQueue = Mesh.ServiceProvider.GetService<AsyncDisposeQueue>();
             var teardownSignal = Mesh.ServiceProvider.GetService<MeshTeardownSignal>();
+            collectibleUnloads = Mesh.ServiceProvider.GetService<CollectibleContextUnloads>();
             Mesh.Dispose();
             TestPhaseTrace(testName, "DISPOSE_INVOKED", sw.ElapsedMilliseconds);
 
@@ -1684,6 +1690,24 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
                         $"{ex.GetType().Name}: {ex.Message}");
                 }
             }
+
+            // 🚨 Plugins#1605 — teardown is not finished until the collectible contexts it retired
+            // have REALLY unloaded. Unload() only requests it; DISPOSE_DONE above is written while
+            // they are still being torn down, and every readable FutuRe crash dump shows the next
+            // mesh being built or run over 3–7 such contexts. So the next test's mesh is sequenced
+            // after the reactive "all collected" signal: xUnit does not construct it until this
+            // DisposeAsync returns. A faulted unload fails the class like a dirty teardown; a
+            // retained context (rooted by something live) is REPORTED, never waited on.
+            var unloadOutcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(collectibleUnloads);
+            TestPhaseTrace(testName,
+                unloadOutcome.Fault is not null ? "DISPOSE_UNLOAD_FAULTED"
+                : unloadOutcome.Retained ? "DISPOSE_ALC_RETAINED"
+                : "DISPOSE_UNLOADS_COLLECTED",
+                sw.ElapsedMilliseconds, unloadOutcome.ToString());
+            if (unloadOutcome.Fault is not null && disposeException is null)
+                disposeException = new InvalidOperationException(
+                    $"{testName} teardown: a collectible context's unload was abandoned — {unloadOutcome}",
+                    unloadOutcome.Fault);
 
             // Force a full GC + finalizers + a second collection so any short-lived
             // garbage is gone and the MEM line shows what actually survived this

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -271,20 +271,31 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// a failure traced rather than thrown, so a teardown fault cannot red a suite that passed.
     /// </summary>
     private sealed class SharedMeshProvider(IServiceProvider serviceProvider, string testClassName)
-        : IDisposable
+        : IAsyncDisposable
     {
         /// <summary>The provider every test of the class shares.</summary>
         public IServiceProvider ServiceProvider { get; } = serviceProvider;
 
-        /// <inheritdoc/>
-        public void Dispose()
+        /// <summary>
+        /// Disposes the shared provider, then — like the per-test path (Plugins#1605) — waits until
+        /// every collectible context its mesh retired has REALLY unloaded, so a collection that starts
+        /// next never builds a mesh over this one's unloading contexts. The tracker is resolved BEFORE
+        /// the provider is disposed (resolving afterwards races the scope's own teardown).
+        /// </summary>
+        public async ValueTask DisposeAsync()
         {
+            var unloads = ServiceProvider.GetService<CollectibleContextUnloads>();
             try { (ServiceProvider as IDisposable)?.Dispose(); }
             catch (Exception ex)
             {
                 Fixture.TestTraceLog.AppendPhase(
                     testClassName, "DISPOSE_SHARED_SP_ERROR", 0, $"{ex.GetType().Name}: {ex.Message}");
             }
+            var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+            Fixture.TestTraceLog.AppendPhase(testClassName,
+                outcome.Fault is not null ? "DISPOSE_SHARED_UNLOAD_FAULTED"
+                : outcome.Retained ? "DISPOSE_SHARED_ALC_RETAINED"
+                : "DISPOSE_SHARED_UNLOADS_COLLECTED", 0, outcome.ToString());
         }
     }
 


### PR DESCRIPTION
Refs Systemorph/MeshWeaver.Plugins#1605

The next mesh now starts only once the previous mesh's collectible NodeType contexts have **really** unloaded. The wait is a subscription to an observable.

This follows the maintainer's diagnosis (2026-09-11): *"disposal being in progress while new instance starting"*. It also follows his design: *"we need to wait (reactively, i.e. observable.Subscribe()) until all is really finished disposing"*.

## What the dumps show

Six crash dumps were read for their **managed** state. The method is recorded in `Doc/Architecture/DebuggingNativeCrashes`, in the entry *"the MANAGED view of sightings #11–#16"*.

**Contexts mid-unload.** In every FutuRe dump that could be read (#12–#16), 3 to 7 `NodeAssemblyLoadContext`s were `_state = Unloading` at the moment of death.
- In #15, the next mesh was being built 12 ms after the previous `DISPOSE_DONE`: 5 contexts were Unloading and none were alive. The crashing thread was inside `HostedHubsCollection.CreateHub`, then `MessageHubConfiguration.Build`, then an Autofac resolve.

**What the zeroed word belongs to.** The zeroed MethodTable word sits in objects a hub **builds**. None is a collectible type, and none is a native wrapper:
- Autofac's child registry (`ServiceRegistrationInfo`, `List<IComponentRegistration>`);
- System.Text.Json polymorphic metadata;
- the `TypeRegistry`;
- persistence closures.

Where I measured reachability (#15, #16), the object is **garbage**: a BFS from every GC root never reaches it. It is left over from a hub that has already been disposed.

**Nothing disposing at the instant of death.** No managed thread was running disposal code. The finalizer thread was idle in `WaitForFinalizerEvent`. The unloads were pending in the GC.

**#11 is a different branch.** It is GitSync, with no collectible context at all, and an interior stale reference: dotnet/runtime#131267's shape.

## Why `DISPOSE_DONE` was not "done"

`AssemblyLoadContext.Unload()` only *requests* an unload. The runtime holds the context through a strong handle and frees it later, on the finalizer thread, over subsequent collections. `MeshTeardownSignal` fires when teardown has requested those unloads, and the test bases wrote `DISPOSE_DONE` at that point. So xUnit built the next mesh over contexts that were still being torn down.

## The fix

- **`CollectibleContextUnloads`** (new, `MeshWeaver.Mesh.Contract`, mesh-scoped singleton):
  - It records each retired context by its **signal**, never by reference.
  - `AllCollected` completes when every context retired before the subscription has been collected.
  - It **errors** when an unload was abandoned: the drain faulted, or `Unload()` threw.
  - It emits synchronously when nothing is pending.
- **`NodeAssemblyLoadContext.RetireInto`** attaches a finalizable sentinel that is referenced only by the context.
  - `Unload()` suppresses the context's own finalizer, so the sentinel carries the signal instead.
  - The runtime releases the context only when it destroys the LoaderAllocator. The sentinel can therefore be finalized only after the unload has really finished.
- **`CompilationCacheService`** retires every context it disposes (`UnloadContext`, `Dispose`) into the tracker. The tracker reaches it as an optional constructor parameter.
- **Test bases.** `MonolithMeshTestBase` and `HubTestBase` end teardown with `CollectibleUnloadDrain`.
  - It drives full collections, which a collectible unload needs and an idle test host never triggers on its own.
  - It then observes `AllCollected`.
  - A **faulted** unload fails the class, like a dirty teardown.
  - A **retained** context (still referenced after full collections free nothing) is **reported** as `DISPOSE_ALC_RETAINED`, and never waited on.

It follows "teardown lets work finish, never forced": nothing is cancelled and nothing is unloaded early. Teardown simply does not claim to be finished until the unload has finished.

## What held the contexts: `gcroot`, and the second fix

Waiting was not enough on its own. In three real FutuRe runs, **84** teardowns ended `DISPOSE_ALC_RETAINED` and 81 ended `DISPOSE_UNLOADS_COLLECTED`. So in about half the fixtures, contexts survived three rounds of full collections.

**How the holder was found.**
- I took a heap dump the instant a teardown wrote `RETAINED`.
- I ran `gcroot` on the two unloading **LoaderAllocators**. The contexts themselves are always strong-held by the runtime's own handle, so rooting them answers nothing.
- Both LoaderAllocators have exactly one strong root, and it is the same: `ReflectionEmitCachingMemberAccessor`, the static cache in System.Text.Json.
- The chain from it runs `CacheEntry` → emitted `Action<object,string>` setter → `DynamicMethod` → `DynamicScope` → the collectible `RuntimeType` → `LoaderAllocator`.
- The other roots are handle type 10, `HNDTYPE_WEAK_INTERIOR_POINTER`, which is weak.

**What this means.** STJ shares its emitted accessors for 1 s after last use and evicts them on a 200 ms timer. An unload therefore *finished* whenever STJ's timer fired, usually while the next mesh was already starting. This is the same shape as the Autofac cache that `ReflectionCacheEviction` already purges.

**The second fix.** `JsonMemberAccessorCacheEviction` is registered on `Unloading`. It calls STJ's published `MetadataUpdateHandler.ClearCache(Type[]?)` hook, the one hot reload uses.
- Control: `ATypeSerializedThroughSystemTextJson_IsCollectedAtTeardown_NotWhenStjsTimerFires`. It also asserts that the hook exists.
- After the fix, over three FutuRe runs: **93** teardowns ended `COLLECTED` and **45** ended `RETAINED`.
- **A second dump**, taken at a `RETAINED` teardown with the eviction active, shows **no strong root** on any of the three contexts. Every root is a type-10 handle (`HNDTYPE_WEAK_INTERIOR_POINTER`, weak) pointing at the context's own statics, for example the compiler's `<4>__ProfitByLoB` method-group cache. So nothing held them *after* `DisposeAsync` returned.
- **They were not slow.** Allowing up to 20 no-progress rounds (40 full collections) left **30** teardowns still `RETAINED`, and nothing was collected between round 4 and round 20. Something **live** held them *during* the drain.
- **A dump taken *inside* the drain names it:** a stack slot of `MonolithMeshTestBase.<DisposeAsync>d__87.MoveNext()`, the very frame running the drain. The chain runs from the disposed `MessageHub` → `Workspace` → `MeshDataSource` → `MeshContentTypeRegistry` → `DiscriminatorClaim` → the collectible `RuntimeType`. The fixture's `ServiceProvider` field is a second route to the same graph.
- **The third fix.** The drain yields before collecting, and the test bases clear `ServiceProvider` first.

**The progression, measured the same way each time (three FutuRe runs each):**

| state | collected | retained |
|---|---|---|
| waiting for "really unloaded" only | 81 | 84 |
| + evicting STJ's accessor cache | 93 | 45 |
| + the teardown releasing its own mesh first | 126 | 12 |

The last 12 are reported and named, never waited on. Two further measurements settle them:
- **No managed root.** A second dump taken inside the drain, with both fixes active, shows no non-weak root on the remaining contexts.
- **The cutoff is right.** Letting the drain run 20 no-progress rounds instead of 3 collected 88 teardowns (32 with nothing to wait for, 56 in 2 rounds) and left 4 retained. **None** was collected at any round from 3 to 20, so three rounds is measured, not guessed.

The residual, 4–9 % of the teardowns that had anything to wait for, is held outside the managed heap, most likely by a native LoaderAllocator-to-LoaderAllocator reference or a runtime-internal one. I'm handing it to #4017.

**For the #4017 retention work:** on a long-lived portal, `MeshContentTypeRegistry`'s discriminator claims hold superseded NodeType generations' `RuntimeType`s for as long as the mesh lives.

## Controls

`RetiredContextCollectedSignalTest`, clean Release `-warnaserror` build: **5 passed, 0 failed**. The full `MeshWeaver.Compiler.Pipeline.Test` suite was run before the STJ control was added: **866 passed, 0 failed**. `MeshWeaver.Documentation.Test`: **397 passed**.

| control | asserts | falsified by | red with |
|---|---|---|---|
| `ATypeSerializedThroughSystemTextJson_IsCollectedAtTeardown_NotWhenStjsTimerFires` | a context whose type went through STJ is **collected** at teardown, and STJ still publishes the hook | removing the `Unloading += JsonMemberAccessorCacheEviction.EvictFor` registration | *…must be collectable the moment its unload is requested — not when STJ's 1 s eviction timer happens to fire (1 context(s) RETAINED after 3 round(s) freed nothing: DynamicNode_Json1605), but found False.* |

| control | asserts | falsified by | red with |
|---|---|---|---|
| `NextStart_RunsOnlyAfterTheRetiredContextIsCollected_AndTheContextIsCollected` | a start sequenced on the signal does not run while the context is only Unload()-requested; the context IS collected; the start is released after collection | signalling at `Unload()` time (`_retirement?.Collected()` right after `Unload()`) | *Expected value to be false because Unload() has only been REQUESTED … but found True.* |
| `AFaultedUnload_ReleasesTheWaiterWithTheFault_NeverHangsIt` | an `Unloading` handler that throws releases the waiter with that fault within budget | removing both `Faulted(...)` arms | *Expected a InvalidOperationException because an abandoned unload must ERROR the signal … but found TimeoutException* |
| `WithNothingRetired_TheNextStartIsNotDelayed` · `ACollectedRetirement_LeavesNothingBehind_SoTheNextWaitIsImmediate` | no delay when nothing is retired; nothing lingers after a collection | the cache holding each retired context (the tracker rooting what it waits for) | control 1 *…must be collected (1 context(s) RETAINED after 3 round(s) freed nothing: DynamicNode_Signal1605), but found False.* and control 4 — and the driver REPORTED the retention after 3 rounds instead of hanging |

## What this does NOT prove, stated plainly

- **No deterministic crash repro.** On macOS arm64, a minimal repro with no MeshWeaver code survived 16,112 overlapped iterations: collectible unload overlapping Autofac child scopes, STJ emit and a GC hammer. On linux-arm64 (`10.0.12`) it survived 11,289. The real `MeshWeaver.FutuRe.Test` survived 20 consecutive runs, 1,180 fixtures, on macOS arm64 without the fix. The CI rate is about 1 % of x64 runs, so none of these could be expected to crash. The dumps establish the overlap *state* at 5 of 5 FutuRe crashes. They do not name the thread that wrote the zero.
- **Scope.** This sequences a mesh *instance* after the previous one's unloads: test fixtures, and any host that tears a mesh down and builds another. In-process NodeType **recompiles** on a live portal still supersede a generation while other hubs run. That is not sequenced here, and it is flagged for reconciliation with the #4017 / #4029 retention work.

## Coordination with #4017 / #4029

The mirror problem is contexts retained too **long**. This PR makes retention **visible** at every teardown (`DISPOSE_ALC_RETAINED` names the contexts) without failing on it, so it neither reds suites on the retention #4017 is fixing nor hides it. `KernelScriptReferences.cs` is untouched. `CompilationCacheService.cs` changes are surgical: the retire calls, the sentinel, and the two fault arms. Unload *timing* is unchanged. Nothing unloads earlier or later; teardown only waits for the unload to finish.

What's New: skipped — test-host teardown sequencing and an internal signal, with no user-visible effect.

Pairs-with: none — no public type or member is removed. `CollectibleContextUnloads` is a new public type, and the `CompilationCacheService` constructor parameter is on an `internal` class.
Implementers: none — no member is added to any public interface.
Mirror-sync: none — no i18n catalog key is added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
