### PR TITLE
fix(#1605): release the shared mesh provider before its unload drain

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -273,8 +273,15 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     private sealed class SharedMeshProvider(IServiceProvider serviceProvider, string testClassName)
         : IAsyncDisposable
     {
+        // Nullable, and cleared by DisposeAsync BEFORE the unload drain: while this holder keeps the
+        // disposed provider, it roots the mesh and its MeshContentTypeRegistry, and with them the very
+        // collectible contexts the drain waits for (Plugins#1605) - the shared twin of the per-test
+        // path's `ServiceProvider = null!`.
+        private IServiceProvider? serviceProvider = serviceProvider;
+
         /// <summary>The provider every test of the class shares.</summary>
-        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+        public IServiceProvider ServiceProvider =>
+            serviceProvider ?? throw new ObjectDisposedException(nameof(SharedMeshProvider), testClassName);
 
         /// <summary>
         /// Disposes the shared provider, then — like the per-test path (Plugins#1605) — waits until
@@ -284,13 +291,20 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         /// </summary>
         public async ValueTask DisposeAsync()
         {
-            var unloads = ServiceProvider.GetService<CollectibleContextUnloads>();
-            try { (ServiceProvider as IDisposable)?.Dispose(); }
+            var provider = serviceProvider;
+            if (provider is null)
+                return;
+            var unloads = provider.GetService<CollectibleContextUnloads>();
+            try { (provider as IDisposable)?.Dispose(); }
             catch (Exception ex)
             {
                 Fixture.TestTraceLog.AppendPhase(
                     testClassName, "DISPOSE_SHARED_SP_ERROR", 0, $"{ex.GetType().Name}: {ex.Message}");
             }
+            // Release the disposed provider before waiting on the contexts it roots: neither this
+            // holder's field nor this frame's local may keep the mesh reachable across the drain.
+            serviceProvider = null;
+            provider = null;
             var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
             Fixture.TestTraceLog.AppendPhase(testClassName,
                 outcome.Fault is not null ? "DISPOSE_SHARED_UNLOAD_FAULTED"


### PR DESCRIPTION
## What

Follow-up to #4046, answering its review comment (https://github.com/Systemorph/MeshWeaver/pull/4046#discussion_r3992357382). #4046 set `ServiceProvider = null!` before the collectible-unload drain on the per-test teardown path, but the shared-mesh path was left out: `SharedMeshProvider.DisposeAsync` kept its get-only `ServiceProvider` populated while it awaited `CollectibleUnloadDrain.WaitUntilCollectedAsync`. That holder still roots the disposed mesh and its `MeshContentTypeRegistry`, and with them the collectible contexts the drain is waiting on.

`SharedMeshProvider` now holds the provider in a nullable field. `DisposeAsync` resolves the tracker, disposes the provider, then clears both the field and its own local before awaiting the drain. After that, reading `ServiceProvider` throws `ObjectDisposedException`, so a late reader surfaces loudly instead of getting a disposed mesh. A second `DisposeAsync` returns without doing anything.

## Why this matters (Plugins#1605)

A teardown ends only when the mesh's collectible contexts have really unloaded (#4042). Any owner still holding the disposed mesh during that wait turns "collected" into "retained". This is the shared-path twin of #4046's frame and SP release.

## Verification

- `dotnet build test/MeshWeaver.Hosting.Monolith.TestBase -c Release -warnaserror`: 0 warnings, 0 errors.
- `MeshWeaver.Graph.Test` `AppIconAdoptionTest` (the one `ShareMeshAcrossTests => true` class in core) passes on the changed path. No test reads the shared provider after its collection disposed it.
- Limit: no core shared-mesh class compiles dynamic NodeTypes, so the shared drain has no retirements to wait on here. The retention effect is the same mechanism #4046 measured on the per-test path.

Pairs-with: none — test-base only; no public `src/` surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
