### PR TITLE
hosting-operator: hosting-inline-env-retire (RetireInlineEnv cluster half) + kv-rotate refuses under an inline shadow

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -66,7 +66,7 @@ jobs:
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
           if [ "$tracked" -lt 20 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 21 (18 commands + run.sh + _common.sh + _audit.jq)."
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 22 (19 commands + run.sh + _common.sh + _audit.jq)."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1
@@ -106,8 +106,10 @@ jobs:
           hosting-dns
           hosting-export
           hosting-federate
+          hosting-inline-env-retire
           hosting-kv-ensure
           hosting-kv-purge
+          hosting-kv-rotate
           hosting-pull-secret
           hosting-pv-purge
           hosting-pv-resize
@@ -148,7 +150,7 @@ jobs:
           not_wired=$(mktemp)
           cat > "$not_wired" <<'EOF'
           # command                  why it ships without a plan entry
-          hosting-kv-rotate          its RotateRegistryKey verb lives in MeshWeaver.Plugins and is not emitted yet
+          # (none — hosting-kv-rotate moved to the plan list: InstanceActionPlan.RotateRegistryKeySteps emits it)
           EOF
           unclaimed=()
           for path in deploy/aks/operator/bin/hosting-*; do
@@ -189,11 +191,11 @@ jobs:
         # through to a REAL az/kubectl on a runner that has one.
         run: |
           set -euo pipefail
-          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl; do
+          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl deploy/aks/operator/test/stubs/inline-env/kubectl deploy/aks/operator/test/stubs/kv-rotate/az; do
             git ls-files --error-unmatch "$f" >/dev/null 2>&1 || { echo "::error::${f} is not tracked"; git check-ignore -v "$f" || true; exit 1; }
             [ "$(git ls-files -s "$f" | awk '{print $1}')" = "100755" ] || { echo "::error::${f} is not committed executable (mode 100755)"; exit 1; }
           done
-          echo "pull-secret stubs tracked and executable"
+          echo "operator test stubs tracked and executable"
 
       - name: Behaviour tests
         run: deploy/aks/operator/test/run-tests.sh

--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
-          if [ "$tracked" -lt 20 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 22 (19 commands + run.sh + _common.sh + _audit.jq)."
+          if [ "$tracked" -lt 23 ]; then
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 23 (20 commands + run.sh + _common.sh + _audit.jq). The floor is the REAL count — raise it with every command added, or a lost file passes."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1

--- a/deploy/aks/operator/bin/hosting-inline-env-retire
+++ b/deploy/aks/operator/bin/hosting-inline-env-retire
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# hosting-inline-env-retire --namespace <ns> --retire <KEY>=<shadowed source> [--retire …]
+#                           [--deployment memex-portal-deployment] [--container memex-portal]
+#
+# Remove inline `env:` entries from the portal Deployment — the entries a Hosting/Deployment record
+# marks RETIRED (`inlineEnv[].retiredBy`) — and only after proving, in the cluster and immediately
+# before the write, that the pod falls through to the SAME value.
+#
+# 🚨 WHY THIS EXISTS. An inline entry is out-of-band by construction: the chart never renders one,
+# and `helm upgrade` never removes one (three-way merge removes only what helm previously OWNED —
+# Doc/Architecture/ChartDriftSemantics). So a key the record retired stayed on the pod spec for
+# ever, and the only instrument was `set env deploy/<name> <KEY>-` from a laptop — the break-glass
+# write the 2026-09-08 rule retired. MeshWeaver#3201 is the worked example: a plugin-registry
+# credential in plaintext on both production portals' pod specs, shadowing the Key Vault copy, with
+# no API action able to take it off (MeshWeaver.Plugins#1593). This is the cluster half of the
+# Reconcile's `RetireInlineEnv` remedy. WHICH keys, in what order, and the record-side refusals (a
+# sole source, a credential whose equality was never recorded) are the Hosting plugin's RepairPlan,
+# unit-tested without a cluster; this script holds the checks only the cluster can answer.
+#
+# 🚨 THE RECORDED EQUALITY IS A SNAPSHOT, SO IT IS RE-MEASURED HERE. For every key, before anything
+# is written:
+#   * the portal container's envFrom is walked IN ORDER and the LAST source carrying the key is the
+#     fall-through (Kubernetes keeps the last envFrom on a clash). None → the inline entry is the
+#     SOLE source, and removing it would BLANK the key: refused.
+#   * that source must be the one the record names (`--retire KEY=<shadowed source>`). An equality
+#     recorded against a source the pod would not read has measured nothing: refused.
+#   * the inline value and the fall-through value are compared and must be EQUAL. DIFFER: refused.
+# Only LENGTHS and the VERDICT are ever printed. A value never reaches stdout, stderr, a
+# `::hosting::` line, the patch or an argv — the 2026-08-30 exposure came from an audit that
+# selected `.value` while asking "is this stored in the clear?".
+#
+# 🚨 IT REFUSES DURING A ROLLOUT. Removing an entry rewrites the pod template, which starts a new
+# rollout and supersedes the one in flight: the pods serving now would keep the entry, and the new
+# ones would meet whatever is holding the current rollout (MeshWeaver#3201, 2026-09-08: both portals
+# held at the bake gate). A Deployment that is not settled — observedGeneration behind, a replica
+# not updated or not available, or paused — is a refusal before any Secret is read.
+#
+# 🚨 EVERY CONTAINER. The language-gate sidecars carry no `envFrom` and the chart renders exactly
+# MESH_GRPC_URL and MESH_GATE_ADDRESS on them, yet a whole-Deployment `set env` once copied the
+# portal's inline entries — credential included — onto both. A retired key is removed from every
+# container that carries it, in ONE patch (one new ReplicaSet), guarded by JSON-patch `test` ops on
+# the Deployment's resourceVersion and on each entry's NAME: a concurrent edit makes the patch fail
+# instead of removing the wrong entry. One refused key refuses the whole run — nothing is retired
+# halfway.
+#
+# IDEMPOTENT: a key no container carries is reported absent and nothing is written; a run with
+# nothing to remove does not roll the Deployment. The rollout this starts is WAITED FOR by the plan
+# step that follows, and the run ends in the same re-audit and generation check as every Reconcile.
+#
+# Output contract (the ::hosting:: lines):
+#   inline_env_retired=<n>      keys removed from the pod spec — read back, not assumed
+#   inline_env_absent=<n>       retired keys no container carried any more
+#   inline_env_retire=dry-run   a rehearsal: every check ran, nothing was written
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-inline-env-retire"
+
+namespace="" deployment="memex-portal-deployment" container="memex-portal"
+keys=() shadows=()
+while [ $# -gt 0 ]; do
+  flag="$1" value="${2:-}"
+  # Shift the value only when there is one: a trailing flag with no value must reach the
+  # need_flag refusal below, not spin on a `shift 2` that cannot shift.
+  if [ $# -gt 1 ]; then shift 2; else shift; fi
+  case "$flag" in
+    --namespace)  namespace="$value" ;;
+    --deployment) deployment="$value" ;;
+    --container)  container="$value" ;;
+    --retire)
+      [[ "$value" == *=* ]] \
+        || hosting::die "--retire '${value}' is not KEY=<shadowed source> — the record names what every retired entry falls through to"
+      keys+=("${value%%=*}")
+      shadows+=("${value#*=}") ;;
+    *) hosting::die "unknown argument '${flag}'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::safe_name namespace "$namespace"
+hosting::safe_name deployment "$deployment"
+hosting::safe_name container "$container"
+[ "${#keys[@]}" -gt 0 ] \
+  || hosting::die "missing required flag --retire — name at least one KEY=<shadowed source>: the record's inlineEnv entries that carry retiredBy"
+
+i=0
+while [ "$i" -lt "${#keys[@]}" ]; do
+  k="${keys[$i]}" s="${shadows[$i]}"
+  [[ "$k" =~ ^[A-Za-z_][A-Za-z0-9_.-]*$ ]] \
+    || hosting::die "key '${k}' is not a plain environment-variable name — refusing to interpolate it"
+  [ -n "$s" ] \
+    || hosting::die "${k} names no shadowed source — an inline entry with no shadow is the SOLE source of its key, and removing it would BLANK the key; the record must name what it falls through to"
+  hosting::safe_name "shadowed source of ${k}" "$s"
+  j=0
+  while [ "$j" -lt "$i" ]; do
+    [ "${keys[$j]}" != "$k" ] || hosting::die "key '${k}' is named twice — one --retire per key"
+    j=$((j + 1))
+  done
+  i=$((i + 1))
+done
+
+command -v jq >/dev/null 2>&1 \
+  || hosting::die "jq is not installed in this image — the Deployment and its sources are JSON and cannot be measured without it"
+
+err="$(mktemp)"
+trap 'rm -f "$err"' EXIT
+
+# ── the Deployment as it is, and whether it is settled ─────────────────────────────────────────
+dep="$(hosting::read kubectl -n "$namespace" get deployment "$deployment" -o json 2>"$err")" \
+  || hosting::die "could not read deployment/${deployment} in ${namespace} ($(tr -d '\n' < "$err"))"
+
+rollout="$(printf '%s' "$dep" | jq -r '[
+    (.metadata.generation // 0), (.status.observedGeneration // 0), (.spec.replicas // 1),
+    (.status.replicas // 0), (.status.updatedReplicas // 0), (.status.availableReplicas // 0),
+    (.status.unavailableReplicas // 0), (if .spec.paused == true then 1 else 0 end)
+  ] | map(tostring) | join(" ")')" \
+  || hosting::die "could not read the rollout state of deployment/${deployment}"
+read -r gen observed want total updated available unavailable paused <<<"$rollout"
+if [ "$observed" -lt "$gen" ] || [ "$total" -ne "$want" ] || [ "$updated" -ne "$want" ] \
+   || [ "$available" -ne "$want" ] || [ "$unavailable" -ne 0 ] || [ "$paused" -ne 0 ]; then
+  paused_note=""
+  [ "$paused" -eq 0 ] || paused_note=", PAUSED"
+  hosting::die "a rollout is in progress on deployment/${deployment} in ${namespace} (generation ${gen}, observed ${observed}; ${want} desired, ${total} running, ${updated} updated, ${available} available, ${unavailable} unavailable${paused_note}). Removing an env entry rewrites the pod template, which starts a NEW rollout and supersedes this one — the pods serving now keep the entry and the new ones meet whatever is holding this one. Hold until it settles, then re-run. Nothing was changed."
+fi
+hosting::log "rollout   deployment/${deployment} is settled (generation ${gen}, ${available}/${want} available)"
+
+printf '%s' "$dep" | jq -e --arg c "$container" 'any(.spec.template.spec.containers[]; .name == $c)' >/dev/null \
+  || hosting::die "deployment/${deployment} has no container '${container}' — the fall-through is measured on the portal container, so there is nothing to measure against"
+
+# ── helpers that stay inside pipes ──────────────────────────────────────────────────────────────
+# 🚨 These two print a VALUE on stdout, so they are only ever the head of a pipe into wc/sha256sum.
+# Neither result is printed either: a length is, a digest is only compared.
+inline_value() {
+  printf '%s' "$dep" | jq -j --arg c "$container" --arg k "$1" \
+    '[.spec.template.spec.containers[] | select(.name == $c) | .env[]? | select(.name == $k) | (.value // "")] | last // ""'
+}
+shadow_value() {  # kind object-json data-key
+  case "$1" in
+    secret)    printf '%s' "$2" | jq -j --arg k "$3" '.data[$k] // ""' | base64 -d ;;
+    configmap) printf '%s' "$2" | jq -j --arg k "$3" '.data[$k] // ""' ;;
+  esac
+}
+source_json() {  # kind name
+  case "$1" in
+    secret)    hosting::read kubectl -n "$namespace" get secret "$2" -o json ;;
+    configmap) hosting::read kubectl -n "$namespace" get configmap "$2" -o json ;;
+    *)         return 1 ;;
+  esac
+}
+
+# The portal container's envFrom, IN ORDER, as kind|name|prefix|optional. `|` rather than a tab:
+# tab is IFS whitespace, and consecutive tabs would collapse an empty prefix into the next field.
+env_from="$(printf '%s' "$dep" | jq -r --arg c "$container" '
+  .spec.template.spec.containers[] | select(.name == $c) | .envFrom[]? |
+  if .configMapRef then ["configmap", .configMapRef.name, (.prefix // ""), ((.configMapRef.optional // false) | tostring)]
+  elif .secretRef then ["secret", .secretRef.name, (.prefix // ""), ((.secretRef.optional // false) | tostring)]
+  else empty end | join("|")')"
+
+# ── every key is measured before anything is written ───────────────────────────────────────────
+remove=()
+absent=0
+i=0
+while [ "$i" -lt "${#keys[@]}" ]; do
+  key="${keys[$i]}" shadow="${shadows[$i]}"
+  i=$((i + 1))
+
+  carriers="$(printf '%s' "$dep" | jq -r --arg k "$key" \
+    '[.spec.template.spec.containers[] | select(any(.env[]?; .name == $k)) | .name] | join(", ")')"
+  if [ -z "$carriers" ]; then
+    hosting::log "${key}  not set inline on any container — already retired, nothing to remove"
+    absent=$((absent + 1))
+    continue
+  fi
+
+  refs="$(printf '%s' "$dep" | jq -r --arg k "$key" \
+    '[.spec.template.spec.containers[] | .name as $c | .env[]? | select(.name == $k and has("valueFrom")) | $c] | join(", ")')"
+  [ -z "$refs" ] \
+    || hosting::die "${key} is set from a valueFrom reference on ${refs} — this remedy retires plain inline VALUES; a reference names its own source and is not a shadow. Nothing was changed."
+
+  on_portal="$(printf '%s' "$dep" | jq -r --arg c "$container" --arg k "$key" \
+    '[.spec.template.spec.containers[] | select(.name == $c) | .env[]? | select(.name == $k)] | length > 0')"
+  if [ "$on_portal" = "true" ]; then
+    winner_kind="" winner_name="" winner_key=""
+    while IFS='|' read -r kind name prefix optional; do
+      [ -n "$kind" ] || continue
+      hosting::safe_name "envFrom source" "$name"
+      if [ -z "$prefix" ]; then
+        data_key="$key"
+      elif [ "${key#"$prefix"}" != "$key" ]; then
+        data_key="${key#"$prefix"}"
+      else
+        continue
+      fi
+      if ! obj="$(source_json "$kind" "$name" 2>"$err")"; then
+        [ "$optional" = "true" ] && continue
+        hosting::die "could not read ${kind}/${name}, an envFrom source of ${container} ($(tr -d '\n' < "$err")) — the fall-through cannot be measured, so nothing is removed"
+      fi
+      if printf '%s' "$obj" | jq -e --arg k "$data_key" '(.data // {}) | has($k)' >/dev/null; then
+        winner_kind="$kind" winner_name="$name" winner_key="$data_key"
+      fi
+    done <<EOF_SOURCES
+$env_from
+EOF_SOURCES
+    unset obj
+
+    [ -n "$winner_kind" ] \
+      || hosting::die "${key} is the SOLE source of its value: no envFrom source of ${container} carries it, so removing the inline entry would BLANK the key rather than fall back. Give the key a declared home first (a Key Vault class, or the record's configuration), then re-run. Nothing was changed."
+    [ "$winner_name" = "$shadow" ] \
+      || hosting::die "the record says ${key} shadows '${shadow}', but ${container} would fall through to ${winner_kind}/${winner_name} — the LAST envFrom source that carries it. An equality recorded against a source the pod would not read has measured nothing: correct inlineEnv[].shadows on the record and re-run. Nothing was changed."
+
+    obj="$(source_json "$winner_kind" "$winner_name" 2>"$err")" \
+      || hosting::die "lost ${winner_kind}/${winner_name} while measuring ${key} ($(tr -d '\n' < "$err"))"
+    inline_len="$(inline_value "$key" | wc -c | tr -d ' ')"
+    shadow_len="$(shadow_value "$winner_kind" "$obj" "$winner_key" | wc -c | tr -d ' ')"
+    inline_sum="$(inline_value "$key" | sha256sum | cut -c1-64)"
+    shadow_sum="$(shadow_value "$winner_kind" "$obj" "$winner_key" | sha256sum | cut -c1-64)"
+    unset obj
+    if [ "$inline_sum" != "$shadow_sum" ]; then
+      hosting::die "${key}: DIFFER (inline ${inline_len} bytes, ${winner_kind}/${winner_name} ${shadow_len} bytes) — removing the inline entry would change the value the portal reads. Promote the IN-USE value into the declared source first (never the other way round, and never mint a replacement as part of a cleanup), then re-run. Nothing was changed."
+    fi
+    unset inline_sum shadow_sum
+    hosting::log "${key}  EQUAL (len ${inline_len}) — ${container} falls through to ${winner_kind}/${winner_name}"
+  else
+    hosting::log "${key}  not set on ${container} — the portal already reads its declared source"
+  fi
+
+  hosting::log "${key}  inline on: ${carriers}"
+  remove+=("$key")
+done
+
+if [ "${#remove[@]}" -eq 0 ]; then
+  hosting::log "nothing to remove — the Deployment is not rolled"
+  hosting::say inline_env_retired 0
+  hosting::say inline_env_absent "$absent"
+  exit 0
+fi
+
+# ── one guarded patch: names and paths only, never a value ─────────────────────────────────────
+keys_json="$(printf '%s\n' "${remove[@]}" | jq -R . | jq -s -c .)"
+rv="$(printf '%s' "$dep" | jq -r '.metadata.resourceVersion // ""')"
+[ -n "$rv" ] \
+  || hosting::die "deployment/${deployment} reports no resourceVersion — the patch is guarded on it, so it is refused rather than written unguarded"
+# Descending entry index within each container, so an earlier removal never shifts a later path.
+patch="$(printf '%s' "$dep" | jq -c --argjson keys "$keys_json" --arg rv "$rv" '
+  [ .spec.template.spec.containers | to_entries[] | .key as $ci | (.value.env // []) | to_entries[]
+    | select(.value.name as $n | any($keys[]; . == $n))
+    | {ci: $ci, ei: .key, name: .value.name} ]
+  | sort_by(.ci, -.ei)
+  | [{op: "test", path: "/metadata/resourceVersion", value: $rv}]
+    + map({op: "test", path: "/spec/template/spec/containers/\(.ci)/env/\(.ei)/name", value: .name},
+          {op: "remove", path: "/spec/template/spec/containers/\(.ci)/env/\(.ei)"})')"
+unset dep
+
+hosting::do kubectl -n "$namespace" patch deployment "$deployment" --type json -p "$patch" >/dev/null \
+  || hosting::die "could not patch deployment/${deployment} — a failed 'test' op means the Deployment changed after it was measured (resourceVersion ${rv}); re-run to measure it again"
+
+if hosting::dry; then
+  hosting::say inline_env_retired 0
+  hosting::say inline_env_absent "$absent"
+  hosting::say inline_env_retire dry-run
+  exit 0
+fi
+
+# ── read it back: the patch is not the outcome, the pod spec is ─────────────────────────────────
+after="$(hosting::read kubectl -n "$namespace" get deployment "$deployment" -o json 2>"$err")" \
+  || hosting::die "lost deployment/${deployment} after patching it ($(tr -d '\n' < "$err"))"
+left="$(printf '%s' "$after" | jq -r --argjson keys "$keys_json" \
+  '[.spec.template.spec.containers[] | .name as $c | .env[]? | select(.name as $n | any($keys[]; . == $n)) | "\($c)/\(.name)"] | join(", ")')"
+unset after
+[ -z "$left" ] \
+  || hosting::die "the patch was accepted but deployment/${deployment} still carries ${left} — refusing to report a retirement that did not happen"
+
+hosting::log "retired   ${remove[*]} from every container (read back); the rollout this started is waited for by the next step"
+hosting::say inline_env_retired "${#remove[@]}"
+hosting::say inline_env_absent "$absent"

--- a/deploy/aks/operator/bin/hosting-kv-rotate
+++ b/deploy/aks/operator/bin/hosting-kv-rotate
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # hosting-kv-rotate --vault <name> --prefix <prefix> --namespace <ns> --synced-secret <k8s secret> [--key <config key>]
+#                   [--deployment memex-portal-deployment]
 #
 # Rotate this instance's plugin-registry key: mint a fresh `mwi_` key, put it in Key Vault, and
 # report ONLY ITS HASH back to the mesh. The registry adopts the hash (the control plane reacts to
@@ -19,7 +20,7 @@
 source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
 # shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
 HOSTING_CMD="hosting-kv-rotate"
-vault="" prefix="" namespace="" synced="" key="PluginCatalog__RegistryToken"
+vault="" prefix="" namespace="" synced="" key="PluginCatalog__RegistryToken" deployment="memex-portal-deployment"
 while [ $# -gt 0 ]; do
   case "$1" in
     --vault)         vault="${2:-}";     shift 2 ;;
@@ -27,6 +28,7 @@ while [ $# -gt 0 ]; do
     --namespace)     namespace="${2:-}"; shift 2 ;;
     --synced-secret) synced="${2:-}";    shift 2 ;;
     --key)           key="${2:-}";       shift 2 ;;
+    --deployment)    deployment="${2:-}"; shift 2 ;;
     *) hosting::die "unknown argument '$1'" ;;
   esac
 done
@@ -37,6 +39,29 @@ hosting::safe_name vault "$vault"
 hosting::safe_name namespace "$namespace"
 hosting::safe_name synced-secret "$synced"
 [ -z "$prefix" ] || hosting::safe_name prefix "$prefix"
+hosting::safe_name key "$key"
+hosting::safe_name deployment "$deployment"
+
+# 🚨 REFUSE UNDER AN INLINE SHADOW — before anything is minted (MeshWeaver#3201, Plugins#1593).
+# An inline `env:` entry outranks every envFrom. With one for the key on the pod spec, this
+# rotation would land the new key in the vault AND in the synced Secret — the wait below goes
+# green — while the restarted pods keep presenting the OLD one; and the registry deletes the old
+# key's index entry the moment it adopts the new hash (MeshWeaverInstanceService.AdoptKeyHash →
+# DeleteIndex), so every read that presents it answers 401. A 401 storm behind a green rotation.
+# The Hosting plan refuses the same thing from the RECORD; this is the in-cluster half, because a
+# record is a snapshot and the Deployment is the fact. Names only — a value is never read out.
+# A dry run narrates the check and needs no cluster, like every other step of a rehearsal here.
+if hosting::dry; then
+  hosting::log "(dry run) would refuse if any container of deployment/${deployment} in ${namespace} sets ${key} inline"
+else
+  command -v jq >/dev/null 2>&1 \
+    || hosting::die "jq is not installed in this image — the inline-shadow check reads the Deployment as JSON"
+  shadowing="$(hosting::read kubectl -n "$namespace" get deployment "$deployment" -o json 2>/dev/null \
+    | jq -r --arg k "$key" '[.spec.template.spec.containers[] | select(any(.env[]?; .name == $k)) | .name] | join(", ")')" \
+    || hosting::die "could not read deployment/${deployment} in ${namespace} — the rotation restarts it, and whether it sets ${key} inline decides whether the new key is ever read"
+  [ -z "$shadowing" ] \
+    || hosting::die "${key} is set INLINE on ${shadowing} of deployment/${deployment} — an inline env: entry outranks every envFrom, so the new key would land in the vault and the synced Secret while the pods keep presenting the OLD one, which the registry stops accepting the moment it adopts the new hash: a 401 storm behind a green rotation. Retire the entry first (Reconcile — its RetireInlineEnv remedy), drop it from the record, then rotate. Nothing was minted."
+fi
 
 # The vault object name follows the SecretProviderClass convention: <prefix><Section>-<Key>, every
 # `__` becoming `-` (HelmValues.VaultSecretName). For PluginCatalog__RegistryToken that is

--- a/deploy/aks/operator/test/fixtures/inline-env/absent/deployment.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/absent/deployment.json
@@ -1,0 +1,95 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 43,
+    "resourceVersion": "918300"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              {
+                "name": "DOTNET_DbgEnableMiniDump",
+                "value": "1"
+              },
+              {
+                "name": "PluginCatalog__RegistryUrl",
+                "value": "https://registry.example.invalid"
+              },
+              {
+                "name": "Features__Ai__Clis__ClaudeCode",
+                "value": "true"
+              }
+            ],
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-secrets"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-keyvault"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-kv-secrets",
+                  "optional": true
+                }
+              }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/python"
+              }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/node"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 43,
+    "replicas": 2,
+    "updatedReplicas": 2,
+    "readyReplicas": 2,
+    "availableReplicas": 2
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/base/configmap_memex-portal-config.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/base/configmap_memex-portal-config.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "v1",
+  "kind": "ConfigMap",
+  "metadata": { "name": "memex-portal-config", "namespace": "memex" },
+  "data": {
+    "Modules__Root": "/data/modules",
+    "PluginCatalog__RegistryUrl": ""
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/base/deployment.after.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/base/deployment.after.json
@@ -1,0 +1,95 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 43,
+    "resourceVersion": "918300"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              {
+                "name": "DOTNET_DbgEnableMiniDump",
+                "value": "1"
+              },
+              {
+                "name": "PluginCatalog__RegistryUrl",
+                "value": "https://registry.example.invalid"
+              },
+              {
+                "name": "Features__Ai__Clis__ClaudeCode",
+                "value": "true"
+              }
+            ],
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-secrets"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-keyvault"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-kv-secrets",
+                  "optional": true
+                }
+              }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/python"
+              }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/node"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 43,
+    "replicas": 2,
+    "updatedReplicas": 2,
+    "readyReplicas": 2,
+    "availableReplicas": 2
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/base/deployment.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/base/deployment.json
@@ -1,0 +1,60 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 42,
+    "resourceVersion": "918273"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              { "name": "DOTNET_DbgEnableMiniDump", "value": "1" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" },
+              { "name": "PluginCatalog__RegistryUrl", "value": "https://registry.example.invalid" },
+              { "name": "Features__Ai__Clis__ClaudeCode", "value": "true" }
+            ],
+            "envFrom": [
+              { "configMapRef": { "name": "memex-portal-config" } },
+              { "secretRef": { "name": "memex-portal-secrets" } },
+              { "secretRef": { "name": "memex-portal-keyvault" } },
+              { "secretRef": { "name": "memex-kv-secrets", "optional": true } }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              { "name": "MESH_GRPC_URL", "value": "http://127.0.0.1:5003" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" },
+              { "name": "MESH_GATE_ADDRESS", "value": "gate/python" }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              { "name": "MESH_GRPC_URL", "value": "http://127.0.0.1:5003" },
+              { "name": "MESH_GATE_ADDRESS", "value": "gate/node" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 42,
+    "replicas": 2,
+    "updatedReplicas": 2,
+    "readyReplicas": 2,
+    "availableReplicas": 2
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/base/secret_memex-portal-keyvault.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/base/secret_memex-portal-keyvault.json
@@ -1,0 +1,10 @@
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": { "name": "memex-portal-keyvault", "namespace": "memex" },
+  "type": "Opaque",
+  "data": {
+    "PluginCatalog__RegistryToken": "ZmFrZS1pbmxpbmUtcmVnaXN0cnktdG9rZW4tMDAwMQ==",
+    "PluginCatalog__Registries__0__Token": "ZmFrZS1pbmxpbmUtcmVnaXN0cnktdG9rZW4tMDAwMQ=="
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/base/secret_memex-portal-secrets.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/base/secret_memex-portal-secrets.json
@@ -1,0 +1,9 @@
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": { "name": "memex-portal-secrets", "namespace": "memex" },
+  "type": "Opaque",
+  "data": {
+    "PluginCatalog__RegistryToken": "ZmFrZS1jaGFydC1zZWNyZXQtdG9rZW4tT1VUUkFOS0VE"
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/differ/secret_memex-portal-keyvault.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/differ/secret_memex-portal-keyvault.json
@@ -1,0 +1,13 @@
+{
+  "apiVersion": "v1",
+  "kind": "Secret",
+  "metadata": {
+    "name": "memex-portal-keyvault",
+    "namespace": "memex"
+  },
+  "type": "Opaque",
+  "data": {
+    "PluginCatalog__RegistryToken": "ZmFrZS1yb3RhdGVkLXJlZ2lzdHJ5LXRva2VuLTk5OTktbG9uZ2Vy",
+    "PluginCatalog__Registries__0__Token": "ZmFrZS1pbmxpbmUtcmVnaXN0cnktdG9rZW4tMDAwMQ=="
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/rolling/deployment.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/rolling/deployment.json
@@ -1,0 +1,108 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 43,
+    "resourceVersion": "918273"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              {
+                "name": "DOTNET_DbgEnableMiniDump",
+                "value": "1"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "fake-inline-registry-token-0001"
+              },
+              {
+                "name": "PluginCatalog__RegistryUrl",
+                "value": "https://registry.example.invalid"
+              },
+              {
+                "name": "Features__Ai__Clis__ClaudeCode",
+                "value": "true"
+              }
+            ],
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-secrets"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-keyvault"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-kv-secrets",
+                  "optional": true
+                }
+              }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "fake-inline-registry-token-0001"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/python"
+              }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/node"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "fake-inline-registry-token-0001"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 43,
+    "replicas": 3,
+    "updatedReplicas": 1,
+    "readyReplicas": 2,
+    "availableReplicas": 1,
+    "unavailableReplicas": 1
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/stuck/deployment.after.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/stuck/deployment.after.json
@@ -1,0 +1,60 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 42,
+    "resourceVersion": "918273"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              { "name": "DOTNET_DbgEnableMiniDump", "value": "1" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" },
+              { "name": "PluginCatalog__RegistryUrl", "value": "https://registry.example.invalid" },
+              { "name": "Features__Ai__Clis__ClaudeCode", "value": "true" }
+            ],
+            "envFrom": [
+              { "configMapRef": { "name": "memex-portal-config" } },
+              { "secretRef": { "name": "memex-portal-secrets" } },
+              { "secretRef": { "name": "memex-portal-keyvault" } },
+              { "secretRef": { "name": "memex-kv-secrets", "optional": true } }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              { "name": "MESH_GRPC_URL", "value": "http://127.0.0.1:5003" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" },
+              { "name": "MESH_GATE_ADDRESS", "value": "gate/python" }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              { "name": "MESH_GRPC_URL", "value": "http://127.0.0.1:5003" },
+              { "name": "MESH_GATE_ADDRESS", "value": "gate/node" },
+              { "name": "PluginCatalog__RegistryToken", "value": "fake-inline-registry-token-0001" }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 42,
+    "replicas": 2,
+    "updatedReplicas": 2,
+    "readyReplicas": 2,
+    "availableReplicas": 2
+  }
+}

--- a/deploy/aks/operator/test/fixtures/inline-env/valuefrom/deployment.json
+++ b/deploy/aks/operator/test/fixtures/inline-env/valuefrom/deployment.json
@@ -1,0 +1,112 @@
+{
+  "apiVersion": "apps/v1",
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment",
+    "namespace": "memex",
+    "generation": 42,
+    "resourceVersion": "918273"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "memex-portal",
+            "image": "cr.example.invalid/memex-portal-ai:test",
+            "env": [
+              {
+                "name": "DOTNET_DbgEnableMiniDump",
+                "value": "1"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "memex-portal-keyvault",
+                    "key": "PluginCatalog__RegistryToken"
+                  }
+                }
+              },
+              {
+                "name": "PluginCatalog__RegistryUrl",
+                "value": "https://registry.example.invalid"
+              },
+              {
+                "name": "Features__Ai__Clis__ClaudeCode",
+                "value": "true"
+              }
+            ],
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-secrets"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-portal-keyvault"
+                }
+              },
+              {
+                "secretRef": {
+                  "name": "memex-kv-secrets",
+                  "optional": true
+                }
+              }
+            ]
+          },
+          {
+            "name": "python-gate",
+            "image": "cr.example.invalid/python-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "fake-inline-registry-token-0001"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/python"
+              }
+            ]
+          },
+          {
+            "name": "node-gate",
+            "image": "cr.example.invalid/node-gate:test",
+            "env": [
+              {
+                "name": "MESH_GRPC_URL",
+                "value": "http://127.0.0.1:5003"
+              },
+              {
+                "name": "MESH_GATE_ADDRESS",
+                "value": "gate/node"
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "fake-inline-registry-token-0001"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  "status": {
+    "observedGeneration": 42,
+    "replicas": 2,
+    "updatedReplicas": 2,
+    "readyReplicas": 2,
+    "availableReplicas": 2
+  }
+}

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -486,6 +486,203 @@ case "$_pv_out" in *"DRY-RUN would run"*"patch pvc"*) ok "…and narrates the pa
   *) bad "a dry run narrates the patch" "said: ${_pv_out}" ;; esac
 
 echo
