### PR TITLE
ci(scope): declare devtools/ a no-op dir — a dev tool no lane runs no longer rebuilds everything

### DIFF
--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -103,7 +103,18 @@ from pathlib import Path
 # drift over-builds the divergent dir out loud instead of silently, and — since 2026-09-08 —
 # instead of switching the whole narrowing off (which is what equality did, on every pull request
 # three satellites ever opened). A literal it cannot READ is still a refusal.
-NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}
+#
+# `devtools/` is the DECLARED home for a script no lane runs — a local dev loop, a triage helper.
+# Before it existed such a script could only live in `scripts/`, which is (correctly) the gates'
+# directory and therefore EVERYTHING: measured on MeshWeaver.Plugins run 34618468550 (#1668), a
+# one-line edit to `scripts/run-node-tests.py` — referenced by no workflow — selected 52 of 52
+# compiled projects and every module suite (~89 runner-minutes of portal-host shards + ~200 of
+# module tests); the same diff without it selected 1 of 52. The name is NEW on purpose: `tools/`
+# exists in MeshWeaver.Plugins and is NOT inert there (`src/Directory.Build.targets` and two test
+# projects read it), and a name no repo has yet lands DORMANT in `check-noop-scope-parity.py`
+# everywhere, so the platform can declare it first without reddening any caller. What a file
+# placed there claims: no compiled project, no module content and no gate reads it.
+NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees", "devtools"}
 
 # 🚨 A repo-ROOT path HAS NO TOP-LEVEL DIRECTORY, so NOOP_DIRS above can never reach it: both
 # no-op branches of the classifier are guarded by `"/" in f`, and a single-segment path takes
