### PR TITLE
roster: Plugins drops its supersede and publish-modules callers (per-module deploy)

### DIFF
--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -78,11 +78,12 @@ repos:
         job: publish-modules
         lane: node-repo-module-publish.yml
         grants: {contents: read}
-        pending: lands with Systemorph/MeshWeaver.Plugins branch fix/3878-staged-module-publication, which switches modules-floor to publish-mode staged and adds this caller (MeshWeaver#3878). Once it has merged the marker is spent and this row is compared key for key.
+        pending: on main since Systemorph/MeshWeaver.Plugins#1663 and REMOVED again by Systemorph/MeshWeaver.Plugins#1676 (per-module deploy — ModuleBuildArchitecture → Per-module deploy, so modules publish on their own verdict, not the whole run's). Compared key for key while main still has it; the marker excuses the absence once #1676 merges — delete this row then.
       - workflow: ci.yml
         job: supersede
         lane: node-repo-supersede.yml
         grants: {actions: write, contents: read}
+        pending: REMOVED by Systemorph/MeshWeaver.Plugins#1676 — per-module deploy never cancels a main run, so Plugins no longer calls the supersede lane (ModuleBuildArchitecture → Per-module deploy). Compared key for key while main still has it; the marker excuses the absence once #1676 merges — delete this row then.
       - workflow: ci.yml
         job: test-repos
         lane: node-repo-gate.yml


### PR DESCRIPTION
Plugins#1676 (per-module deploy; design of record in `ModuleBuildArchitecture` → *Per-module deploy*, core #4044) removes two Plugins callers: `ci.yml#supersede`, because no main run is ever cancelled, and `ci.yml#publish-modules`, added by Plugins#1663, because modules publish on their own verdict. Its `validate` is red on the fleet-roster assertion, because the roster still lists `supersede` without a marker.

Both rows get `pending:`. The marker excuses ABSENCE only, so the rows are still compared key for key while Plugins main has the callers, and are excused once #1676 merges.

Verified locally: `check-workflow-permission-pairing.py --assert-fleet-row Systemorph/MeshWeaver.Plugins` passes against both the #1676 tree and a main-based tree, and `--self-test` passes.

Follow-up: delete both rows after #1676 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LdfUffwySkxQVsoAev4pBm