+echo "── hosting-inline-env-retire: a retired shadow leaves, onto the same value only ──"
+# The stub answers the Deployment, Secret and ConfigMap reads from a per-scenario fixture (falling
+# back to fixtures/inline-env/base) and RECORDS the patch, so the decisions — refuse mid-rollout,
+# refuse a sole source, refuse a shadow the pod would not read, refuse DIFFER, remove from EVERY
+# container in one guarded patch, read it back — are asserted without a cluster. Every fixture value
+# is an obviously fake placeholder, and the no-leak arms prove none of them is ever printed, patched
+# or passed in an argv. What is NOT proven here: that the API server honours a JSON-patch `test` op
+# on resourceVersion — that is Kubernetes' contract, and the first real run is what shows it.
+#
+# 🚨 EVERY invocation below — the argument refusals included — runs with the stub FIRST on PATH. A
+# laptop running this suite may carry a real kubectl with a live context, and a guard that failed to
+# stop would otherwise read (or patch) whatever cluster that context names.
+IE_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/inline-env" && pwd)"
+IE_FIXTURES="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/fixtures/inline-env" && pwd)"
+IE_TOKEN="PluginCatalog__RegistryToken=memex-portal-keyvault"
+_ie_args_state="$(mktemp -d)"
+IE_ENV=(env "PATH=$IE_STUBS:$PATH" "HOSTING_IE_FIXTURE=$IE_FIXTURES/base" "HOSTING_IE_BASE=$IE_FIXTURES/base" "HOSTING_IE_STATE=$_ie_args_state")
+ie() {  # ie <scenario> "<KEY=source> [KEY=source…]" [env…] — sets $_ie_out $_ie_rc $_ie_log $_ie_patch
+  local scenario="$1" pairs="$2" pair
+  shift 2
+  local retire=()
+  for pair in $pairs; do retire+=(--retire "$pair"); done
+  _ie_state="$(mktemp -d)"
+  _ie_out="$(env "$@" PATH="$IE_STUBS:$PATH" HOSTING_IE_FIXTURE="$IE_FIXTURES/$scenario" HOSTING_IE_BASE="$IE_FIXTURES/base" \
+    HOSTING_IE_STATE="$_ie_state" hosting-inline-env-retire --namespace memex "${retire[@]}" 2>&1)"; _ie_rc=$?
+  _ie_log="$(cat "$_ie_state/log" 2>/dev/null || true)"
+  _ie_patch="$(cat "$_ie_state/patch" 2>/dev/null || true)"
+  rm -rf "$_ie_state"
+}
+ie_no_patch() {  # the run wrote nothing to the Deployment
+  case "$_ie_log" in *" patch deployment "*) bad "$1" "kubectl saw a patch: ${_ie_log}" ;; *) ok "$1" ;; esac
+}
+ie_no_value() {  # no fixture value in the output, the patch or any argv kubectl saw
+  case "${_ie_out}${_ie_patch}${_ie_log}" in
+    *fake-inline-registry-token*|*fake-chart-secret-token*|*fake-rotated-registry-token*|*registry.example.invalid*)
+      bad "$1" "a value appeared — out: ${_ie_out} patch: ${_ie_patch}" ;;
+    *) ok "$1" ;;
+  esac
+}
+
+refuses "inline-env-retire needs --namespace"     "missing required flag --namespace" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --retire "$IE_TOKEN"
+refuses "inline-env-retire needs a --retire"      "missing required flag --retire" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex
+refuses "inline-env-retire rejects unknown flags" "unknown argument" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire "$IE_TOKEN" --nope 1
+refuses "inline-env-retire needs KEY=<source>"    "is not KEY=<shadowed source>" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire PluginCatalog__RegistryToken
+refuses "inline-env-retire refuses a blank shadow — that entry is the sole source" "SOLE source" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire PluginCatalog__RegistryToken=
+refuses "inline-env-retire refuses a key named twice" "named twice" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire "$IE_TOKEN" --retire "$IE_TOKEN"
+refuses_hard "inline-env-retire key with a metacharacter"    "is not a plain environment-variable name" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire 'K;kubectl delete deploy --all=s'
+refuses_hard "inline-env-retire shadow with a metacharacter" "is not a plain name" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace memex --retire 'PluginCatalog__RegistryToken=s;rm -rf /'
+refuses_hard "inline-env-retire namespace with a metacharacter" "is not a plain name" \
+  "${IE_ENV[@]}" hosting-inline-env-retire --namespace 'memex; kubectl delete ns memex' --retire "$IE_TOKEN"
+case "$(cat "$_ie_args_state/log" 2>/dev/null)" in
+  "") ok "…and no argument refusal ever reached kubectl" ;;
+  *)  bad "no argument refusal reaches kubectl" "kubectl saw: $(cat "$_ie_args_state/log")" ;;
+esac
+rm -rf "$_ie_args_state"
+
+ie base "$IE_TOKEN"
+[ "$_ie_rc" -eq 0 ] && ok "a retired credential EQUAL to the source it shadows is removed" \
+  || bad "a retired credential EQUAL to the source it shadows is removed" "exited ${_ie_rc}: ${_ie_out}"
+case "$_ie_out" in *"PluginCatalog__RegistryToken  EQUAL (len 31)"*"falls through to secret/memex-portal-keyvault"*)
+    ok "…reporting the verdict and a LENGTH, and naming the source it falls through to" ;;
+  *) bad "the EQUAL verdict is reported with its length" "said: ${_ie_out}" ;; esac
+ie_no_value "…and no value is printed, patched or passed in an argv"
+_ie_all=1
+for _p in 0/env/1 1/env/1 2/env/2; do
+  case "$_ie_patch" in *"{\"op\":\"remove\",\"path\":\"/spec/template/spec/containers/${_p}\"}"*) ;; *) _ie_all=0 ;; esac
+done
+[ "$_ie_all" = 1 ] && ok "…from EVERY container that carries it — the portal and both gate sidecars" \
+  || bad "the key is removed from every container that carries it" "patch: ${_ie_patch}"
+[ "$(printf '%s\n' "$_ie_log" | grep -c ' patch deployment ')" = "1" ] && ok "…in ONE patch (one new ReplicaSet, one rollout)" \
+  || bad "the removal is one patch" "kubectl saw: ${_ie_log}"
+case "$_ie_patch" in '[{"op":"test","path":"/metadata/resourceVersion","value":"918273"}'*)
+    ok "…guarded FIRST on the resourceVersion that was measured" ;;
+  *) bad "the patch is guarded on the measured resourceVersion" "patch: ${_ie_patch}" ;; esac
+case "$_ie_patch" in *'{"op":"test","path":"/spec/template/spec/containers/0/env/1/name","value":"PluginCatalog__RegistryToken"},{"op":"remove","path":"/spec/template/spec/containers/0/env/1"}'*)
+    ok "…and each removal on the entry's NAME, immediately before it" ;;
+  *) bad "each removal is guarded on the entry's name" "patch: ${_ie_patch}" ;; esac
+case "$_ie_patch" in *RegistryUrl*|*ClaudeCode*|*DOTNET_*|*MESH_*) bad "only the retired key is touched" "patch: ${_ie_patch}" ;;
+  *) ok "…and nothing but the retired key is touched" ;; esac
+case "$_ie_out" in *"::hosting:: inline_env_retired=1"*) ok "…and the count it reports comes after the read-back" ;;
+  *) bad "the retired count is reported" "said: ${_ie_out}" ;; esac
+
+# 🚨 The refusals — every one BEFORE any write.
+ie differ "$IE_TOKEN"
+[ "$_ie_rc" -ne 0 ] && ok "a shadow that DIFFERS is refused — removing the entry would change the value the portal reads" \
+  || bad "a DIFFER is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"DIFFER (inline 31 bytes, secret/memex-portal-keyvault 39 bytes)"*) ok "…reporting both lengths and the verdict, never a value" ;;
+  *) bad "the DIFFER refusal reports lengths" "said: ${_ie_out}" ;; esac
+ie_no_patch "…and writes nothing"
+ie_no_value "…and prints no value either"
+
+ie base "PluginCatalog__RegistryToken=memex-portal-secrets"
+[ "$_ie_rc" -ne 0 ] && ok "a record naming a shadow the pod would NOT fall through to is refused" \
+  || bad "a wrong recorded shadow is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"would fall through to secret/memex-portal-keyvault"*) ok "…naming the source that actually wins (the LAST envFrom that carries the key)" ;;
+  *) bad "the wrong-shadow refusal names the winner" "said: ${_ie_out}" ;; esac
+ie_no_patch "…and writes nothing"
+
+ie base "Features__Ai__Clis__ClaudeCode=memex-portal-config"
+[ "$_ie_rc" -ne 0 ] && ok "a SOLE-source entry is refused — removing it would blank the key" \
+  || bad "a sole source is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"SOLE source"*) ok "…saying so" ;; *) bad "the sole-source refusal says so" "said: ${_ie_out}" ;; esac
+ie_no_patch "…and writes nothing"
+
+ie base "PluginCatalog__RegistryUrl=memex-portal-config"
+[ "$_ie_rc" -ne 0 ] && ok "a key the ConfigMap renders EMPTY is refused as DIFFER, not blanked (#3201's RegistryUrl)" \
+  || bad "an empty-rendered key is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"DIFFER (inline 32 bytes, configmap/memex-portal-config 0 bytes)"*) ok "…naming both lengths" ;;
+  *) bad "the empty-rendered refusal names both lengths" "said: ${_ie_out}" ;; esac
+ie_no_patch "…and writes nothing"
+
+ie base "$IE_TOKEN Features__Ai__Clis__ClaudeCode=memex-portal-config"
+[ "$_ie_rc" -ne 0 ] && ok "one refused key refuses the whole run" || bad "one refused key refuses the run" "exited 0: ${_ie_out}"
+ie_no_patch "…so nothing is retired halfway — not even the key that measured EQUAL"
+
+ie rolling "$IE_TOKEN"
+[ "$_ie_rc" -ne 0 ] && ok "a Deployment mid-rollout is refused — the patch would supersede the rollout in flight" \
+  || bad "a mid-rollout Deployment is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"a rollout is in progress"*"1 updated"*) ok "…naming what is not settled" ;;
+  *) bad "the rollout refusal names what is unsettled" "said: ${_ie_out}" ;; esac
+case "$_ie_log" in *"get secret"*) bad "…before any Secret is read" "kubectl saw: ${_ie_log}" ;; *) ok "…before any Secret is read" ;; esac
+ie_no_patch "…and writes nothing"
+
+ie valuefrom "$IE_TOKEN"
+[ "$_ie_rc" -ne 0 ] && ok "a valueFrom reference is refused — it names its own source and is not a shadow" \
+  || bad "a valueFrom entry is refused" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"valueFrom"*) ok "…saying so" ;; *) bad "the valueFrom refusal says so" "said: ${_ie_out}" ;; esac
+ie_no_patch "…and writes nothing"
+
+ie stuck "$IE_TOKEN"
+[ "$_ie_rc" -ne 0 ] && ok "a patch the API accepted but that did not take is a FAILED step, not a pass" \
+  || bad "an ineffective patch fails" "exited 0: ${_ie_out}"
+case "$_ie_out" in *"still carries"*) ok "…naming what is still there (read back)" ;;
+  *) bad "the read-back failure names what is left" "said: ${_ie_out}" ;; esac
+
+ie absent "$IE_TOKEN"
+[ "$_ie_rc" -eq 0 ] && ok "a key no container carries any more is a successful no-op (idempotent plan step)" \
+  || bad "an already-retired key is a no-op" "exited ${_ie_rc}: ${_ie_out}"
+ie_no_patch "…that writes nothing, so it rolls nothing"
+case "$_ie_out" in *"::hosting:: inline_env_retired=0"*"::hosting:: inline_env_absent=1"*) ok "…and says so" ;;
+  *) bad "the no-op says so" "said: ${_ie_out}" ;; esac
+
+# A dry run measures for real, narrates the patch and writes nothing.
+ie base "$IE_TOKEN" HOSTING_DRY_RUN=true
+[ "$_ie_rc" -eq 0 ] && ok "a dry run succeeds" || bad "a dry run succeeds" "exited ${_ie_rc}: ${_ie_out}"
+ie_no_patch "a dry run writes nothing"
+case "$_ie_out" in *"DRY-RUN would run"*"patch deployment"*) ok "…narrates the patch it would write" ;;
+  *) bad "a dry run narrates the patch" "said: ${_ie_out}" ;; esac
+case "$_ie_out" in *"::hosting:: inline_env_retire=dry-run"*) ok "…and never claims a retirement" ;;
+  *) bad "a dry run never claims a retirement" "said: ${_ie_out}" ;; esac
+ie_no_value "…still printing no value"
+
+echo
+echo "── hosting-kv-rotate refuses under an inline shadow ──────────────"
+# MeshWeaver#3201 / Plugins#1593: an inline `env:` entry outranks every envFrom, so a rotation that
+# lands the new key in the vault and the synced Secret leaves the pods presenting the OLD one — and
+# the registry deletes the old key's index entry the moment it adopts the new hash
+# (MeshWeaverInstanceService.AdoptKeyHash → DeleteIndex). A 401 storm behind a green rotation. The
+# rotation therefore measures the Deployment first, and refuses BEFORE anything is minted. Both a
+# kubectl and an az stub lead PATH: the control case really does reach the vault write, and the az
+# stub refuses it without recording the argv that carries the minted key.
+KVR_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/kv-rotate" && pwd)"
+kvr() {  # kvr <inline-env scenario> — sets $_kvr_out $_kvr_rc $_kvr_az
+  _kvr_state="$(mktemp -d)"
+  _kvr_out="$(env PATH="$KVR_STUBS:$IE_STUBS:$PATH" HOSTING_IE_FIXTURE="$IE_FIXTURES/$1" HOSTING_IE_BASE="$IE_FIXTURES/base" \
+    HOSTING_IE_STATE="$_kvr_state" HOSTING_KV_SYNC_ATTEMPTS=1 \
+    hosting-kv-rotate --vault V --prefix memex- --namespace memex --synced-secret memex-portal-keyvault 2>&1)"; _kvr_rc=$?
+  _kvr_az="$(cat "$_kvr_state/az.log" 2>/dev/null || true)"
+  rm -rf "$_kvr_state"
+}
+kvr base
+[ "$_kvr_rc" -ne 0 ] && ok "a rotation with the key set INLINE on the Deployment is refused" \
+  || bad "an inline shadow refuses the rotation" "exited 0: ${_kvr_out}"
+case "$_kvr_out" in *"PluginCatalog__RegistryToken is set INLINE on memex-portal, python-gate, node-gate"*"RetireInlineEnv"*)
+    ok "…naming every container that carries it and the prior step (RetireInlineEnv)" ;;
+  *) bad "the shadow refusal names the containers and the prior step" "said: ${_kvr_out}" ;; esac
+case "$_kvr_out" in *"::hosting::"*) bad "…before anything is reported" "said: ${_kvr_out}" ;;
+  *) ok "…before anything is reported — no key_hash line, so the registry adopts nothing" ;; esac
+[ -z "$_kvr_az" ] && ok "…and before anything is minted or stored (no az call at all)" \
+  || bad "nothing is stored under a refusal" "az saw: ${_kvr_az}"
+kvr absent
+case "$_kvr_out" in *"set INLINE"*) bad "CONTROL: the same Deployment WITHOUT the inline entry passes the shadow check" "said: ${_kvr_out}" ;;
+  *) ok "CONTROL: the same Deployment WITHOUT the inline entry passes the shadow check" ;; esac
+case "$_kvr_az" in "az keyvault secret"*) ok "…and reaches the vault write (the az stub refuses it, so nothing is stored)" ;;
+  *) bad "the control reaches the vault write" "az saw: '${_kvr_az}', said: ${_kvr_out}" ;; esac
+case "$_kvr_out" in *mwi_*) bad "…without ever printing the minted key" "said: ${_kvr_out}" ;;
+  *) ok "…without ever printing the minted key" ;; esac
+
+echo
 echo "── hosting-audit: what lives only on the cluster ─────────────────"
 # The stubs are NOT mocks of helm/kubectl — they answer the audit's read-only calls from fixture
 # files so the DETECTION can be asserted without a cluster. What a fixture cannot prove (that a

