### PR TITLE
ci: per-module deploy — never cancel trunk runs, push builds its dependency network, newest wins per module

### DIFF
--- a/.github/scripts/bake-scope.sh
+++ b/.github/scripts/bake-scope.sh
@@ -221,6 +221,19 @@ AZ
   rm -rf "$ST_TMP/state"
   write_selector 0 '{"runAll": false, "mount": [], "affected": [], "skipped": ["Store","Edu"], "support": []}'
   expect "a diff that reaches no module at all (docs/, e2e/, .claude/)" none "$(run_case push acct/share)"
+  # Per-module deploy: a later run sealed first. Sealing the OLDER tree would move every instance's
+  # sources backwards, so the older run bakes nothing — and a diverged seal is NOT that case: it
+  # still falls through to the rewritten-history full bake above.
+  rm -rf "$ST_TMP/state"; write_selector 0 "$OK_JSON"
+  seal newer/share "$HEAD_SHA" Store.zip Edu.zip
+  expect "a NEWER commit is already sealed (runs finished out of order) — never seal backwards" \
+    none "$(run_case push newer/share "$BASE_SHA")"
+  # The control, one variable apart: the same guard with a sealed commit this run's tree is NOT in
+  # (a diverged line — OTHER forks from BASE, so HEAD is not its ancestor) must not skip; it falls
+  # through to the rewritten-history full bake.
+  rm -rf "$ST_TMP/state"; seal newer/share "$OTHER_SHA" Store.zip Edu.zip
+  expect "…while a sealed commit that does NOT contain this run's tree is still a full bake" \
+    full "$(run_case push newer/share)"
 
   # ── THE POINTER. The flat copy and the generation deliberately record DIFFERENT baselines, so
   # ── the verdict says which one was read: a diverged baseline forces `full`, an ancestor one
@@ -459,6 +472,27 @@ if [ "$prev_sha" = "$HEAD_SHA" ]; then
   echo "::notice title=Nothing to bake::$REASON"
   if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
     printf '### ✅ Already published\n\n%s\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  BASELINE="$prev_sha"
+  emit
+  exit 0
+fi
+
+# ── 4b. never seal BACKWARDS ─────────────────────────────────────────────────────────────────
+# 🚨 Per-module deploy (maintainer, 2026-09-11: "builds are not superseded … however they must be
+# atomic"): a repo on per-module deploy never cancels a push run on `main`, so two of them can reach
+# the bake in either order. When a NEWER commit is already sealed, this run's tree is contained in
+# it, and sealing this one would move every instance's sources BACKWARDS — SealedSyncGate holds a
+# repository's sources at the sealed commit — until the next seal. That is a positive finding with
+# both shas, not an input-shaped skip. (publish-bake-bundles.sh repeats the check at write time: a
+# newer run can seal while this one is still baking.)
+if git -C "$REPO_DIR" cat-file -e "${prev_sha}^{commit}" 2>/dev/null \
+   && git -C "$REPO_DIR" merge-base --is-ancestor "$HEAD_SHA" "$prev_sha" 2>/dev/null; then
+  SCOPE="none"
+  REASON="the sealed publication records $prev_sha, which is NEWER than this run's $HEAD_SHA and already contains it — a later run sealed first. Sealing this tree would move every instance's sources backwards; nothing to rebuild and nothing to publish."
+  echo "::notice title=Nothing to bake::$REASON"
+  if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+    printf '### ✅ A newer publication is already sealed\n\n%s\n' "$REASON" >> "$GITHUB_STEP_SUMMARY"
   fi
   BASELINE="$prev_sha"
   emit

--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -218,9 +218,18 @@ def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
         # to the caller's publication lane, which hands over only on a green validation set. Saying
         # "nothing published" there would be true and misleading; saying "published" would be false.
         staged = sorted(m for m, r in receipts.items() if r.get("publication") == "staged")
+        # `superseded` is a FOURTH (publish-newest-only, per-module deploy): the leg built and
+        # tested, then stood down because a NEWER trunk commit reaches the module and that commit's
+        # own run publishes it. Named, so "not published here" never reads as "not published".
+        superseded = sorted(m for m, r in receipts.items() if r.get("publication") == "superseded")
+        stood_down = (f"; {len(superseded)} stood down for a newer trunk commit that reaches them "
+                      f"(its own run publishes them): " + ", ".join(superseded)) if superseded else ""
         if published:
             notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; "
-                         f"{len(published)} published to the registry")
+                         f"{len(published)} published to the registry{stood_down}")
+        elif superseded and not staged:
+            notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; none published "
+                         f"from this run{stood_down}")
         elif staged:
             notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built; "
                          f"{len(staged)} STAGED for the publication lane — nothing has reached the "