@@ -576,7 +587,7 @@ _STUB_PROJECTS = (
 # 🚨 The stub carries a NOOP_DIRS literal because the real selector does and this script now
 # READS it — a fixture without one would make every case take the drift fallback.
 _STUB_SELECTOR = (
-    'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}\n'
+    'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees", "devtools"}\n'
     "import json,sys\n"
     "paths=[l for l in open(sys.argv[sys.argv.index('--changed')+1]).read().splitlines() if l]\n"
     "pk=sorted({p.split('/')[0] for p in paths})\n"
@@ -891,7 +902,8 @@ def self_test() -> int:
         selector_path = root / "scripts" / "affected-modules.py"
         # THEIRS is missing `app` — MeshWeaver.SocialMedia's live divergence, measured on run
         # 34122662676, which used to answer `full` on every pull request that repo ever opened.
-        theirs_short = 'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", ".claude", ".worktrees"}\n'
+        theirs_short = ('NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", ".claude", ".worktrees", '
+                        '"devtools"}\n')
         selector_path.write_text(theirs_short + selector_src, encoding="utf-8")
         got = _run(root, "modules", "pull_request", ["docs/guide.md"])
         check("a caller missing one of our NOOP dirs still NARROWS on the ones both agree about",
@@ -904,7 +916,7 @@ def self_test() -> int:
         # THEIRS carries a dir we do not — the other direction, and it must be just as safe.
         selector_path.write_text(
             'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees", '
-            '"vendor"}\n' + selector_src, encoding="utf-8")
+            '"devtools", "vendor"}\n' + selector_src, encoding="utf-8")
         got = _run(root, "modules", "pull_request", ["vendor/lib.js"])
         check("a dir only THEY call inert is still EVERYTHING here (the other direction)",
               got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
@@ -924,6 +936,14 @@ def self_test() -> int:
         got = _run(root, "modules", "pull_request", ["WhatsNew/note.md"])
         check("WhatsNew/ is a NOOP dir — a note-only PR builds NOTHING, not everything",
               got["scope"] == "narrowed" and got["count"] == 0,
+              f"scope={got['scope']} count={got['count']}")
+        got = _run(root, "modules", "pull_request", ["devtools/run-node-tests.py"])
+        check("devtools/ is a NOOP dir — a local dev tool builds NOTHING, not everything",
+              got["scope"] == "narrowed" and got["count"] == 0,
+              f"scope={got['scope']} count={got['count']}")
+        got = _run(root, "modules", "pull_request", ["scripts/run-node-tests.py"])
+        check("…while the same script under scripts/ (the gates) is still EVERYTHING",
+              got["scope"] == "full" and got["count"] == 2,
               f"scope={got['scope']} count={got['count']}")
 
         print("the caller's graphs are load-bearing — every failure of theirs is a FULL run:")

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildScopeNarrowing.md
@@ -95,6 +95,30 @@ them agree by construction.
 READ — renamed, moved, reformatted onto several lines — leaves the platform unable to know what the
 caller believes, and "cannot verify" has exactly one honest answer: the full set.
 
+## A declared home for dev tools — `devtools/`
+
+`scripts/` is the gates' directory, so a change there is EVERYTHING, and that is right: a gate
+script genuinely changes what a run proves. But it left a script that NO lane runs — a local dev
+loop, a triage helper — with nowhere to live except the gates' directory. Measured on
+MeshWeaver.Plugins run 34618468550 (#1668, 2026-09-11): a one-line edit to
+`scripts/run-node-tests.py`, which no workflow references, selected **52 of 52** compiled projects
+and every module suite — about 89 runner-minutes of portal-host shards and 200 of module tests,
+15:50Z → 18:45Z — while the same diff without that one file selected **1 of 52**.
+
+`devtools` is therefore in `NOOP_DIRS` (2026-09-11). Two choices in that are deliberate:
+
+- **A new name, not `tools/`.** MeshWeaver.Plugins has a `tools/` directory and it is **not**
+  inert there: `src/Directory.Build.targets` and two test projects read it (the Monaco bundle and
+  the Memex template pack). Declaring it a no-op would have under-built them.
+- **The platform declares it first.** No repository in the fleet had a `devtools/` directory, so
+  `check-noop-scope-parity.py` reports the new name as *dormant* in every caller and nothing turns
+  red. A caller then adds `devtools` to its own `scripts/affected-modules.py` literal in the same
+  change that creates the directory, and from that commit the two sets agree about a directory
+  that exists. The reverse order would red that caller's `Validate node repos` for the whole gap.
+
+A file placed under `devtools/` claims that no compiled project, no module content and no gate
+reads it. If that stops being true, the file belongs back in `scripts/`.
+
 ## Both denominators, printed
 
 `selected` answers what is BUILT. A floor-only entry — one the caller's gates compose on every run,
@@ -139,7 +163,7 @@ image digests, and a pin move genuinely invalidates every bundle in the reposito
 Two, and each was made to fail before it was believed.
 
 **`node-repo-scope.py --self-test`** runs unconditionally in the `select` job of every satellite's
-every run, next to the answer it produces, and again in core's own `dotnet-test.yml`. 63 cases.
+every run, next to the answer it produces, and again in core's own `dotnet-test.yml`. 73 cases (2026-09-11).
 The load-bearing ones for this change:
 
 - every name in `NOOP_FILES` narrows to nothing on its own — asserted by iterating the set itself,


### PR DESCRIPTION
This adds `devtools` to `NOOP_DIRS` in `.github/scripts/node-repo-scope.py`. With it, a script that no lane runs has a declared home, and editing it no longer rebuilds every compiled project and module suite in a node repo.

## Why

Peer session `meshweaver-plugins-a6` measured this on MeshWeaver.Plugins run 34618468550 (#1668). A one-line edit to `scripts/run-node-tests.py` selected **52 of 52** compiled projects and every module suite: about 89 runner-minutes of portal-host shards plus about 200 of module tests, 15:50Z → 18:45Z. No workflow references that script; it's a local dev loop. The same diff without it selected **1 of 52**. `scripts/` is the gates' directory, so a change there correctly counts as EVERYTHING. The problem was that a dev tool had nowhere else to live. `NOOP_FILES` is a closed list of root names by design, so it couldn't help.

This came out of the Plugins PR-drain investigation (Systemorph/MeshWeaver.Plugins#1678 → `Hosting/PullRequestDrain.md`).

## Two deliberate choices

- **A new name, not `tools/`.** MeshWeaver.Plugins already has a `tools/` directory, and it is **not** inert: `src/Directory.Build.targets`, `Memex.Portal.Gui.Test` and `MeshWeaver.Observability.Test` read it (the Monaco bundle and the Memex template pack).
- **The platform goes first.** I checked the root of every fleet repo (MeshWeaver, Plugins, Education, Reinsurance, SocialMedia, Manufacturing, Crm, Memex); none has a `devtools/` directory. So `check-noop-scope-parity.py` reports the name as *dormant* everywhere and no caller's `Validate node repos` goes red. Plugins then adds `devtools` to its `scripts/affected-modules.py` literal in the same change that creates the directory and moves `run-node-tests.py` into it. The reverse order would turn Plugins red for the whole gap.

## Verification

- `node-repo-scope.py --self-test`: **73 cases green**. Two are new: a file under `devtools/` narrows to nothing, and the same script under `scripts/` is still EVERYTHING.
- `node-repo-project-scope.py --self-test`: 16 green. It reads the same sets through `resolve_noop_dirs`.
- `check-noop-scope-parity.py --self-test`: 7 green.
- `check-noop-scope-parity.py --root <MeshWeaver.Plugins main> --platform-scope <this branch>` reports `divergent but DORMANT … devtools` and `✓ the two sets agree about every top-level directory this repo has (69 checked)`.
- Docs: `Doc/Architecture/BuildScopeNarrowing` gains a section on this, and its case count is updated.

No C#, no public surface, no i18n key. **No What's New entry:** this is a pure CI-internal change with no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