--- a/deploy/aks/operator/test/stubs/inline-env/kubectl
+++ b/deploy/aks/operator/test/stubs/inline-env/kubectl
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# A stand-in `kubectl` for test/run-tests.sh — answers hosting-inline-env-retire's read/patch shapes
+# (and hosting-kv-rotate's inline-shadow read) from a fixture directory and records every
+# invocation in $HOSTING_IE_STATE/log. Not a mock of kubectl: what is asserted is the command's
+# DECISIONS — refuse mid-rollout, refuse a sole source or a DIFFER, patch once, read it back — not
+# what kubectl does. Every value in the fixtures is an obviously fake placeholder.
+#
+#   kubectl -n <ns> get deployment <name> -o json → deployment.json; after a patch,
+#                                                   deployment.after.json (the API's answer)
+#   kubectl -n <ns> get secret <name> -o json     → secret_<name>.json, else NotFound, exit 1
+#   kubectl -n <ns> get configmap <name> -o json  → configmap_<name>.json, else NotFound, exit 1
+#   kubectl -n <ns> patch deployment <name> --type json -p <patch>
+#                                                 → the patch lands in $HOSTING_IE_STATE/patch
+#
+# Each file is read from $HOSTING_IE_FIXTURE, falling back to $HOSTING_IE_BASE — so a scenario
+# carries only the file(s) that make it different.
+set -uo pipefail
+fixture="${HOSTING_IE_FIXTURE:?the inline-env kubectl stub needs HOSTING_IE_FIXTURE}"
+base="${HOSTING_IE_BASE:-$fixture}"
+state="${HOSTING_IE_STATE:?the inline-env kubectl stub needs HOSTING_IE_STATE}"
+printf 'kubectl %s\n' "$*" >> "$state/log"
+
+pick() {
+  if [ -f "$fixture/$1" ]; then cat "$fixture/$1"
+  elif [ -f "$base/$1" ]; then cat "$base/$1"
+  else return 1
+  fi
+}
+
+[ "${1:-}" = "-n" ] && shift 2
+verb="${1:-}" kind="${2:-}" name="${3:-}"
+case "$verb $kind" in
+  "get deployment")
+    if [ -f "$state/patched" ] && pick deployment.after.json; then exit 0; fi
+    pick deployment.json \
+      || { echo "Error from server (NotFound): deployments.apps \"${name}\" not found" >&2; exit 1; } ;;
+  "get secret")
+    pick "secret_${name}.json" \
+      || { echo "Error from server (NotFound): secrets \"${name}\" not found" >&2; exit 1; } ;;
+  "get configmap")
+    pick "configmap_${name}.json" \
+      || { echo "Error from server (NotFound): configmaps \"${name}\" not found" >&2; exit 1; } ;;
+  "patch deployment")
+    shift 3
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        -p) printf '%s\n' "${2:-}" > "$state/patch"; shift 2 ;;
+        *)  shift ;;
+      esac
+    done
+    touch "$state/patched"
+    echo "deployment.apps/${name} patched" ;;
+  *) echo "kubectl stub (inline-env): unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/deploy/aks/operator/test/stubs/kv-rotate/az
+++ b/deploy/aks/operator/test/stubs/kv-rotate/az
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# A stand-in `az` for hosting-kv-rotate's inline-shadow tests. It records the SUBCOMMAND only —
+# never the argv, which for `keyvault secret set` carries the freshly minted key — and refuses every
+# call. So a test can prove the rotation stopped before the vault write (nothing recorded) or got
+# past the shadow check to it (one `keyvault secret set` recorded), without a vault, a login, or a
+# key ever leaving the process.
+set -uo pipefail
+printf 'az %s %s %s\n' "${1:-}" "${2:-}" "${3:-}" >> "${HOSTING_IE_STATE:?the az stub needs HOSTING_IE_STATE}/az.log"
+echo "az stub: refusing '${1:-} ${2:-} ${3:-}' — there is no vault in a test" >&2
+exit 1

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -115,8 +115,9 @@ the status quo.
 vault copy are **EQUAL** — `Systemorph/Memex#180` promoted each instance's *in-use* token verbatim
 rather than picking a winner, so removing the inline entry is now a no-op in value terms. What
 remains is the plaintext inline entry itself, on both pod specs, still outranking every `envFrom`.
-Nothing in a repository can remove it — see
-[DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 has NO API action"*.
+Nothing in a repository can remove it; since 2026-09-11 a `Reconcile` can, from the record's
+`retiredBy` — see [DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 is a
+`Reconcile`"*.
 
 ### A credential shadow can be two PRINCIPALS, not two values
 
@@ -210,7 +211,8 @@ today**. Agreeing is not safe: it means the next change to the chart will silent
 effect. Disagreeing means somebody is already reading a setting no pod uses.
 
 > Fixing a `SHADOWS` or `COLLIDES` takes **both** steps, in order: put the intended value in the
-> chart, *then* delete the inline entry (`kubectl set env deploy/… KEY-`). Either step alone leaves
+> chart, *then* delete the inline entry (mark it `retiredBy` on the record and run `Reconcile`; the
+> break-glass form is `kubectl set env deploy/… KEY-`). Either step alone leaves
 > the pod on the inline value — so a plan that reads "add these to the chart and the drift clears"
 > leaves the cluster exactly where it was.
 
@@ -396,9 +398,8 @@ a Key Vault entry at all"* stopped being true on 2026-09-06 for `memex` and by 2
 `memex-cloud`: `Systemorph/Memex#180` declared a chart-owned `keyVaultSecrets` class on both, and
 re-measured 2026-09-08T01:03Z the inline value and the vault copy are **EQUAL** on each portal. The
 table stays as it was measured; read this line with it. The remaining act — delete the inline entry
-— has no repository half and no `Hosting/InstanceAction` kind; what remains possible is the
-break-glass `kubectl set env deploy/<name> <KEY>-`
-([DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 has NO API action"*).
+— has no repository half; since 2026-09-11 it is a `Reconcile` over the record's `retiredBy`
+([DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Step 2 is a `Reconcile`"*).
 
 Zero `COLLIDES` and zero `CHART-ONLY` — as on 2026-09-03, which is the only other run since #3168
 introduced those two classes, so "consecutive" is a two-run claim and nothing more. The `EMAIL__*`

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -197,8 +197,8 @@ Three further things this key showed, each of which generalises:
   not anyone read it. Retiring the shadow stops the *next* reader; rotating the key at its issuer is
   what closes the disclosure, and it is a separate, deliberate act with its own blast radius.
 
-🚨 **Step 2 rolls the Deployment, so it is subject to whatever else is rolling.** `set env` mutates
-the pod template, which creates a new ReplicaSet and supersedes an in-flight rollout. Read
+🚨 **Step 2 rolls the Deployment, so it is subject to whatever else is rolling.** Removing an entry —
+the remedy's patch or a break-glass `set env` alike — mutates the pod template, which creates a new ReplicaSet and supersedes an in-flight rollout. Read
 `kubectl rollout status` first and hold if a deploy is already in progress — a cleanup that ejects a
 release roll costs more than the shadow it clears. `hosting-inline-env-retire` makes exactly that
 check itself and refuses mid-rollout.
@@ -207,8 +207,9 @@ check itself and refuses mid-rollout.
 
 Under the 2026-09-08 operating directive every operation is a `Hosting/InstanceAction` the control
 instance's operator executes in-cluster, and a cluster command is break-glass
-([OperatingFromThePortal](/Doc/Architecture/OperatingFromThePortal)). **Step 2 is the one act on
-this page that has no such action.** Four sources say so, and they agree — measured 2026-09-10:
+([OperatingFromThePortal](/Doc/Architecture/OperatingFromThePortal)). **Until 2026-09-11, step 2 was
+the one act on this page that had no such action** — and no configuration change could stand in
+for one. Four sources said so, and they agreed — measured 2026-09-10:
 
 - **The chart cannot render it away, because the chart never rendered it.**
   `deploy/helm/templates/memex-portal/deployment.yaml` emits **four unconditional** inline `env:`

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentEnvLayers.md
@@ -128,8 +128,11 @@ leaves the pod exactly where it was:
 
 1. **give the key a declared home** — a `keyVaultSecrets` mapping, so the vault-synced Secret
    carries it. This changes nothing observable: the inline entry still outranks every `envFrom`.
-2. **remove the inline entry** — `kubectl -n <ns> set env deployment/<name> <KEY>-`. This is the
-   step that changes which value the pod reads, and it rolls the Deployment.
+2. **remove the inline entry** — mark the record's `inlineEnv` entry `retiredBy` and run
+   `Reconcile`; its `RetireInlineEnv` remedy removes the key from every container (see *"Step 2 is
+   a `Reconcile`"* below). This is the step that changes which value the pod reads, and it rolls
+   the Deployment. Until 2026-09-11 it was a break-glass
+   `kubectl -n <ns> set env deployment/<name> <KEY>-`.
 
 The trap is doing step 2 first, or doing step 2 without measuring what the pod falls through *to*.
 `PluginCatalog__RegistryToken` is the worked example (MeshWeaver#3201). Its inline entry stood over
@@ -170,6 +173,12 @@ A=$(inline <ns>); B=$(sec <ns> <synced-secret> <KEY>)
 `DIFFER` means step 1 is not done — promote the **in-use** value into the vault first, never the
 other one, and never mint a replacement as part of a cleanup.
 
+The remedy runs this same comparison itself, in-cluster, immediately before it writes, and refuses
+on `DIFFER` — so a recorded `agreesWithShadowed: true` that has gone stale cannot switch a portal
+onto another credential; it produces a refusal. What no `InstanceAction` offers yet is a
+read-only equality measurement, so *recording* `agreesWithShadowed` for a new credential entry
+still takes the break-glass read above.
+
 Three further things this key showed, each of which generalises:
 
 - **Precedence within `envFrom` decides which copy is the fall-through.** On `memex` the order is
@@ -191,9 +200,10 @@ Three further things this key showed, each of which generalises:
 🚨 **Step 2 rolls the Deployment, so it is subject to whatever else is rolling.** `set env` mutates
 the pod template, which creates a new ReplicaSet and supersedes an in-flight rollout. Read
 `kubectl rollout status` first and hold if a deploy is already in progress — a cleanup that ejects a
-release roll costs more than the shadow it clears.
+release roll costs more than the shadow it clears. `hosting-inline-env-retire` makes exactly that
+check itself and refuses mid-rollout.
 
-### 🚨 Step 2 has NO API action — the audit finds it, and no remedy can act on it
+### Step 2 is a `Reconcile` — and why it needed a remedy of its own
 
 Under the 2026-09-08 operating directive every operation is a `Hosting/InstanceAction` the control
 instance's operator executes in-cluster, and a cluster command is break-glass
@@ -224,19 +234,24 @@ this page that has no such action.** Four sources say so, and they agree — mea
   asserts the finding by its literal name,
   `env:memex-portal:PluginCatalog__RegistryToken`.
 
-**So the audit names the drift and nothing can repair it.** `kubectl -n <ns> set env
-deployment/<name> <KEY>-` remains the only instrument. Read that under rule 2 of
-OperatingFromThePortal: an audit finding with no remedy is **a gap to file against the Hosting
-package**, not a recipe to promote back into a procedure — filed as
-[MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593). The remedy the record's shape already
-anticipates is the one that does not exist — `InlineEnvOverride.RetiredBy` names what retires an
-entry, and no code reads it.
+**So until 2026-09-11 the audit named the drift and nothing could repair it**, and
+`kubectl -n <ns> set env deployment/<name> <KEY>-` was the only instrument. Under rule 2 of
+OperatingFromThePortal an audit finding with no remedy is **a gap to file against the Hosting
+package**, not a recipe to promote back into a procedure — filed as [MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593), and closed by the
+remedy the record's shape had anticipated all along: `Reconcile` now carries
+`RepairRemedy.RetireInlineEnv`, which reads `InlineEnvOverride.RetiredBy` and removes exactly the
+entries it names. The procedure — mark the entry retired, file a `Reconcile`, drop the entry once
+the audit is clean — is in [OperatingFromThePortal](/Doc/Architecture/OperatingFromThePortal) →
+*"Retiring an inline `env:` entry"*. It needs an operator image carrying
+`hosting-inline-env-retire` and the Hosting module version that plans it; until both are on the
+control instance, the break-glass line is still the only one that works.
 
 **Why this matters more than one duplicated variable.** MeshWeaver#3201 has outlived three merged
 PRs. Every deferral until 2026-09-08 was about *rollout timing* — a fleet freeze, then the newly
 armed readiness gate (#3404, #3395), then the bake-gate stall (#3663). All three closed by
 2026-09-08. What is left is not a schedule and not a risk: the last step's instrument is the one the
-operating model withdrew, and the entry's `retiredBy` therefore has no lane to travel.
+operating model withdrew, and the entry's `retiredBy` had no lane to travel — until the remedy above
+gave it one.
 
 ## What else the record gained
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OperatingFromThePortal.md
@@ -105,37 +105,56 @@ and how to reconcile it in the same session. Do not re-derive that list here —
    `Restart`; `scale --replicas=0` → `Suspend`; `helm upgrade` → `HelmRelease deploy` (today) /
    the record pin + `Roll`; "make the cluster match the record" → `Reconcile`; "what is drifting?"
    → `Audit`; `patch pvc … storage` → `volumes[].size` on the record + `Reconcile` (the operator's
-   `hosting-pv-resize`, which never shrinks and reads the capacity back). Use the action. The
-   kubectl line is what the operator runs for you.
+   `hosting-pv-resize`, which never shrinks and reads the capacity back); `set env deploy/<name> <KEY>-` → `retiredBy` on the record's
+   `inlineEnv` entry + `Reconcile` (the operator's `hosting-inline-env-retire`). Use the action.
+   The kubectl line is what the operator runs for you.
 2. **Is it a read the API does not answer yet?** (the three above) Take it read-only, name it as
    break-glass in what you write down, and file the gap against the Hosting package rather than
    leaving the recipe as the procedure.
 3. **Is it a measurement in a war story?** Leave it — it is the reason the rule on the page exists.
    Do not run it to "check"; ask the API question the page's rule now points at.
 
-### The one WRITE with no action kind: retiring an inline `env:` entry
+### Retiring an inline `env:` entry — `Reconcile`, driven by the record's `retiredBy`
 
-Rule 1 has exactly one known miss, and it is a write rather than a read. **No repository change and
-no `InstanceAction` can remove an inline `env:` entry from a Deployment** — a break-glass
-`kubectl set env deploy/<name> <KEY>-` still can, and is the whole point: it is the one routine act
-with no lane back into the API. The chart never rendered one (it emits four unconditional
-portal entries — the `DOTNET_Dbg*` crash-dump set — plus `AZURE_CLIENT_ID` when
+Until 2026-09-11 this was the one routine WRITE with no action kind. No repository change and no
+`InstanceAction` could remove an inline `env:` entry from a Deployment; only a break-glass
+`kubectl set env deploy/<name> <KEY>-` could. The chart never rendered one (it emits four
+unconditional portal entries — the `DOTNET_Dbg*` crash-dump set — plus `AZURE_CLIENT_ID` when
 `selfUpdate.azureClientId` is set, and two per gate sidecar; every name is fixed and no values key
-extends the list), the record's `inlineEnv` is
-declarative by contract — *dropping an entry does not delete one* — and `Reconcile`'s only
-configuration remedy, `ReapplyRecord`, is a `helm upgrade`, whose three-way merge removes only what
-helm previously owned. `Audit` detects the drift precisely, under `envLiveOnly` and
-`plainSecretEntries`, so the finding is reported and no remedy can act on it.
+extends the list), the record's `inlineEnv` is declarative by contract — *dropping an entry does not
+delete one* — and `ReapplyRecord` is a `helm upgrade`, whose three-way merge removes only what helm
+previously owned. `Audit` detected the drift precisely, under `envLiveOnly` and
+`plainSecretEntries`, and no remedy could act on it.
 
-The record already carries the intent: `InlineEnvOverride.RetiredBy` names what retires an entry,
-and no code reads it. **The gap is a `RetireInlineEnv` remedy** (filed as
-[MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593)) that removes the keys a record marks
-retired, ordered after `ReapplyRecord` so the key has a declared home before the shadow goes — the
-two-step in
-[DeploymentEnvLayers](/Doc/Architecture/DeploymentEnvLayers) → *"Retiring a shadow takes two steps"*,
-with the equality precondition that page states. Until it exists, `kubectl set env deploy/<name>
-<KEY>-` is break-glass and the live worked example (MeshWeaver#3201, a plugin-registry credential in
-plaintext on two portals' pod specs) stays open on the instrument, not on the analysis.
+**The lane is now `Reconcile`** ([MeshWeaver.Plugins#1593](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1593)). Its `RetireInlineEnv` remedy reads the one statement the
+record could always make and nothing read — `inlineEnv[].retiredBy` — and removes exactly the
+entries that carry it:
+
+1. **Mark the entry retired on the record**: `retiredBy` names the issue that ends it, `shadows`
+   names the `envFrom` source it falls through to, and a credential also needs
+   `agreesWithShadowed: true`. The plan REFUSES, naming the entry, a sole source (`shadows` blank —
+   removal would blank the key), a credential whose equality is not recorded `true`, and any entry
+   the record says disagrees with its shadow. One refused entry refuses the whole `Reconcile`.
+2. **File a `Reconcile`.** The retirement runs after `ReapplyRecord` — so the key's declared home is
+   on the pod first — and before any roll. The operator's `hosting-inline-env-retire` refuses while
+   a rollout is in progress; walks the portal container's `envFrom` in order and requires the LAST
+   source carrying the key to be the one the record names; re-measures in-cluster that the inline
+   value and that source are **EQUAL** (lengths and a verdict, never a value); and only then removes
+   the key from **every** container that carries it, the gate sidecars included, in one patch
+   guarded on the Deployment's `resourceVersion`. The run waits for the rollout and ends in the
+   re-audit and **Verify one generation**, like every `Reconcile`.
+3. **Drop the entry from the record** once the closing audit no longer lists it. Until then the
+   record still describes a shadow, and `RotateRegistryKey` refuses while the record lists an inline
+   entry for any key the registry key lands as; `hosting-kv-rotate` refuses the same thing
+   in-cluster, before it mints.
+
+🚨 **It works only once the control instance has BOTH halves**: an operator image that carries
+`hosting-inline-env-retire` (the operator image is control-instance configuration, moved by a
+`helm-release deploy`, not by any record) and the Hosting module version that plans the remedy
+(1.17). On an older operator image the step fails by name (`command not found`) after the re-apply
+and nothing is removed. And it retires a shadow; it does **not** remediate a disclosure — a
+credential that sat in plaintext in a Deployment spec still needs rotating at its issuer, which is a
+separate act (MeshWeaver#3201 is the worked example).
 
 ## Related rules decided the same day
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-registry-key-rotation-refuses-under-an-inline-shadow.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-registry-key-rotation-refuses-under-an-inline-shadow.md
@@ -1,0 +1,32 @@
+---
+Name: A registry-key rotation refuses under an inline shadow
+Category: Fix
+Description: RotateRegistryKey no longer rotates a plugin-registry key that an inline env entry on the Deployment would keep shadowing. Before, the new key reached Key Vault while the portal kept presenting the old one — which the registry had just stopped accepting — so every catalog read failed behind a rotation that reported success.
+Icon: ShieldCheckmark
+Order: -20260911
+---
+
+# A registry-key rotation refuses under an inline shadow
+
+`RotateRegistryKey` mints a new plugin-registry key into Key Vault, has the registry adopt it, and
+restarts the portal onto it. The registry retires the **old** key the moment it adopts the new one.
+
+If the portal's Deployment also carried the key as an **inline** environment variable — as both
+production portals did — that inline value outranks the vault copy. The rotation then landed the
+new key where nothing read it, the restarted pods kept presenting the old key, and the registry
+refused it. Every catalog read, update check and registration failed, while every check the
+rotation itself runs stayed green: it confirms the new key reached the synced Secret, and its final
+probe accepts an unauthorised answer as "the instance is up".
+
+## What changed
+
+The rotation now refuses before anything is minted, and says why:
+
+- **From the record** — while the Deployment record lists an inline entry for any key the registry
+  key is delivered as, whether or not that entry is already marked retired.
+- **From the cluster** — the operator reads the Deployment first and refuses when any container
+  still sets the key inline.
+
+To rotate such an instance, retire the inline entry first — mark it `retiredBy` on the record and run
+`Reconcile` — then drop the entry from the record once the audit no longer reports it, and rotate.
+The order is in [Operating from the portal](/Doc/Architecture/OperatingFromThePortal).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-reconcile-retires-an-inline-env-entry-the-record-retires.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-reconcile-retires-an-inline-env-entry-the-record-retires.md
@@ -1,0 +1,47 @@
+---
+Name: Reconcile retires an inline env entry the record retires
+Category: Feature
+Description: An inline env entry on a portal's Deployment — never rendered by the chart and never removed by a helm upgrade — can now be removed through the API. Mark it retiredBy on the Deployment record and run Reconcile; the operator re-measures that the pod falls back to the same value before it removes the entry from every container.
+Icon: Cloud
+Order: -20260911
+---
+
+# Reconcile retires an inline env entry the record retires
+
+An environment variable set **inline** on a portal's Deployment outranks every other source of
+configuration, and nothing in a repository creates or removes one: the chart never renders it, and
+a `helm upgrade` leaves it where it is. Until now, the only way to take one off was a `kubectl`
+command run with cluster credentials — exactly what operating through the portal is meant to end.
+The audit could see these entries; nothing could act on them.
+
+## What changed
+
+`Reconcile` now carries a **retire inline env** step. It reads one field of the Deployment record
+that had no effect until now — `inlineEnv[].retiredBy` — and removes exactly the entries that
+carry it:
+
+1. Mark the entry on the record: `retiredBy` (the issue that ends it), `shadows` (the source the
+   pod should fall back to) and, for a credential, `agreesWithShadowed: true`.
+2. File a `Reconcile`. After the record is re-applied, the operator checks that no rollout is in
+   progress, confirms that the pod really falls back to the source the record names, and compares
+   the two values inside the cluster — reporting only lengths and a verdict, never a value. Only if
+   they are **equal** does it remove the entry, from every container that carries it, in one
+   guarded change. The run then waits for the rollout and ends in the usual audit.
+3. Once the audit no longer lists the entry, drop it from the record.
+
+An entry that cannot safely go is refused by name, and the whole `Reconcile` with it: one that is
+the only source of its key (removing it would leave the key empty), a credential whose equality with
+its fallback was never recorded, or any value the record says differs from what the pod would fall
+back to.
+
+## When you can use it
+
+It needs two things on the control instance: an operator image that includes the new
+`hosting-inline-env-retire` command, and the Hosting module version that plans it (1.17). Until both
+are there, a `Reconcile` over a record that retires an entry stops at that step without removing
+anything. The procedure is in
+[Operating from the portal](/Doc/Architecture/OperatingFromThePortal) and
+[Deployment env layers](/Doc/Architecture/DeploymentEnvLayers).
+
+Removing an inline credential stops the next reader; it does not undo a disclosure. A credential
+that has sat in plaintext on a Deployment still needs rotating afterwards.


### PR DESCRIPTION
The cluster half of **Systemorph/MeshWeaver.Plugins#1593** (`RetireInlineEnv`), the operation #3201 has been waiting on: a plugin-registry credential sits in plaintext as an inline `env:` entry on the Deployment specs of both production portals, and no `Hosting/InstanceAction` could remove it. The policy half (which keys, which order, which refusals) is the Plugins PR that follows this one; this PR ships the operator command it plans, plus an in-cluster guard on `hosting-kv-rotate`.

## `hosting-inline-env-retire`

`hosting-inline-env-retire --namespace <ns> --retire KEY=<shadowed source> [--retire …]`

| check | when it refuses |
|---|---|
| rollout preflight | the Deployment is not settled: `observedGeneration` behind, a replica not updated or available, or paused. Checked **before** any Secret is read |
| fall-through | the portal container's `envFrom` is walked in order and the LAST source carrying the key wins. No source → **SOLE** source (removal would blank the key). A different source than the record names → refused, naming the real one |
| equality, re-measured | inline value vs fall-through: **DIFFER** is refused. Only lengths + the verdict are printed. A value never reaches stdout, stderr, a `::hosting::` line, the patch or an argv |
| `valueFrom` | a reference is not a shadow; refused |

It then removes the key from **every** container that carries it (the `python-gate`/`node-gate` sidecars carry the credential too and have no `envFrom`), in **one** JSON patch guarded by `test` ops on `resourceVersion` and on each entry's name, and reads the Deployment back. If nothing is left to remove, it is an idempotent no-op that rolls nothing. One refused key refuses the whole run.

## `hosting-kv-rotate` refuses under an inline shadow

It now reads the Deployment **before** it mints, and refuses when any container sets the key inline. From source: `MeshWeaverInstanceService.AdoptKeyHash` ends in `DeleteIndex(previousHash)` (`memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs:458`, body at `:507`). The old key stops authenticating the moment the hash is adopted. Under an inline shadow the pods keep presenting that old key, which is a 401 storm behind a green rotation: the synced-Secret wait reads the Secret, and `hosting-verify` accepts 401. The dry-run path stays cluster-free.

## RBAC

New calls are `get`/`patch deployments` and `get secrets`/`configmaps`. All are already granted. `check-rbac-coverage.sh` sees them: the positive control (the new scripts only) finds 7 calls and 4 grants. The negative control, a ClusterRole without `patch` on deployments, reports `MISSING hosting-inline-env-retire: kubectl patch deployment`. `hosting-operator.yml`:
- claims the new command;
- moves `hosting-kv-rotate` from "not yet wired" to the plan list (`RotateRegistryKeySteps` emits it; that entry was stale);
- tracks the two new stubs.

## Verification (local, this branch)

- `deploy/aks/operator/test/run-tests.sh`: **221 passed, 0 failed** (58 new cases). Stubbed `kubectl` and `az` lead `PATH` for every new invocation, including the argument refusals, so a failed guard can never reach a real context.
- Each guard fails against its unfixed variant:
  - rollout guard removed: 4 FAIL;
  - equality check removed: 5 FAIL;
  - sole-source check removed: 1 FAIL;
  - `origin/main`'s `hosting-kv-rotate`: 3 FAIL (the control arm stays green).
- `shellcheck -S warning` over `bin/`: clean.
- `check-rbac-coverage.sh`: 36 calls, 0 missing.
- `src/MeshWeaver.Documentation` and `test/MeshWeaver.Documentation.Test`, `-c Release -warnaserror`: `0 Warning(s)`, `0 Error(s)`. Tests: 397/397 passed (per the `.trx`).

## Docs

- `OperatingFromThePortal`: "The one WRITE with no action kind" becomes "Retiring an inline `env:` entry: `Reconcile`, driven by the record's `retiredBy`".
- `DeploymentEnvLayers`: the two-step and the "Step 2" section.
- `ChartDriftSemantics`: its three references follow.
- Two What's New entries: Feature (the remedy) and Fix (the rotation guard).

## 🚨 Usable only after two things reach the control instance

1. The **operator image** carrying `hosting-inline-env-retire`. That image is control-instance configuration applied by a `helm-release deploy`, not by a record.
2. The **Hosting module 1.17** (the Plugins PR). Until both are there, a Reconcile over a record that retires an entry stops at that step, and nothing is removed.

Pairs-with: none — this PR only adds (a new operator command, a new optional flag, docs); no public type or member leaves `src/`.

Nothing was run against any cluster; no `InstanceAction` was created. No token value was read, printed or stored. Fixtures carry obviously fake placeholders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
