### PR TITLE
fix(Plugins#1605): the teardown lets go of the mesh before it waits for the mesh's unloads

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1796,6 +1796,20 @@ The progression, each step measured the same way:
 
 The 12 that remain are reported and named, never waited on.
 
+**The residual has no managed root, and the cutoff is measured, not guessed.**
+- A second heap dump taken *inside* the drain, with both fixes active, shows **no** non-weak root on either
+  still-unloading LoaderAllocator. None is a stack root, a strong or pinned handle, a dependent handle, or a
+  finalizer-queue root.
+- Letting the drain run **20** no-progress rounds instead of 3 then collected **88** teardowns: 32 with nothing
+  to wait for, 56 in 2 rounds. It left **4** retained after 20 rounds. **No teardown was collected at any round
+  from 3 to 20.**
+- So three rounds is right: raising the number frees nothing.
+
+What holds the last 4–9 % is outside the managed heap. The most likely candidates are a native
+LoaderAllocator-to-LoaderAllocator reference between NodeType contexts (one context's types used by another's)
+or a runtime-internal reference, and `gcroot` cannot see either. It is left to the retention work of
+#4017/#4029, and the teardown reports each such case by name.
+
 **For the retention work (#4017/#4029).** On a long-lived portal, `MeshContentTypeRegistry`'s discriminator
 claims hold `RuntimeType`s of superseded NodeType generations for as long as the mesh lives. In a test that
 registry dies with its mesh, so the fix above is enough; on a portal it is a retention candidate of exactly

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1742,8 +1742,64 @@ against 81 and 84 before it:
 - 43 collected everything in 2 rounds;
 - 2 collected everything in 3 rounds.
 
-The contexts still retained are `LocalAnalysis`, `BusinessUnit` and `GroupAnalysis`. What holds them is the
-subject of the next gcroot, below.
+The contexts still retained are `LocalAnalysis`, `BusinessUnit` and `GroupAnalysis`.
+
+**What still holds them: nothing strong.** A second heap dump was taken at a `DISPOSE_ALC_RETAINED` teardown,
+this time with the eviction active (pid 61593: `LocalAnalysis`, `BusinessUnit` and `GroupAnalysis` Unloading).
+`gcroot` on their three LoaderAllocators finds **no strong, pinned or dependent root at all**.
+
+Every chain starts at a handle of type 10, `HNDTYPE_WEAK_INTERIOR_POINTER`. It runs to the collectible assembly's
+own statics array, then to a static delegate in it (for example the compiler's method-group cache
+`<4>__ProfitByLoB`, typed `Func<LayoutAreaHost, RenderingContext, UiControl>`), then to its `RuntimeMethodInfo`
+and the LoaderAllocator. That is the context referring to itself through a weak handle.
+
+**But they were not slow — they were held, and the holder was the teardown itself.** A controlled run let the
+drain go on for up to **20** rounds with no progress, 40 full collections with a finalizer pass after each. It
+still ended **30** teardowns `DISPOSE_ALC_RETAINED`, each in about 250 ms, and nothing was collected between
+round 4 and round 20. So something **live** held these contexts *during* the drain and let go the moment
+`DisposeAsync` returned. That is why a dump taken afterwards shows no strong root.
+
+A third dump was taken **inside** the drain, at the instant it concluded "retained" (a local diagnostic that ran
+`dotnet-dump collect` on its own process). It names the holder. For every Unloading context, the only non-weak
+root is a stack slot of `MonolithMeshTestBase.<DisposeAsync>d__87.MoveNext()`, the very frame running the drain:
+
+```
+MonolithMeshTestBase.<DisposeAsync>d__87.MoveNext()  Fp+118
+  -> MeshWeaver.Messaging.MessageHub                (the mesh teardown had just disposed)
+  -> its properties dictionary -> RecycleAnnouncement -> Action -> MeshWeaver.Data.Workspace
+  -> SynchronizationStream<MeshNode> -> ReduceManager<MeshNode> -> … -> MeshWeaver.Graph.MeshDataSource
+  -> MeshNodeTypeSource -> MeshWeaver.Mesh.Services.MeshContentTypeRegistry
+  -> ConcurrentDictionary<string, DiscriminatorClaim> -> DiscriminatorClaim
+  -> System.RuntimeType (the collectible node type) -> System.Reflection.LoaderAllocator
+```
+
+The teardown was waiting to see an unload while holding, in its own frame, the mesh that pins it. The fixture's
+`ServiceProvider` field is a second route to the same graph: `MonolithMeshTestBase` disposes the provider but,
+unlike `ServiceSetup.Dispose`, never clears the field.
+
+**The fix — the waiter lets go before it waits.**
+- The test bases clear `ServiceProvider` before the drain.
+- `CollectibleUnloadDrain` yields before its first collection, so the calling frame and its temporaries are
+  gone by the time anything is collected.
+
+**Measured after this fix.** Over three FutuRe runs (macOS arm64, all green, 138 teardowns), **126** ended
+`DISPOSE_UNLOADS_COLLECTED` (48 with nothing to wait for, 78 collected in 2 rounds) and **12** ended
+`DISPOSE_ALC_RETAINED`. None faulted.
+
+The progression, each step measured the same way:
+
+| state | collected | retained |
+|---|---|---|
+| waiting for "really unloaded" only | 81 | 84 |
+| + evicting STJ's accessor cache | 93 | 45 |
+| + the teardown releasing its own mesh first | 126 | 12 |
+
+The 12 that remain are reported and named, never waited on.
+
+**For the retention work (#4017/#4029).** On a long-lived portal, `MeshContentTypeRegistry`'s discriminator
+claims hold `RuntimeType`s of superseded NodeType generations for as long as the mesh lives. In a test that
+registry dies with its mesh, so the fix above is enough; on a portal it is a retention candidate of exactly
+the kind #4017 measures.
 
 ## Reading the result honestly
 

--- a/test/MeshWeaver.Fixture/CollectibleUnloadDrain.cs
+++ b/test/MeshWeaver.Fixture/CollectibleUnloadDrain.cs
@@ -61,6 +61,15 @@ public static class CollectibleUnloadDrain
         if (unloads is null || unloads.Pending == 0)
             return new CollectibleUnloadOutcome(0, [], null);
 
+        // 🚨 Leave the caller's frame BEFORE collecting (measured, Plugins#1605). The drain is called
+        // from a teardown that has just disposed the mesh, and that frame's stack slots still hold it:
+        // a heap dump taken INSIDE the drain found the only non-weak root of every still-unloading
+        // context in MonolithMeshTestBase.DisposeAsync's MoveNext frame — the disposed MessageHub →
+        // Workspace → MeshDataSource → MeshContentTypeRegistry → DiscriminatorClaim → the collectible
+        // RuntimeType. Collecting while that frame is live measures the teardown's own reference, not
+        // the unload. After the yield the caller has returned to its awaiter and its frame is gone.
+        await Task.Yield();
+
         var rounds = 0;
         var stalled = 0;
         var before = unloads.Pending;

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1709,6 +1709,10 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // after the reactive "all collected" signal: xUnit does not construct it until this
             // DisposeAsync returns. A faulted unload fails the class like a dirty teardown; a
             // retained context (rooted by something live) is REPORTED, never waited on.
+            // The fixture must not itself hold the mesh it is waiting to see unloaded: the disposed
+            // provider still reaches every singleton, the mesh hub and its content-type registry, whose
+            // discriminator claims hold the collectible types (gcroot inside the drain, #1605).
+            ServiceProvider = null!;
             var unloadOutcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(collectibleUnloads);
             TestPhaseTrace(testName,
                 unloadOutcome.Fault is not null ? "DISPOSE_UNLOAD_FAULTED"


### PR DESCRIPTION
Refs Systemorph/MeshWeaver.Plugins#1605 · follow-up to #4042, which was already in the merge queue when these commits landed. A queued branch cannot be updated, and dequeuing would have restarted a green run.

#4042 makes teardown wait until the collectible NodeType contexts it retired have **really** unloaded. That wait is only as good as what still holds those contexts. This PR removes the second holder, which turned out to be the teardown itself, and records what is left.

## The holder: the teardown's own frame

With #4042's STJ eviction in place, three FutuRe runs still ended **45** of 138 teardowns `DISPOSE_ALC_RETAINED`.

- **The contexts were held, not slow.** Letting the drain run 20 no-progress rounds left 30 teardowns retained, and nothing was collected between round 4 and round 20. So something **live** held them during the drain, and let go once `DisposeAsync` returned. That explains why a dump taken afterwards showed no strong root.
- **A heap dump taken *inside* the drain names it.** At its "retained" verdict, the only non-weak root of every Unloading context was a stack slot of `MonolithMeshTestBase.<DisposeAsync>d__87.MoveNext()`, the frame running the drain:
  `MessageHub` (just disposed) → `RecycleAnnouncement` → `Workspace` → `SynchronizationStream<MeshNode>` → `MeshDataSource` → `MeshNodeTypeSource` → `MeshContentTypeRegistry` → `DiscriminatorClaim` → the collectible `RuntimeType` → `LoaderAllocator`.
- **A second route.** The fixture's `ServiceProvider` field reaches the same objects: `MonolithMeshTestBase` disposes the provider but, unlike `ServiceSetup.Dispose`, never clears the field.

## The fix: the waiter lets go before it waits

- `CollectibleUnloadDrain` does `await Task.Yield()` before its first collection, so the calling frame and its temporaries are gone by then.
- `MonolithMeshTestBase` clears `ServiceProvider` before the drain. The Plugins copy gets the same change in its own PR.

## Measured

Every row is three `MeshWeaver.FutuRe.Test` runs on macOS arm64, all green.

| state | collected | retained |
|---|---|---|
| waiting for "really unloaded" only | 81 | 84 |
| + STJ's accessor cache evicted on `Unloading` (#4042) | 93 | 45 |
| + the teardown releases its own mesh before waiting (this PR) | **126** | **12** |

## The residual, and why the 3-round cutoff stays

- **No managed root.** A second inside-the-drain dump, taken with this fix active, shows no non-weak root on the remaining contexts: no stack root, no strong or pinned handle, no dependent handle, no finalizer-queue root.
- **The cutoff is measured.** With 20 no-progress rounds allowed, 88 teardowns were collected (32 with nothing to wait for, 56 in 2 rounds), 4 stayed retained, and **none** was collected at any round from 3 to 20. So three rounds is right, and raising it frees nothing.
- **Where it goes.** The remaining 4–9 % is held outside the managed heap, most likely by a native LoaderAllocator-to-LoaderAllocator reference between NodeType contexts. It is reported by name (`DISPOSE_ALC_RETAINED`) and handed to the #4017/#4029 retention track.
- **Also for #4017.** On a long-lived portal, `MeshContentTypeRegistry`'s discriminator claims hold superseded generations' `RuntimeType`s for as long as the mesh lives.

## Verification

- `MeshWeaver.Compiler.Pipeline.Test` → `RetiredContextCollectedSignalTest`: 5 passed on a clean Release `-warnaserror` build, with the yield in place.
- `MeshWeaver.Documentation.Test`: 397 passed.
- The integration evidence is the table above.

What's New: skipped — test-host teardown and a debugging reference, with no user-visible effect.

Pairs-with: none — nothing public removed.
Implementers: none — no interface member added.
Mirror-sync: none — no i18n key added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