@@ -840,6 +849,19 @@ def self_test() -> int:
         errs, _ = identity_agreement(own_receipts(parsed, "floor-abc123", set(three)))
         check("…and one file mutated to a second identity turns it RED",
               any("DIFFERENT framework identities" in e for e in errs), f"{errs}")
+
+    print("publish-newest-only — a leg that stood down is NAMED, never read as unpublished:")
+    code, errs, nts = verify(["A", "B"], {"A": {"module": "A", "published": True, "publication": "direct"},
+                                         "B": {"module": "B", "published": False, "publication": "superseded"}},
+                             [], "success", True)
+    check("one published + one stood down is green, and the note names the stood-down module",
+          code == 0 and any("1 published" in n and "stood down" in n and "B" in n for n in nts),
+          f"{errs} {nts}")
+    code, errs, nts = verify(["B"], {"B": {"module": "B", "published": False, "publication": "superseded"}},
+                             [], "success", True)
+    check("…and a run whose only leg stood down says so — not 'not a trunk/release run'",
+          code == 0 and any("none published from this run" in n for n in nts)
+          and not any("not a trunk/release run" in n for n in nts), f"{errs} {nts}")
 
     if failures:
         print(f"\n::error title=node-repo-pack-verify self-test failed::{len(failures)} case(s) — "

--- a/.github/scripts/node-repo-publication-base.py
+++ b/.github/scripts/node-repo-publication-base.py
@@ -2,49 +2,135 @@
 """Find a conservative publication baseline from a successful trunk publishing workflow.
 
 The caller opts in by naming a workflow whose successful main PUSH publishes all selected
-outputs. A failed, cancelled, manual or release-follow run cannot advance this baseline.
-An unavailable API or missing ancestor costs a full build, never an omitted publication.
+outputs. Only such a run ADVANCES the baseline. A failed, cancelled or in-flight run after it does
+NOT reset it (per-module deploy, maintainer 2026-09-11: "no huge runs ever"): the caller narrows by
+the history UNION from the baseline (`git log baseline..HEAD`, node-repo-scope.py), which carries
+every change those runs held, so the next run rebuilds whatever they left unpublished. Resetting to
+FULL instead made one cancelled run cost the next run the whole catalog — and under a steady merge
+rate every full run was cancelled in turn, so Plugins main published NO module for nine hours.
+
+What DOES reset it — a full build, never an omitted publication:
+  * a run after the baseline that attested a DIFFERENT toolchain (platform, images, build logic):
+    it may have published some modules with it, which git history cannot show;
+  * a successful run that is not an ancestor of HEAD (history rewritten — a union from any older
+    baseline would miss what that run published from the rewritten commits);
+  * no successful run in the page read, too many unsettled runs to attest, an unavailable API, or
+    an unreadable attestation.
 """
 import argparse
+import io
 import json
 import os
 import re
 import subprocess
 import sys
-import tempfile
-from pathlib import Path
+import zipfile
 from urllib.parse import quote
+
+# Beyond this many unsettled runs since the last success, attesting each one costs more than the
+# full build it would save — and that many reds in a row is itself worth a full rebuild.
+MAX_UNSETTLED = 30
 
 
 def baseline(runs, branch, ancestor, current_run=""):
+    """The newest successful main push that is an ancestor of HEAD, plus the ids of the publishing
+    runs NEWER than it (failed, cancelled, in flight) whose toolchain the caller must still check.
+    `runs` is the API's newest-first listing. Pure: `ancestor(sha)` is the only question asked."""
     publishing = {"push", "repository_dispatch", "schedule"}
+    between = []
     for run in runs:
         if str(run.get("id")) == str(current_run) or run.get("head_branch") != branch or run.get("event") not in publishing:
             continue
         sha = run.get("head_sha", "")
-        if (run.get("event") == "push" and run.get("head_branch") == branch
-                and run.get("status") == "completed" and run.get("conclusion") == "success"
-                and re.fullmatch(r"[0-9a-f]{40}", sha) and ancestor(sha)):
-            return {"sha": sha, "run": run["id"], "url": run["html_url"]}
-        # A later partial publish may have used a different variable-resolved toolchain,
-        # invisible in git history. Without a successful receipt for it, rebuild everything.
-        break
-    return {"sha": "", "run": "", "url": ""}
+        if (run.get("event") == "push" and run.get("status") == "completed"
+                and run.get("conclusion") == "success" and re.fullmatch(r"[0-9a-f]{40}", sha)):
+            if ancestor(sha):
+                return {"sha": sha, "run": run["id"], "url": run["html_url"], "between": between}
+            break
+        between.append(run["id"])
+    return {"sha": "", "run": "", "url": "", "between": between}
+
+
+def toolchain_verdict(current, prior, between):
+    """None when the baseline may narrow; otherwise the reason for a full build. `prior` is what
+    the baseline run attested; `between` pairs each later run with its attestation, or None when
+    it never reached the scope job (no artifact — it built and published nothing)."""
+    if prior != current:
+        return "publication toolchain changed since the baseline run — full build"
+    for run_id, inputs in between:
+        if inputs is not None and inputs != current:
+            return (f"run {run_id}, after the baseline, attested a different toolchain and may have "
+                    "published with it — full build")
+    return None
 
 
 def self_test():
     good = dict(event="push", head_branch="main", status="completed", conclusion="success",
                 head_sha="a" * 40, id=1, html_url="https://example.test/runs/1")
-    for change in [dict(event="workflow_dispatch"), dict(event="repository_dispatch"),
-                   dict(event="schedule"), dict(conclusion="failure"), dict(conclusion="cancelled"),
-                   dict(status="in_progress"), dict(head_branch="other"), dict(head_sha="short")]:
-        expected = 1 if change.get("event") == "workflow_dispatch" or change.get("head_branch") == "other" else ""
-        assert baseline([{**good, **change}, good], "main", lambda _: True)["run"] == expected
-        assert baseline([{**good, **change}], "main", lambda _: True)["sha"] == ""
-    assert baseline([good], "main", lambda _: False)["sha"] == ""
-    assert baseline([], "main", lambda _: True)["sha"] == ""
-    assert baseline([good], "main", lambda _: True)["sha"] == "a" * 40
-    print("publication baseline: 19 assertions passed")
+
+    def newer(**change):
+        return {**good, "id": 2, "head_sha": "b" * 40, "html_url": "https://example.test/runs/2", **change}
+
+    yes = lambda _: True  # noqa: E731
+    passed = 0
+
+    def check(condition, what):
+        nonlocal passed
+        assert condition, what
+        passed += 1
+
+    # WALKED PAST: the baseline stays the older success and the newer run comes back to be
+    # toolchain-checked — a run that did not succeed carries changes the union already contains.
+    for change in [dict(conclusion="failure"), dict(conclusion="cancelled"),
+                   dict(status="in_progress", conclusion=None), dict(event="repository_dispatch"),
+                   dict(event="schedule"), dict(head_sha="short")]:
+        got = baseline([newer(**change), good], "main", yes)
+        check(got["run"] == 1 and got["between"] == [2], f"walk past {change}: {got}")
+    # IGNORED: not a publishing run of this branch — neither the baseline nor between.
+    for change in [dict(event="workflow_dispatch"), dict(event="pull_request"), dict(head_branch="other")]:
+        got = baseline([newer(**change), good], "main", yes)
+        check(got["run"] == 1 and got["between"] == [], f"ignore {change}: {got}")
+    got = baseline([newer(), good], "main", yes, current_run="2")
+    check(got["run"] == 1 and got["between"] == [], "the current run is never its own baseline")
+    check(baseline([newer(), good], "main", yes)["run"] == 2, "the newest success wins")
+    got = baseline([newer(), good], "main", lambda sha: sha != "b" * 40)
+    check(got["sha"] == "" and got["run"] == "", "a success off HEAD's line stops the walk (full)")
+    got = baseline([newer(conclusion="failure")], "main", yes)
+    check(got["sha"] == "" and got["between"] == [2], "no success at all is a full build")
+    check(baseline([], "main", yes)["sha"] == "", "an empty listing is a full build")
+
+    same = {"platform": "p1", "portal": "d1", "tester": "t1", "logic": "l1"}
+    moved = {**same, "platform": "p2"}
+    check(toolchain_verdict(same, same, []) is None, "same toolchain narrows")
+    check(toolchain_verdict(same, moved, []) is not None, "a baseline on another toolchain is full")
+    check(toolchain_verdict(same, None, []) is not None, "a baseline with no attestation is full")
+    check(toolchain_verdict(same, same, [(2, None)]) is None,
+          "a later run that never reached the scope job published nothing — narrows")
+    check(toolchain_verdict(same, same, [(2, same), (3, same)]) is None, "later runs on the same toolchain narrow")
+    check("run 3" in (toolchain_verdict(same, same, [(2, same), (3, moved)]) or ""),
+          "a later run on another toolchain is full, and names the run")
+    print(f"publication baseline: {passed} assertions passed")
+
+
+def gh_json(path):
+    out = subprocess.run(["gh", "api", path], capture_output=True, text=True, timeout=60, check=True)
+    return json.loads(out.stdout)
+
+
+def attested_inputs(repo, run_id):
+    """What a run attested in its `publication-inputs` artifact, or None when it has none (it never
+    reached the scope job). Read through the artifact API rather than `gh run download`, which
+    refuses a run that is still in flight — and in-flight runs are exactly the ones walked past."""
+    listing = gh_json(f"repos/{repo}/actions/runs/{run_id}/artifacts?name=publication-inputs")
+    live = [x for x in listing.get("artifacts", []) if not x.get("expired")]
+    if not live:
+        if listing.get("total_count"):
+            raise ValueError(f"run {run_id}'s publication-inputs artifact has expired")
+        return None
+    blob = subprocess.run(["gh", "api", f"repos/{repo}/actions/artifacts/{live[0]['id']}/zip"],
+                          capture_output=True, timeout=60, check=True).stdout
+    with zipfile.ZipFile(io.BytesIO(blob)) as archive:
+        return json.loads(archive.read("publication-inputs.json"))
 
 
 def main():
@@ -61,34 +147,39 @@ def main():
         return 0
     if not a.workflow or not a.inputs or not re.fullmatch(r"[\w.-]+/[\w.-]+", a.repo):
         p.error("--workflow, --inputs and --repo owner/name are required")
-    current = json.loads(Path(a.inputs).read_text())
+    with open(a.inputs, encoding="utf-8") as fh:
+        current = json.load(fh)
     if not current or not isinstance(current, dict) or not all(current.values()):
         p.error("resolved publication inputs must be a nonempty object with no empty values")
     endpoint = (f"repos/{a.repo}/actions/workflows/{quote(a.workflow, safe='')}/runs"
                 f"?branch={quote(a.branch, safe='')}&per_page=100")
+    empty = dict(sha="", run="", url="", between=[])
     try:
-        response = subprocess.run(["gh", "api", endpoint], capture_output=True, text=True,
-                                  timeout=60, check=True)
-        runs = json.loads(response.stdout)["workflow_runs"]
+        runs = gh_json(endpoint)["workflow_runs"]
         if not isinstance(runs, list):
             raise ValueError("workflow_runs is not a list")
         result = baseline(runs, a.branch, lambda sha: subprocess.run(
             ["git", "merge-base", "--is-ancestor", sha, "HEAD"], cwd=a.root,
             capture_output=True, timeout=30).returncode == 0, os.environ.get("GITHUB_RUN_ID", ""))
-        if result["run"]:
+        if result["run"] and len(result["between"]) > MAX_UNSETTLED:
+            print(f"{len(result['between'])} unsettled runs since the last success (more than "
+                  f"{MAX_UNSETTLED}) — full build", file=sys.stderr)
+            result = empty
+        elif result["run"]:
             # Git source alone cannot see a repository variable overriding the platform ref.
-            # Successful runs attest their actual resolved inputs in this run-scoped artifact.
-            with tempfile.TemporaryDirectory() as tmp:
-                subprocess.run(["gh", "run", "download", str(result["run"]), "--repo", a.repo,
-                                "--name", "publication-inputs", "--dir", tmp],
-                               capture_output=True, text=True, timeout=60, check=True)
-                previous = json.loads((Path(tmp) / "publication-inputs.json").read_text())
-                if previous != current:
-                    print("publication toolchain changed — full build", file=sys.stderr)
-                    result = dict(sha="", run="", url="")
-    except (OSError, ValueError, KeyError, subprocess.SubprocessError) as exc:
+            # Every run attests its actual resolved inputs in this run-scoped artifact.
+            reason = toolchain_verdict(current, attested_inputs(a.repo, result["run"]),
+                                       [(rid, attested_inputs(a.repo, rid)) for rid in result["between"]])
+            if reason:
+                print(reason, file=sys.stderr)
+                result = empty
+            elif result["between"]:
+                print(f"walked past {len(result['between'])} unsettled run(s) "
+                      f"({', '.join(map(str, result['between']))}) — the history union from the "
+                      "baseline carries their changes, so the next build covers them", file=sys.stderr)
+    except (OSError, ValueError, KeyError, zipfile.BadZipFile, subprocess.SubprocessError) as exc:
         print(f"::warning::publication baseline unavailable ({type(exc).__name__}); full build", file=sys.stderr)
-        result = dict(sha="", run="", url="")
+        result = empty
     print(json.dumps(result))
     print(f"publication baseline: {result['url'] or 'none — full build'}", file=sys.stderr)
     if os.environ.get("GITHUB_OUTPUT"):

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -1280,7 +1280,11 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
     if [ -n "$published_sha" ] && [ "$published_sha" != "unknown" ]; then
       order=""
       if [ -n "${GH_TOKEN:-}" ] && [ -n "${BAKE_CONTENT_REPOSITORY:-}" ]; then
-        order=$(gh api "repos/$BAKE_CONTENT_REPOSITORY/compare/$SOURCE_SHA...$published_sha" --jq .status 2>/dev/null || echo "")
+        # The refusal's own words go to the log: an unorderable pair must say WHY it was unorderable.
+        if ! order=$(gh api "repos/$BAKE_CONTENT_REPOSITORY/compare/$SOURCE_SHA...$published_sha" --jq .status 2>"$SENTINEL_LOCAL_DIR/compare.err"); then
+          echo "::warning::the compare API refused to order $SOURCE_SHA against $published_sha: $(tail -c 400 "$SENTINEL_LOCAL_DIR/compare.err" | tr '\n' ' ')"
+          order=""
+        fi
       fi
       if [ "$order" = "ahead" ]; then
         echo "::notice::$ACCOUNT/$SHARE: the sealed publication under $LIVE is from $published_sha, which is NEWER than this bake's $SOURCE_SHA and contains it — a later run sealed first. Not sealing backwards; skipping."

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -1269,6 +1269,25 @@ publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `ex
       echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $LIVE ($SENTINEL present) — surface unchanged, bake already published; skipping."
       return 0
     fi
+    # 🚨 NEVER SEAL BACKWARDS (per-module deploy, maintainer 2026-09-11). A repo on per-module deploy
+    # never cancels a push run on its trunk, so two runs can reach this point in either order. When
+    # the sealed commit is NEWER than this bake's and contains it, republishing would move every
+    # instance's sources BACKWARDS (SealedSyncGate holds a repository's sources at the sealed commit)
+    # until the next seal. bake-scope.sh asks this when the bake is narrowed; this is the write-time
+    # repeat, because a newer run can seal while this one is still baking. `ahead` = the sealed
+    # commit is ahead of this one. A comparison that cannot be made keeps today's behaviour
+    # (republish) and SAYS so — it never skips on a guess.
+    if [ -n "$published_sha" ] && [ "$published_sha" != "unknown" ]; then
+      order=""
+      if [ -n "${GH_TOKEN:-}" ] && [ -n "${BAKE_CONTENT_REPOSITORY:-}" ]; then
+        order=$(gh api "repos/$BAKE_CONTENT_REPOSITORY/compare/$SOURCE_SHA...$published_sha" --jq .status 2>/dev/null || echo "")
+      fi
+      if [ "$order" = "ahead" ]; then
+        echo "::notice::$ACCOUNT/$SHARE: the sealed publication under $LIVE is from $published_sha, which is NEWER than this bake's $SOURCE_SHA and contains it — a later run sealed first. Not sealing backwards; skipping."
+        return 0
+      fi
+      [ -n "$order" ] || echo "::warning::could not order the sealed $published_sha against this bake's $SOURCE_SHA (no GH_TOKEN / BAKE_CONTENT_REPOSITORY, or the compare API refused) — republishing as before."
+    fi
     resealing=true
     echo "sealed publication under $LIVE is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
   fi

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -297,6 +297,20 @@ on:
           FrameworkDeclined (#2088). See the caller contract at the top of this file.
         type: boolean
         default: false
+      publish-newest-only:
+        description: >-
+          Per-module deploy (MeshWeaver.Plugins, 2026-09-11) — for a caller that NEVER cancels its
+          trunk runs. Two such runs can build the same module and finish in either order, and the
+          registry keeps whatever arrives LAST. With this on, right before the hand-over each leg
+          fetches the trunk tip and asks the same scope script the selection uses whether a newer
+          commit reaches its module's dependency network; if one does, the leg stands down (receipt
+          `publication: superseded`, naming the tip) and that commit's own run publishes a tree
+          containing this one — a module never goes backwards and never waits for an unrelated one.
+          `direct` mode only; refuses a `content-repository` (it reads THIS repository's trunk). Off
+          by default: a caller whose trunk runs supersede each other gets its ordering from that.
+        type: boolean
+        required: false
+        default: false
       publish-mode:
         description: >
           WHERE the live-registry hand-over happens, when `publish` is true. Both values are
@@ -2543,6 +2557,54 @@ jobs:
           retention-days: 14
           compression-level: 9
 
+      # ═══════ NEWEST WINS, PER MODULE (`publish-newest-only`, per-module deploy 2026-09-11) ═══════
+      # A caller that never cancels its trunk runs can have two of them build this module at once,
+      # finishing in either order — and the registry keeps whatever arrives LAST. So right before the
+      # hand-over the leg fetches the trunk tip and asks the SAME scope script the selection uses
+      # whether any newer commit reaches this module's dependency network. If one does, this leg does
+      # not publish: that commit's own run (never cancelled) builds the module from a tree containing
+      # this one. Every uncertainty in the scope script answers FULL — "reached" — which stands this
+      # leg down; that is safe because the newer run takes the same fallback and builds the module.
+      # A trunk that cannot be read is RED: "cannot tell" must never publish as "nothing newer".
+      - name: A newer trunk commit reaches this module? (publish-newest-only)
+        id: newer
+        if: ${{ inputs.publish && inputs.publish-newest-only && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' }}
+        env:
+          CONTENT_REPOSITORY: ${{ inputs.content-repository }}
+          TRUNK: ${{ github.event.repository.default_branch }}
+          ENTRY: ${{ toJSON(matrix.entry) }}
+          MODULE: ${{ matrix.entry.module }}
+        run: |
+          set -euo pipefail
+          [ -z "$CONTENT_REPOSITORY" ] || { echo "::error::publish-newest-only reads THIS repository's trunk, but content-repository is '$CONTENT_REPOSITORY' — a lane packing another repository's content cannot say whether a newer commit of it exists. Turn one of the two off."; exit 1; }
+          [ -n "$TRUNK" ] || { echo "::error::the event carries no default branch, so the trunk tip cannot be read — and 'cannot tell' must never publish as 'nothing newer'."; exit 1; }
+          git fetch --no-tags --depth=1 origin "+refs/heads/$TRUNK:refs/remotes/origin/$TRUNK"
+          mine=$(git rev-parse HEAD)
+          tip=$(git rev-parse "refs/remotes/origin/$TRUNK")
+          newer=false
+          if [ "$tip" = "$mine" ]; then
+            echo "this run's commit $mine IS the trunk tip — nothing newer; publishing $MODULE"
+          else
+            # Two trees, no history needed: both commits are present in this shallow clone.
+            changed=$(git diff --no-renames --name-only "$mine" "$tip" | paste -sd, -)
+            if [ -z "$changed" ]; then
+              echo "the trunk moved to $tip, but its tree equals this run's — nothing newer reaches $MODULE; publishing"
+            else
+              jq -n --argjson e "$ENTRY" '[$e]' > "$RUNNER_TEMP/newer-entry.json"
+              GITHUB_OUTPUT="$RUNNER_TEMP/newer-scope.out" GITHUB_STEP_SUMMARY=/dev/null \
+                python3 meshweaver/.github/scripts/node-repo-scope.py --for modules --root . \
+                  --modules "@$RUNNER_TEMP/newer-entry.json" --event pull_request \
+                  --changed-list "$changed" > "$RUNNER_TEMP/newer-scope.json"
+              if [ "$(jq -r '.count' "$RUNNER_TEMP/newer-scope.json")" != "0" ]; then
+                newer=true
+                echo "::notice title=Stood down for a newer commit::$MODULE is NOT published from $mine — trunk tip $tip reaches its dependency network ($(jq -r '.reason' "$RUNNER_TEMP/newer-scope.json")), and that commit's own run publishes it."
+              else
+                echo "the trunk moved to $tip, but nothing it changed reaches $MODULE's dependency network — publishing"
+              fi
+            fi
+          fi
+          { echo "newer=$newer"; echo "tip=$tip"; } >> "$GITHUB_OUTPUT"
+
       # 🚨 The hand-over. Without it a module that has LEFT the platform repo is packed, versioned,
       # inspected — and reaches nobody, because a registry serves only bytes it holds. A missing
       # token here FAILS the job rather than skipping quietly: "published nothing" and "published
@@ -2561,7 +2623,7 @@ jobs:
       # produce quietly.
       - name: Hand the bundle to the registry
         id: publish
-        if: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' }}
+        if: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' && steps.newer.outputs.newer != 'true' }}
         env:
           TOKEN: ${{ secrets.publish-token }}
           REGISTRY: ${{ inputs.registry-url }}
@@ -2776,14 +2838,16 @@ jobs:
           # `publish-mode: staged` nothing reached the registry from here, and a receipt saying
           # otherwise would make the lane's own report ("N published to the registry") a claim
           # about something that has not happened yet.
-          PUBLISHED: ${{ inputs.publish && inputs.publish-mode == 'direct' }}
+          PUBLISHED: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.newer.outputs.newer != 'true' }}
           # 🚨 WHICH ARM OWNED THIS LEG'S HAND-OVER, written down rather than inferred from an
           # `if:` nobody can read after the fact — the same discipline as `TESTS` below. `direct`:
           # this leg POSTed the bundle itself. `staged`: it staged the bytes for the caller's
           # publication lane, which hands over after the full source verdict (MeshWeaver#3878).
           # `none`: this call does not publish at all. Two mutually exclusive conditions can BOTH
           # be false; this is what makes that impossible to do quietly.
-          PUBLICATION: ${{ !inputs.publish && 'none' || inputs.publish-mode }}
+          PUBLICATION: ${{ !inputs.publish && 'none' || (steps.newer.outputs.newer == 'true' && 'superseded' || inputs.publish-mode) }}
+          # publish-newest-only: the trunk tip whose own run publishes this module instead.
+          SUPERSEDED_BY: ${{ steps.newer.outputs.newer == 'true' && steps.newer.outputs.tip || '' }}
           # 🚨 WHICH LANE OWNS THIS MODULE'S SUITE, written down rather than inferred from an `if:`
           # nobody can read after the fact. `none` — the selection says this entry owes no test run
           # (a floor-only entry, or a ledger record that already carries a verdict); `inline` — the
@@ -2828,8 +2892,8 @@ jobs:
                 --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
                 --argjson pub "$PUBLISHED" --arg pm "$PUBLICATION" \
                 --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
-                --arg fid "$IDENTITY" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, publication:$pm, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}}' \
+                --arg fid "$IDENTITY" --arg sb "${SUPERSEDED_BY:-}" \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, publication:$pm, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}} + (if $sb == "" then {} else {supersededBy:$sb} end)' \
              > "$RUNNER_TEMP/receipts/$MODULE.json"
           cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1349,6 +1349,10 @@ jobs:
           # it was written for. Same expression as the checkout's `repository:` on purpose: one
           # answer to "whose content is this", used by both.
           BAKE_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
+          # Read-only: publish-bake-bundles.sh orders the sealed commit against this bake's through
+          # the compare API and refuses to seal BACKWARDS (per-module deploy). A token that cannot
+          # read the content repository just makes the comparison unavailable, and the script says so.
+          GH_TOKEN: ${{ github.token }}
           # flat (the default) or generation — see the `publication-layout` input. At `flat` the
           # script behaves byte-identically to before this input existed.
           BAKE_PUBLICATION_LAYOUT: ${{ inputs.publication-layout }}

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -28,8 +28,9 @@ select ─┬─► prepare (ONCE) ──► build (ONE workspace) ──► pac
 1. **select** — which bundles this diff can reach. The selector can say "these" or
    "everything", never "skip"; a workflow/pin change legitimately selects everything, because
    the compiler itself changed. A `src/` change is bounded by the **compile tree**, not treated
-   as "everything", and a superseded `main` run is **cancelled by construction** — see
-   *Superseded runs on `main`* below.
+   as "everything". A `main` push builds the **dependency network** changed since the last
+   successful run and is never cancelled — see *Per-module deploy* below; a repo that has not
+   adopted it cancels a superseded `main` run by construction (*Superseded runs on `main`*).
 2. **prepare, once per run** — everything every job consumes identically is staged here, never
    per module: the platform image as a per-digest zstd tarball in the **actions cache (GitHub's
    blob storage, colocated with the runners)**, the tester-app and platform-refs extractions,
@@ -365,7 +366,78 @@ grant the CI user the `Admin` role there (`MainNode = "Admin/ModuleBuilds"`), mi
 token, store it as the satellite's `REGISTRY_LEDGER_TOKEN`. `ledger: required` with an empty token
 is RED in `select` — a ledger that silently did not run and one that ran must never look alike.
 
+## 🚨 Per-module deploy — a merge ships its dependency network, and nothing supersedes it
+
+**Maintainer directives, 2026-09-11**, after MeshWeaver.Plugins `main` published NO module for nine
+hours — every merge superseded the run before it reached its publish, the baseline then fell back to
+FULL, the full run was superseded in turn, and the release-follow runs went red on an unrelated
+portal-host test: *"why do deployments depend on a complete main run?!"* · *"each module should
+update individually ⇒ mono-repo"* · *"only flooring"* · *"make sufficient tests"* · *"builds are not
+superseded then, however they must be atomic"* · *"no huge runs ever"* · *"on platform build we will
+do a full run to ensure compatibility … [it] will also be superseded by next platform run"* · *"we
+will only force consistency inside a dependency network, not just all — ever"*.
+
+MeshWeaver.Plugins adopts it first. Every lane default is unchanged, so a repo that has not opted in
+keeps the supersede model in the next section.
+
+### The rules
+
+1. **A push run on the trunk is never cancelled** — not by the concurrency group
+   (`cancel-in-progress` is already false on the default branch) and not by the supersede lane, which
+   a per-module repo does not call (`scripts/check-main-runs-not-cancelled.py` refuses the call).
+   Every merge's run reaches its own verdict.
+2. **A push builds its DEPENDENCY NETWORK, never everything.** The scope is the affected closure —
+   the in-mesh `requires`/dependents walk plus the `ProjectReference` compile tree — over the history
+   union since the newest SUCCESSFUL trunk run (`node-repo-publication-base.py`). Failed, cancelled
+   and in-flight runs after it are walked past, because the union carries every change they held.
+   Only a toolchain change resets to the full set: a run in between that attested a different
+   platform, image or build-logic set may have published with it, which git history cannot show.
+   Unrelated modules are not rebuilt, not retested, not republished.
+3. **A module publishes on its OWN verdict.** The module lane needs only the platform resolution and
+   the scope — no repo-wide validate gate, no portal-host suite, no sibling module's test. Each leg
+   builds, runs the module's own suite, and POSTs one bundle, whole or not at all
+   (content-addressed, keyed `{package}@{version}`). A red sibling leaves this module's publication
+   untouched; a red leg leaves its module at the version it last published.
+4. **Newest wins, per module (`publish-newest-only`).** Runs are no longer cancelled, so two of them
+   can build one module and finish in either order — and the registry keeps what arrives last.
+   Immediately before the POST the leg fetches the trunk tip and asks the same scope script whether
+   a newer commit reaches its module's network. If one does, the leg stands down (receipt
+   `publication: superseded`, naming the tip): that commit's own never-cancelled run builds the
+   module from a tree that contains this one. A module never goes backwards and never waits for an
+   unrelated module.
+5. **The seal never goes backwards.** The same reordering reaches the NodeType bake. A bake whose
+   commit is an ancestor of the commit already sealed answers `scope=none` at decision time
+   (`bake-scope.sh`) and skips at write time (`publish-bake-bundles.sh`, through the compare API):
+   sealing it would move every instance's sources back, since `SealedSyncGate` holds a repository's
+   sources at the sealed commit. The bake is narrowed too (`narrow-by-affected`), so a merge re-bakes
+   only what its diff affects.
+6. **The platform release is the ONE full run.** `repository_dispatch` and the `schedule` poll
+   rebuild and republish everything against the new platform — the compatibility check across the
+   whole catalog. It is the only run that is superseded, and only by the next platform run: the
+   release lane shares one concurrency group, so a newer platform run replaces a queued older one.
+7. **Compatibility is decided by floors.** A bundle states the framework it was built against and its
+   `minMeshVersion`/`requires` ranges, and an instance adopts it only when they hold. Consistency is
+   forced inside a dependency network (rule 2) and never across unrelated modules.
+
+### What it costs, and what it does not cover
+
+* **Overlap.** A push landing while an earlier run still builds rebuilds that run's network too
+  (rule 2's union). That is the price of never cancelling; rule 4 makes it harmless.
+* **A red newest leg.** When the newest run's leg for a module fails, rule 4 has already stood the
+  older leg down, so the module stays at its previously published version until the fix lands. The
+  red is on the trunk and names the module.
+* **The seal window.** A module built while a platform release is still sealing can be built against
+  the outgoing platform; the release run, and at the latest the daily poll, rebuild it.
+* **One workspace per run.** A push touching two unrelated networks still compiles them in one
+  fail-fast workspace, so a compile error in one stops the other's legs in that run. A workspace per
+  network is the next step.
+* **An in-flight platform run is not cancelled** by a newer one (rule 6 replaces only a queued one):
+  cancelling it mid-seal is the torn publication of Plugins#826.
+
 ## 🚨 Superseded runs on `main` — cancelled by construction, selected by the compile tree
+
+> **Repos on per-module deploy (above) do not cancel `main` runs at all** — this section is the
+> model for every repo that has not adopted it.
 
 **Maintainer directives, 2026-09-08** (during the memex roll block): *"cancel superseded"*,
 *"superseded means overlapping code"*, *"they are monorepos — walk the dependency tree, find all


### PR DESCRIPTION
## Why

MeshWeaver.Plugins `main` published **no module for nine hours** on 2026-09-11. The supersede lane cancelled each push run before its publish; the baseline then fell back to FULL after the cancellation; the full run was cancelled in turn. Release-follow runs went red on an unrelated portal-host test. Maintainer directive: *each module deploys individually; builds are not superseded but stay atomic; no huge runs; the platform release is the one full run; consistency only inside a dependency network.*

## What (all opt-in — lane defaults unchanged, satellites keep the supersede model)

| Piece | Change |
|---|---|
| `node-repo-publication-base.py` | Walk **past** failed/cancelled/in-flight runs to the newest successful trunk run — the history union carries their changes. Full build only when a run in between attested a different toolchain. Artifact API (works for in-flight runs). |
| `node-repo-module-pack.yml` | New input **`publish-newest-only`**: before the POST a leg stands down when a newer trunk commit reaches its module's dependency network (receipt `publication: superseded`, `supersededBy`). A module never goes backwards and never waits for an unrelated one. |
| `node-repo-pack-verify.py` | Names stood-down legs. |
| `bake-scope.sh`, `publish-bake-bundles.sh`, `node-repo-publish-bake.yml` | **Never seal backwards** — decision time and write time (compare API, `GH_TOKEN`). |
| `Doc/Architecture/ModuleBuildArchitecture` | New section *Per-module deploy* — the design of record, with its costs and what it does not cover. |

The Plugins caller (never calls the supersede lane on push; module lane needs only `platform-ref` + `build-scope`; `publish-newest-only: true`; `narrow-by-affected: true`) follows in a Plugins PR once this lands — it passes the new input, so it must merge after this.

## Tests
- `node-repo-publication-base.py --self-test`: 20 assertions (walk-past, ignore, rewritten history, toolchain verdicts)
- `bake-scope.sh --self-test`: all green incl. 2 new ordering cases (newer seal ⇒ none; a non-containing seal ⇒ full)
- `node-repo-pack-verify.py --self-test`: 2 new superseded cases
- `node-repo-scope.py --self-test` 71 ✓, `supersede-main-runs.py --self-test` 8/8 ✓
- actionlint: clean on both edited workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdfUffwySkxQVsoAev4pBm