### PR TITLE
URGENT prod regression: the batch bake compiled a stale definition over newer sources (Hosting/Issue CS0103 held memex 8372)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -258,6 +258,25 @@ seal time, not merge time** — attribute by the set each run's `Resolve the rel
 names, never by the clock. And **a red in the dependent is evidence about core only after the diff
 is held constant** — one commit, two sets.
 
+### A shape-7 suspect that was NOT shape 7: the torn bake input (2026-09-11)
+
+`Hosting/Issue` compiled on core set `3.0.0-ci.8314` and failed with `CS0103 'ObservationQueries'` on a
+new pod of `3.0.0-ci.8372`; the range between them touched source resolution and compile-cache code,
+nothing touched the `shared=` literal, and the obvious reading was shape 7 — behaviour changed behind
+an unchanged signature. It was not. The failing type's own version history showed its definition
+MOVING during the pod's bake (v458 at 18:53:04Z with no declared sources, v462 at 18:53:51Z with the
+`shared=` entry): the bake had compiled the definition it enumerated before a module update over
+the files that landed after it. The deterministic repro fails identically on both ends of the range
+(`45306a33e` and `74d4c8527`), and a fresh pod on the same image baked the type cleanly. Bisecting
+the range would have found nothing.
+
+**The discriminating read before bisecting a shape-7 suspect in a NodeType compile:** read the
+failing type's versions across the failing process's bake window (`get_versions`, then
+`get_version` on each side of the window). If the definition moved while the process was baking,
+the verdict was measured against a moving input, and the image range is the wrong place to look.
+The defect and its fix: [the batch bake compiles the definition the mesh holds when it
+compiles](../NodeTypeCompilation).
+
 ### 🚨 Shape 7 in the by-hand sweep: a `!` on the WRONG receiver hides the site (#3321)
 
 Shape 7 has no gate, so the only control is a **by-hand sweep of the dependents**. This is about how

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -2102,6 +2102,62 @@ record byte-for-byte untouched, and on a live hub adopts.
 
 ---
 
+### 🚨 The batch bake compiles the definition the mesh holds WHEN IT COMPILES (2026-09-11)
+
+A pod's bake sweep enumerates every NodeType definition **once, at its start**
+(`DynamicTypePreWarmer.WarmDynamicTypes` → `DynamicTypesOf`), the batched discovery pass
+(`NodeTypeBatchBake.ResolveSources`) resolves source sets from those enumerated definitions later,
+and the sequential compile reaches each type minutes after that. `BakeOne` used to hand the
+compiler the **enumerated** node together with the **later** source set. A module update landing
+inside that window moves a definition and its files together, and the pair Roslyn received was
+neither the old content nor the new one.
+
+Measured on `memex.systemorph.com`, new pod on `3.0.0-ci.8372` started 18:50Z, while the Hosting
+module moved 1.15 → 1.16 (Plugins `cff9fb34cb`, which added `FleetWatch` and its
+`shared=@Hosting/InstanceAction/Source/ObservationQueries` entry together):
+
+| When (UTC) | `Hosting/Issue` |
+|---|---|
+| 18:53:04 — v458 | no `sources` (the defaults), module 1.15, fingerprint `ca01bf82…` `AdoptedVerified` |
+| 18:53:51 — v462 | `sources` = own `Source` + the `shared=` entry, module 1.16; `FleetWatch` in the source set |
+| ~18:55 — the pod's batch compile | "Executed source queries (2)" (the 1.15 definition) over a set holding `FleetWatch` → `CS0103 'ObservationQueries'` → a CompileError on a previously healthy type → readiness refused ~30 min |
+
+Nothing read anything partially and no resolver dropped the `shared=` entry: v458 genuinely declared
+no sources, and the pod's prebuilt DECLINE of the 1.16 bundle (`d251868c…` against the live
+`ca01bf82…`) was correct when it was taken. A fresh pod on the same image baked the type cleanly.
+It is not a regression of the core range the image moved across either: the repro below fails
+identically on `45306a33e` and on `74d4c8527`.
+
+**The rule now:** `NodeTypeBatchBake.CurrentCompileInput` re-reads the type's row immediately before
+the compile, through the same `IStorageAdapter.Read` the compile stamp already uses (never a routed
+point read, which on a type a sync has just pruned opens the storm-breaker), and compiles THAT row.
+The batch's pre-resolved set is kept only when the row declares the very source queries the batch
+resolved it with; when the queries moved, the type's sources are resolved again from its current
+queries through the batch's own bounded, truncation-checked `RunQuery`, held to the same
+`DiscoveryUnestablished` invariant.
+
+Each "I don't know" falls in a stated direction. A row that is gone, unreadable, or whose read faults
+keeps the ENUMERATED input — the verdict that always stood, and `ReclassifyIfRemoved` still answers a
+pruned type afterwards. A definition that demonstrably moved but whose new sources cannot be
+established reports `TimedOut` — "not evaluated", never a gating CompileError — because the enumerated
+input is then known to be stale.
+
+**Test:** `ABakeCompilesTheDefinitionItResolvedTest` (MeshWeaver.Hosting.Test) runs the sweep's own
+enumeration, discovery and compile against a real monolith mesh. Its repro moves a consumer's
+definition between enumeration and compile, adding a single-node `shared=` entry, and expects the
+verdict the CURRENT content earns — `Compiled` for sound content, a gating `CompileError` naming the
+genuine defect for broken content. Without the fix both cases fail with the production text
+(`Executed source queries (2)` … `CS0103 The name 'LibAnswers' does not exist`) on `45306a33e` and on
+`main`; two controls — an unmoved definition compiles from the batch set, and a genuine compile
+error still gates — pass on all three.
+
+**Residue, named rather than closed.** A mesh that is itself torn when the compile runs — the file
+has landed and its definition has not — still earns a CompileError, because that is what the content
+IS at that instant. Its cure remains #1214's `WatchForRecovery`, which retracts the regression on a
+fresh usable build on THIS image. Whether that watch can be starved when the type's own hub is hosted
+by a previous-generation pod (whose rebuild is stamped for the old framework) is consistent with this
+incident's ~30-minute hold but was not established here.
+
 ## 🚨 That recompile can FAIL — and nothing upstream can warn you
 
 Rule 3 guarantees a framework upgrade recompiles **every** dynamic NodeType. That recompile

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -2131,16 +2131,26 @@ identically on `45306a33e` and on `74d4c8527`.
 **The rule now:** `NodeTypeBatchBake.CurrentCompileInput` re-reads the type's row immediately before
 the compile, through the same `IStorageAdapter.Read` the compile stamp already uses (never a routed
 point read, which on a type a sync has just pruned opens the storm-breaker), and compiles THAT row.
-The batch's pre-resolved set is kept only when the row declares the very source queries the batch
-resolved it with; when the queries moved, the type's sources are resolved again from its current
-queries through the batch's own bounded, truncation-checked `RunQuery`, held to the same
-`DiscoveryUnestablished` invariant.
+The batch's pre-resolved set is reused only when both witnesses say it is still the set: the row
+declares the very source queries the batch resolved it with, AND the row's own
+`CurrentSourceVersions` record is absent or names exactly the versions the batch holds. Otherwise the
+sources are resolved again from the current queries through the batch's own bounded,
+truncation-checked `RunQuery` (same `DiscoveryUnestablished` invariant), and the row is read once more
+afterwards; a definition that moved AGAIN meanwhile is not compiled. One deadline covers the re-read,
+any re-resolution, the compile and the stamp — the compile gets only the time that is left.
 
-Each "I don't know" falls in a stated direction. A row that is gone, unreadable, or whose read faults
-keeps the ENUMERATED input — the verdict that always stood, and `ReclassifyIfRemoved` still answers a
-pruned type afterwards. A definition that demonstrably moved but whose new sources cannot be
-established reports `TimedOut` — "not evaluated", never a gating CompileError — because the enumerated
-input is then known to be stale.
+Every "I don't know" is a non-verdict (`TimedOut`, "not evaluated"), never a compile of a pair nobody
+can vouch for: a re-read that faults or runs out of budget, a row that no longer reads as a
+`NodeTypeDefinition`, a current source set that cannot be established, a definition that moved again.
+A row absent from storage is confirmed by a listing and reported `Removed` WITHOUT a compile or a
+stamp — the stamp's insert-if-absent would otherwise re-create the type its repository just pruned.
+
+**What it does NOT establish: an atomic snapshot.** Neither a row read nor a query is a transaction,
+and the version record lags the files by the sources watcher's own latency, so a source edited in the
+last instant before the compile can still be compiled at its earlier version. That residue heals
+itself — `CompiledSources` records what was compiled, the watcher's newer record reads dirty, the type
+rebuilds — and a verdict it produces is the one #1214's recovery watch exists for (see the residue
+note below).
 
 **Test:** `ABakeCompilesTheDefinitionItResolvedTest` (MeshWeaver.Hosting.Test) runs the sweep's own
 enumeration, discovery and compile against a real monolith mesh. Its repro moves a consumer's
@@ -2149,7 +2159,11 @@ verdict the CURRENT content earns — `Compiled` for sound content, a gating `Co
 genuine defect for broken content. Without the fix both cases fail with the production text
 (`Executed source queries (2)` … `CS0103 The name 'LibAnswers' does not exist`) on `45306a33e` and on
 `main`; two controls — an unmoved definition compiles from the batch set, and a genuine compile
-error still gates — pass on all three.
+error still gates — pass on all three. Three further cases pin the review's findings (#4051): a source
+edited under UNCHANGED queries is compiled as it now stands once its version record moved; a moved
+definition whose current source set cannot be established inside the per-type deadline is `TimedOut`,
+never a `CompileError`; and a type pruned during the sweep is `Removed` and is NOT re-created by a
+stamp.
 
 **Residue, named rather than closed.** A mesh that is itself torn when the compile runs — the file
 has landed and its definition has not — still earns a CompileError, because that is what the content

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-module-update-during-a-rollout-no-longer-blocks-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-module-update-during-a-rollout-no-longer-blocks-it.md
@@ -1,0 +1,17 @@
+---
+Name: A module update during a rollout no longer blocks it
+Category: Fix
+Description: When a module's content changed while a new portal version was starting up, the start-up check could build a type from its old definition and its new files, report a failure that did not exist, and hold the rollout. It now builds each type as it stands at that moment.
+Icon: Checkmark
+Order: -20260911
+---
+
+# A module update during a rollout no longer blocks it
+
+A new portal version checks every type before it starts serving. When a module update arrived
+while that check was running, the check could combine a type's previous definition with its
+updated files. The result failed to build, the check reported the type as broken, and the rollout
+waited until the new version was restarted.
+
+The check now reads each type again immediately before building it, so it builds the definition
+and the files of one and the same moment. A type that is genuinely broken still stops the rollout.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-module-update-during-a-rollout-no-longer-blocks-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-module-update-during-a-rollout-no-longer-blocks-it.md
@@ -1,7 +1,7 @@
 ---
 Name: A module update during a rollout no longer blocks it
 Category: Fix
-Description: When a module's content changed while a new portal version was starting up, the start-up check could build a type from its old definition and its new files, report a failure that did not exist, and hold the rollout. It now builds each type as it stands at that moment.
+Description: When a module's content changed while a new portal version was starting up, the start-up check could build a type from its old definition and its new files, report a failure that did not exist, and hold the rollout. It now builds each type as it stands when it is built.
 Icon: Checkmark
 Order: -20260911
 ---
@@ -13,5 +13,7 @@ while that check was running, the check could combine a type's previous definiti
 updated files. The result failed to build, the check reported the type as broken, and the rollout
 waited until the new version was restarted.
 
-The check now reads each type again immediately before building it, so it builds the definition
-and the files of one and the same moment. A type that is genuinely broken still stops the rollout.
+The check now reads each type again immediately before building it. When the definition or its
+files changed since the check started, it builds the definition as it now stands, with the files that
+definition names, and when it cannot tell which files those are it reports the type as not checked
+instead of broken. A type that is genuinely broken still stops the rollout.

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Text;
+using System.Text.Json;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
@@ -716,24 +717,37 @@ internal static class NodeTypeBatchBake
         IReadOnlyList<MeshNode> sources,
         TimeSpan budget,
         ILogger? logger)
-        => CurrentCompileInput(mesh, typeNode, sources, budget, logger)
-            .SelectMany(input => input.Unestablished is { } reason
-                // The definition MOVED and its new source set could not be established. Compiling
-                // the enumerated input instead would be a verdict about content that no longer
-                // exists, so this is "not evaluated" — the same non-verdict an unestablished
-                // discovery earns everywhere else (#1218) — never a CompileError.
-                ? Observable.Return(new PreWarmOutcome(typeNode.Path, PreWarmStatus.TimedOut, reason))
-                : BakeResolved(mesh, input.Node, input.Sources, budget, logger));
+        => Observable.Defer(() =>
+        {
+            // 🚨 ONE deadline for the whole type — the re-read, any re-resolution, the compile and
+            // the stamp together. The sweep calls this sequentially with no outer bound, so giving
+            // the compile a second full budget after the re-read would let one slow read double
+            // the documented per-type budget across the whole rollout (#4051 review). Only the time
+            // that is LEFT reaches the compile.
+            var deadline = DateTimeOffset.UtcNow + budget;
+            return CurrentCompileInput(mesh, typeNode, sources, deadline, logger)
+                .SelectMany(input =>
+                {
+                    if (input.Settled is { } settled)
+                        return Observable.Return(settled);
+                    var remaining = deadline - DateTimeOffset.UtcNow;
+                    return remaining > TimeSpan.Zero
+                        ? BakeResolved(mesh, input.Node, input.Sources, remaining, logger)
+                        : Observable.Return(new PreWarmOutcome(typeNode.Path, PreWarmStatus.TimedOut,
+                            "the per-type budget was spent establishing the compile input — not evaluated"));
+                });
+        });
 
     /// <summary>
-    /// What <see cref="BakeOne"/> compiles: ONE definition and the source set ITS OWN queries select.
-    /// <paramref name="Unestablished"/> names why no such pair could be formed.
+    /// What <see cref="BakeOne"/> compiles: ONE definition and the source set ITS OWN queries select —
+    /// or, in <paramref name="Settled"/>, the outcome that stands INSTEAD of a compile, because the
+    /// type is gone or no input could be vouched for.
     /// </summary>
     internal sealed record CompileInput(
-        MeshNode Node, IReadOnlyList<MeshNode> Sources, string? Unestablished = null);
+        MeshNode Node, IReadOnlyList<MeshNode> Sources, PreWarmOutcome? Settled = null);
 
     /// <summary>
-    /// 🚨 <b>The compile input, re-read at the moment of the compile.</b>
+    /// 🚨 <b>The compile input, re-established at the moment of the compile.</b>
     ///
     /// <para>The sweep enumerates every definition ONCE, at its start, and the batched discovery
     /// pass resolves source sets from those enumerated definitions some time later; a sequential
@@ -743,87 +757,128 @@ internal static class NodeTypeBatchBake
     /// (2026-09-11, a pod started 18:50Z) Hosting 1.16 landed between 18:53:04Z and 18:53:55Z: the
     /// sweep had enumerated <c>Hosting/Issue</c> at v458 — no declared sources — and compiled it
     /// ~18:55Z over a set that already held the 1.16 <c>FleetWatch</c>, which calls the
-    /// <c>ObservationQueries</c> file the 1.16 definition pulls in through <c>shared=</c>. Nothing
-    /// was read partially; the definition had simply stopped being the definition.</para>
+    /// <c>ObservationQueries</c> file the 1.16 definition pulls in through <c>shared=</c>.</para>
     ///
-    /// <para>So the type's row is read again here — through the same storage read the compile
-    /// stamp already uses (<see cref="BuildStamp"/>), not a point read through the routing, which on
-    /// a type a sync has just pruned would open the storm-breaker — and the CURRENT row is compiled.
-    /// The batch's pre-resolved set is kept only when that row declares the very queries the batch
-    /// resolved it with; when the queries moved, the type's sources are resolved again from its
-    /// current queries through <see cref="RunQuery"/> — the same bounded, truncation-checked read
-    /// the batch pass uses — and held to the same emptiness invariant
-    /// (<see cref="DiscoveryUnestablished"/>).</para>
+    /// <para>So the type's row is read again — through the same storage read the compile stamp uses
+    /// (<see cref="BuildStamp"/>), never a point read through the routing, which on a type a sync
+    /// has just pruned would open the storm-breaker — and the CURRENT row is compiled. The batch's
+    /// pre-resolved set is reused only when BOTH witnesses say it is still the set: the row declares
+    /// the very queries the batch resolved it with, and the row's own source-version record
+    /// (<see cref="NodeTypeDefinition.CurrentSourceVersions"/>, kept by the per-NodeType sources
+    /// watcher) either is absent or names exactly the versions the batch holds. Otherwise the sources
+    /// are resolved again from the current queries (<see cref="ResolveDeclared"/>), and the row is
+    /// read once more afterwards: a definition that moved AGAIN while its sources were being
+    /// resolved is not compiled.</para>
     ///
-    /// <para>Which way each "I don't know" falls, and why: a row that is gone, unreadable, or whose
-    /// read faults or times out keeps the ENUMERATED input — the verdict that always stood, and
-    /// <c>ReclassifyIfRemoved</c> still answers a pruned type after the compile. A definition that
-    /// demonstrably moved but whose new sources cannot be established is
-    /// <see cref="CompileInput.Unestablished"/>: the enumerated input is then KNOWN to be stale, so
-    /// compiling it would be a verdict about nothing.</para>
+    /// <para>🚨 <b>What this does NOT establish</b>: an atomic snapshot. Neither a row read nor a
+    /// query is a transaction, and the version record lags the files by the watcher's own latency,
+    /// so a source edited in the last instant before the compile can still be compiled at its earlier
+    /// version. That residue is self-healing — <see cref="NodeTypeDefinition.CompiledSources"/>
+    /// records what was compiled, the watcher's newer record then reads dirty, and the type rebuilds
+    /// — and a verdict it produces is the one #1214's recovery watch already exists for.</para>
+    ///
+    /// <para>Every "I don't know" is a NON-verdict, never a compile of a pair nobody can vouch for:
+    /// a re-read that faults or runs out of budget, a row that no longer reads as a
+    /// <see cref="NodeTypeDefinition"/>, a current source set that cannot be established, and a
+    /// definition that moved again are all <see cref="PreWarmStatus.TimedOut"/> ("not evaluated").
+    /// A row absent from storage is confirmed by a LISTING
+    /// (<see cref="DynamicTypePreWarmer.TypeNodeExists"/>) and then reported
+    /// <see cref="PreWarmStatus.Removed"/> WITHOUT a compile or a stamp — the stamp's
+    /// insert-if-absent would otherwise re-create the type its repository just pruned. A listing that
+    /// still names the type (a definition this storage does not hold) compiles the enumerated input,
+    /// exactly as before this re-read existed.</para>
     /// </summary>
     internal static IObservable<CompileInput> CurrentCompileInput(
         IMessageHub mesh,
         MeshNode enumerated,
         IReadOnlyList<MeshNode> resolved,
-        TimeSpan budget,
+        DateTimeOffset deadline,
         ILogger? logger)
     {
         var storage = mesh.ServiceProvider.GetService<IStorageAdapter>();
         var meshService = mesh.ServiceProvider.GetService<IMeshService>();
-        var asEnumerated = new CompileInput(enumerated, resolved);
+        // A host with nothing to re-read from: the input is the enumerated one, exactly as before.
         if (storage is null || meshService is null)
-            return Observable.Return(asEnumerated);
+            return Observable.Return(new CompileInput(enumerated, resolved));
 
         var options = mesh.JsonSerializerOptions;
         var typePath = enumerated.Path;
         var enumeratedQueries = DeclaredQueries(
             enumerated.ContentAs<NodeTypeDefinition>(options, logger), typePath);
 
-        return storage
-            .Read(typePath, options)
-            .Take(1)
-            .Timeout(budget)
-            .Select(stored => (Stored: stored, Current: stored?.ContentAs<NodeTypeDefinition>(options, logger)))
-            .Catch<(MeshNode? Stored, NodeTypeDefinition? Current), Exception>(ex =>
+        CompileInput NotEvaluated(string why) => new(enumerated, [],
+            new PreWarmOutcome(typePath, PreWarmStatus.TimedOut, why + " — not evaluated"));
+
+        return ReadRow(storage, typePath, options, deadline, logger)
+            .SelectMany(row =>
             {
-                logger?.LogWarning(ex,
-                    "BatchBake: could not re-read {TypePath} before compiling it — compiling the "
-                    + "definition the sweep enumerated, exactly as before", typePath);
-                return Observable.Return<(MeshNode?, NodeTypeDefinition?)>((null, null));
-            })
-            .DefaultIfEmpty((null, null))
-            .SelectMany(read =>
-            {
-                if (read.Stored is null || read.Current is null)
-                    return Observable.Return(asEnumerated);
+                if (row.Fault is { } fault)
+                    return Observable.Return(NotEvaluated(
+                        $"'{typePath}' could not be re-read before its compile "
+                        + $"({fault.GetType().Name}: {fault.Message})"));
+
+                if (row.Stored is null)
+                    return DynamicTypePreWarmer.TypeNodeExists(mesh, typePath, logger)
+                        .Timeout(deadline)
+                        // A listing that cannot answer keeps the type PRESENT — the direction that
+                        // never launders a real verdict (TypeNodeExists' own rule).
+                        .Catch<bool, Exception>(_ => Observable.Return(true))
+                        .Select(exists => exists
+                            ? new CompileInput(enumerated, resolved)
+                            : new CompileInput(enumerated, [], new PreWarmOutcome(
+                                typePath, PreWarmStatus.Removed,
+                                "the NodeType definition no longer exists — pruned during the sweep, so it "
+                                + "was neither compiled nor stamped (a stamp would have re-created it)")));
+
+                if (row.Definition is null)
+                    return Observable.Return(NotEvaluated(
+                        $"'{typePath}' no longer reads as a NodeTypeDefinition"));
 
                 // Typed content, always: the compiler takes the self-definition branch only for a
-                // NodeTypeDefinition, and a row served as raw JSON would otherwise be compiled as
-                // an instance of the meta-type.
-                var current = read.Stored with { Content = read.Current };
-                var currentQueries = DeclaredQueries(read.Current, typePath);
-                if (currentQueries.SetEquals(enumeratedQueries))
+                // NodeTypeDefinition, and a row served as raw JSON would otherwise be compiled as an
+                // instance of the meta-type.
+                var current = row.Stored with { Content = row.Definition };
+                var queriesMoved = !DeclaredQueries(row.Definition, typePath).SetEquals(enumeratedQueries);
+                if (!queriesMoved && VersionRecordAgrees(row.Definition, resolved))
                     return Observable.Return(new CompileInput(current, resolved));
 
                 logger?.LogInformation(
-                    "BatchBake: {TypePath}'s declared source queries MOVED since the sweep enumerated "
-                    + "it (v{Enumerated} → v{Current}) — a content update landed during the bake. "
-                    + "Compiling the current definition over the sources its own queries select: "
-                    + "{Queries}",
-                    typePath, enumerated.Version, read.Stored.Version,
-                    string.Join(" | ", currentQueries.Order(StringComparer.Ordinal)));
+                    "BatchBake: re-resolving the sources of {TypePath} before its compile — {Why} "
+                    + "(enumerated v{Enumerated}, current v{Current})",
+                    typePath,
+                    queriesMoved
+                        ? "its declared source queries moved since the sweep enumerated it"
+                        : "its own source-version record disagrees with the batch's set",
+                    enumerated.Version, row.Stored.Version);
+
                 return ResolveDeclared(
                         meshService, mesh.ServiceProvider.GetService<AccessService>(),
-                        read.Current, typePath, logger)
-                    .Select(set => new CompileInput(current, set))
-                    .Catch<CompileInput, Exception>(ex => Observable.Return(new CompileInput(
-                        current, [],
-                        $"the definition of '{typePath}' moved during the bake (v{enumerated.Version} → "
-                        + $"v{read.Stored.Version}) and the source set its current queries select could "
-                        + $"not be established ({ex.GetType().Name}: {ex.Message}) — not evaluated")));
+                        row.Definition, typePath, deadline, logger)
+                    .SelectMany(set => ReadRow(storage, typePath, options, deadline, logger)
+                        .Select(again => again is { Stored: { } stored, Definition: { } latest }
+                                         && SameCompileDefinition(latest, row.Definition, typePath, options)
+                            ? new CompileInput(stored with { Content = latest }, set)
+                            : NotEvaluated(
+                                $"'{typePath}' could not be confirmed unchanged after its sources were "
+                                + "resolved (it moved again, or its re-read failed)")))
+                    .Catch<CompileInput, Exception>(ex => Observable.Return(NotEvaluated(
+                        $"the definition of '{typePath}' moved during the bake and the source set its "
+                        + $"current queries select could not be established ({ex.GetType().Name}: {ex.Message})")));
             });
     }
+
+    /// <summary>One storage read of a type row: the row, its definition, or why neither is known.</summary>
+    private sealed record Row(MeshNode? Stored, NodeTypeDefinition? Definition, Exception? Fault);
+
+    private static IObservable<Row> ReadRow(
+        IStorageAdapter storage, string typePath, JsonSerializerOptions options,
+        DateTimeOffset deadline, ILogger? logger)
+        => Observable.Defer(() => storage.Read(typePath, options))
+            .Take(1)
+            .Timeout(deadline)
+            .Select(stored => new Row(stored, stored?.ContentAs<NodeTypeDefinition>(options, logger), null))
+            .DefaultIfEmpty(new Row(null, null, null))
+            .Catch<Row, Exception>(ex => Observable.Return(new Row(null, null, ex)));
 
     /// <summary>
     /// The expanded Source + Test queries a definition declares — the SAME expansion
@@ -837,15 +892,45 @@ internal static class NodeTypeBatchBake
             .ToImmutableHashSet(StringComparer.Ordinal);
 
     /// <summary>
+    /// Whether the row's own source-version record allows the batch's set to stand: absent (no
+    /// witness — nothing contradicts the set, as before), or naming exactly the paths and versions
+    /// the set holds (<see cref="NodeTypeDefinition.SourceVersionOf"/>, the rule both snapshots use).
+    /// </summary>
+    private static bool VersionRecordAgrees(NodeTypeDefinition current, IReadOnlyList<MeshNode> set)
+    {
+        if (current.CurrentSourceVersions is not { } record)
+            return true;
+        var nodes = set.Where(n => !string.IsNullOrEmpty(n.Path)).ToList();
+        return record.Count == nodes.Count
+            && nodes.All(n => record.TryGetValue(n.Path!, out var version)
+                              && version == NodeTypeDefinition.SourceVersionOf(n));
+    }
+
+    /// <summary>
+    /// Whether two definitions hand the compiler the same input: the same source queries, the same
+    /// <see cref="NodeTypeDefinition.Configuration"/> and the same content collections. Stamp fields
+    /// (status, versions, coordinates) move constantly and are deliberately not compared.
+    /// </summary>
+    private static bool SameCompileDefinition(
+        NodeTypeDefinition a, NodeTypeDefinition b, string typePath, JsonSerializerOptions options) =>
+        DeclaredQueries(a, typePath).SetEquals(DeclaredQueries(b, typePath))
+        && string.Equals(a.Configuration, b.Configuration, StringComparison.Ordinal)
+        && string.Equals(
+            JsonSerializer.Serialize(a.ContentCollections, options),
+            JsonSerializer.Serialize(b.ContentCollections, options),
+            StringComparison.Ordinal);
+
+    /// <summary>
     /// One type's source set from its OWN declared queries, each run through <see cref="RunQuery"/>
     /// (bounded, truncation-checked, System-scoped) — the per-type counterpart of the batch pass,
-    /// held to the same <see cref="DiscoveryUnestablished"/> invariant.
+    /// held to the same <see cref="DiscoveryUnestablished"/> invariant and to the type's deadline.
     /// </summary>
     private static IObservable<IReadOnlyList<MeshNode>> ResolveDeclared(
         IMeshService meshService,
         AccessService? accessService,
         NodeTypeDefinition def,
         string typePath,
+        DateTimeOffset deadline,
         ILogger? logger)
     {
         var queries = DeclaredQueries(def, typePath).Order(StringComparer.Ordinal).ToList();
@@ -856,7 +941,7 @@ internal static class NodeTypeBatchBake
                     .Aggregate(
                         ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
                         (all, page) => all.SetItems(page)))
-            .Timeout(DiscoveryBudget)
+            .Timeout(deadline)
             .SelectMany(all => DiscoveryUnestablished(
                     all.Count, def.Sources is { Count: > 0 }, def.CurrentSourceVersions?.Count)
                 ? Observable.Throw<IReadOnlyList<MeshNode>>(new SourceDiscoveryFailedException(

--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -701,8 +701,176 @@ internal static class NodeTypeBatchBake
     /// <see cref="NodeTypeCompilationHelpers.ApplyCompileFailure"/> — the shared field-set),
     /// storage-level under System identity. Emits exactly one <see cref="PreWarmOutcome"/> with
     /// the activation path's status vocabulary; never throws.
+    ///
+    /// <para>🚨 <b>It compiles the definition the mesh holds WHEN IT COMPILES</b>, not the one the
+    /// sweep enumerated (see <see cref="CurrentCompileInput"/>). The two differ whenever a module
+    /// update lands during the sweep, and compiling the enumerated one against a source set resolved
+    /// later hands Roslyn a tear of two contents — measured on memex.systemorph.com 2026-09-11, where
+    /// the Hosting 1.15 definition of <c>Hosting/Issue</c> (no <c>shared=</c> entry) was compiled
+    /// over its 1.16 source files and <c>CS0103 'ObservationQueries'</c> held a rollout for ~30
+    /// minutes.</para>
     /// </summary>
     public static IObservable<PreWarmOutcome> BakeOne(
+        IMessageHub mesh,
+        MeshNode typeNode,
+        IReadOnlyList<MeshNode> sources,
+        TimeSpan budget,
+        ILogger? logger)
+        => CurrentCompileInput(mesh, typeNode, sources, budget, logger)
+            .SelectMany(input => input.Unestablished is { } reason
+                // The definition MOVED and its new source set could not be established. Compiling
+                // the enumerated input instead would be a verdict about content that no longer
+                // exists, so this is "not evaluated" — the same non-verdict an unestablished
+                // discovery earns everywhere else (#1218) — never a CompileError.
+                ? Observable.Return(new PreWarmOutcome(typeNode.Path, PreWarmStatus.TimedOut, reason))
+                : BakeResolved(mesh, input.Node, input.Sources, budget, logger));
+
+    /// <summary>
+    /// What <see cref="BakeOne"/> compiles: ONE definition and the source set ITS OWN queries select.
+    /// <paramref name="Unestablished"/> names why no such pair could be formed.
+    /// </summary>
+    internal sealed record CompileInput(
+        MeshNode Node, IReadOnlyList<MeshNode> Sources, string? Unestablished = null);
+
+    /// <summary>
+    /// 🚨 <b>The compile input, re-read at the moment of the compile.</b>
+    ///
+    /// <para>The sweep enumerates every definition ONCE, at its start, and the batched discovery
+    /// pass resolves source sets from those enumerated definitions some time later; a sequential
+    /// bake of ~200 types then reaches each type minutes after that. A module update landing inside
+    /// that window moves the definition AND its files, and pairing the enumerated definition with
+    /// the later files is neither the old content nor the new one. On memex.systemorph.com
+    /// (2026-09-11, a pod started 18:50Z) Hosting 1.16 landed between 18:53:04Z and 18:53:55Z: the
+    /// sweep had enumerated <c>Hosting/Issue</c> at v458 — no declared sources — and compiled it
+    /// ~18:55Z over a set that already held the 1.16 <c>FleetWatch</c>, which calls the
+    /// <c>ObservationQueries</c> file the 1.16 definition pulls in through <c>shared=</c>. Nothing
+    /// was read partially; the definition had simply stopped being the definition.</para>
+    ///
+    /// <para>So the type's row is read again here — through the same storage read the compile
+    /// stamp already uses (<see cref="BuildStamp"/>), not a point read through the routing, which on
+    /// a type a sync has just pruned would open the storm-breaker — and the CURRENT row is compiled.
+    /// The batch's pre-resolved set is kept only when that row declares the very queries the batch
+    /// resolved it with; when the queries moved, the type's sources are resolved again from its
+    /// current queries through <see cref="RunQuery"/> — the same bounded, truncation-checked read
+    /// the batch pass uses — and held to the same emptiness invariant
+    /// (<see cref="DiscoveryUnestablished"/>).</para>
+    ///
+    /// <para>Which way each "I don't know" falls, and why: a row that is gone, unreadable, or whose
+    /// read faults or times out keeps the ENUMERATED input — the verdict that always stood, and
+    /// <c>ReclassifyIfRemoved</c> still answers a pruned type after the compile. A definition that
+    /// demonstrably moved but whose new sources cannot be established is
+    /// <see cref="CompileInput.Unestablished"/>: the enumerated input is then KNOWN to be stale, so
+    /// compiling it would be a verdict about nothing.</para>
+    /// </summary>
+    internal static IObservable<CompileInput> CurrentCompileInput(
+        IMessageHub mesh,
+        MeshNode enumerated,
+        IReadOnlyList<MeshNode> resolved,
+        TimeSpan budget,
+        ILogger? logger)
+    {
+        var storage = mesh.ServiceProvider.GetService<IStorageAdapter>();
+        var meshService = mesh.ServiceProvider.GetService<IMeshService>();
+        var asEnumerated = new CompileInput(enumerated, resolved);
+        if (storage is null || meshService is null)
+            return Observable.Return(asEnumerated);
+
+        var options = mesh.JsonSerializerOptions;
+        var typePath = enumerated.Path;
+        var enumeratedQueries = DeclaredQueries(
+            enumerated.ContentAs<NodeTypeDefinition>(options, logger), typePath);
+
+        return storage
+            .Read(typePath, options)
+            .Take(1)
+            .Timeout(budget)
+            .Select(stored => (Stored: stored, Current: stored?.ContentAs<NodeTypeDefinition>(options, logger)))
+            .Catch<(MeshNode? Stored, NodeTypeDefinition? Current), Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "BatchBake: could not re-read {TypePath} before compiling it — compiling the "
+                    + "definition the sweep enumerated, exactly as before", typePath);
+                return Observable.Return<(MeshNode?, NodeTypeDefinition?)>((null, null));
+            })
+            .DefaultIfEmpty((null, null))
+            .SelectMany(read =>
+            {
+                if (read.Stored is null || read.Current is null)
+                    return Observable.Return(asEnumerated);
+
+                // Typed content, always: the compiler takes the self-definition branch only for a
+                // NodeTypeDefinition, and a row served as raw JSON would otherwise be compiled as
+                // an instance of the meta-type.
+                var current = read.Stored with { Content = read.Current };
+                var currentQueries = DeclaredQueries(read.Current, typePath);
+                if (currentQueries.SetEquals(enumeratedQueries))
+                    return Observable.Return(new CompileInput(current, resolved));
+
+                logger?.LogInformation(
+                    "BatchBake: {TypePath}'s declared source queries MOVED since the sweep enumerated "
+                    + "it (v{Enumerated} → v{Current}) — a content update landed during the bake. "
+                    + "Compiling the current definition over the sources its own queries select: "
+                    + "{Queries}",
+                    typePath, enumerated.Version, read.Stored.Version,
+                    string.Join(" | ", currentQueries.Order(StringComparer.Ordinal)));
+                return ResolveDeclared(
+                        meshService, mesh.ServiceProvider.GetService<AccessService>(),
+                        read.Current, typePath, logger)
+                    .Select(set => new CompileInput(current, set))
+                    .Catch<CompileInput, Exception>(ex => Observable.Return(new CompileInput(
+                        current, [],
+                        $"the definition of '{typePath}' moved during the bake (v{enumerated.Version} → "
+                        + $"v{read.Stored.Version}) and the source set its current queries select could "
+                        + $"not be established ({ex.GetType().Name}: {ex.Message}) — not evaluated")));
+            });
+    }
+
+    /// <summary>
+    /// The expanded Source + Test queries a definition declares — the SAME expansion
+    /// <see cref="ResolveSources(IMeshService, AccessService, IReadOnlyDictionary{string, NodeTypeDefinition}, IReadOnlyCollection{string}, ILogger)"/>
+    /// and the compiler apply, so "the queries moved" means exactly "a different set would be selected".
+    /// </summary>
+    private static ImmutableHashSet<string> DeclaredQueries(NodeTypeDefinition? def, string typePath) =>
+        CodeQueryResolver
+            .ExpandAll(def?.Sources, CodeQueryResolver.DefaultSources, typePath)
+            .Concat(CodeQueryResolver.ExpandAll(def?.Tests, CodeQueryResolver.DefaultTests, typePath))
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+    /// <summary>
+    /// One type's source set from its OWN declared queries, each run through <see cref="RunQuery"/>
+    /// (bounded, truncation-checked, System-scoped) — the per-type counterpart of the batch pass,
+    /// held to the same <see cref="DiscoveryUnestablished"/> invariant.
+    /// </summary>
+    private static IObservable<IReadOnlyList<MeshNode>> ResolveDeclared(
+        IMeshService meshService,
+        AccessService? accessService,
+        NodeTypeDefinition def,
+        string typePath,
+        ILogger? logger)
+    {
+        var queries = DeclaredQueries(def, typePath).Order(StringComparer.Ordinal).ToList();
+        return accessService.RunAsSystem(
+                () => queries
+                    .Select(q => RunQuery(meshService, q, logger, discovery: null))
+                    .Concat()
+                    .Aggregate(
+                        ImmutableDictionary<string, MeshNode>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
+                        (all, page) => all.SetItems(page)))
+            .Timeout(DiscoveryBudget)
+            .SelectMany(all => DiscoveryUnestablished(
+                    all.Count, def.Sources is { Count: > 0 }, def.CurrentSourceVersions?.Count)
+                ? Observable.Throw<IReadOnlyList<MeshNode>>(new SourceDiscoveryFailedException(
+                    $"the source queries of '{typePath}' resolved an EMPTY set with no corroborating "
+                    + "empty snapshot"))
+                : Observable.Return<IReadOnlyList<MeshNode>>(all.Values
+                    .OrderBy(n => n.Path, StringComparer.Ordinal)
+                    .ToList()));
+    }
+
+    /// <summary>
+    /// <see cref="BakeOne"/> once its input is settled: the compile, the stamp and the outcome.
+    /// </summary>
+    private static IObservable<PreWarmOutcome> BakeResolved(
         IMessageHub mesh,
         MeshNode typeNode,
         IReadOnlyList<MeshNode> sources,

--- a/test/MeshWeaver.Hosting.Test/ABakeCompilesTheDefinitionItResolvedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ABakeCompilesTheDefinitionItResolvedTest.cs
@@ -1,0 +1,219 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>The batch bake compiles the definition the mesh holds WHEN IT COMPILES, never the one it
+/// enumerated minutes earlier.</b> Measured on <c>memex.systemorph.com</c>, 2026-09-11, new pod on
+/// <c>3.0.0-ci.8372</c> (started 18:50Z) while the Hosting module moved 1.15 → 1.16:
+///
+/// <code>
+/// v458 18:53:04Z  Hosting/Issue  sources: (none — the defaults)        module 1.15
+/// v462 18:53:51Z  Hosting/Issue  sources: [namespace:Source scope:subtree,
+///                                         shared=@Hosting/InstanceAction/Source/ObservationQueries]  module 1.16
+/// ~18:55Z  BatchBake: Executed source queries (2): namespace:Hosting/Issue/Source … / …/Test …
+///          Matched: … Hosting/Issue/Source/FleetWatch …    (FleetWatch is the 1.16 file that calls ObservationQueries)
+///          CS0103: The name 'ObservationQueries' does not exist in the current context
+///          → CompileError on a previously healthy type → "1 NodeType(s) regressed" → readiness refused ~30 min
+/// </code>
+///
+/// <para>The sweep enumerated every NodeType definition ONCE, at its start, and handed that
+/// enumeration-time node to <see cref="NodeTypeBatchBake.BakeOne"/> together with a source set the
+/// batched discovery pass resolved LATER. So Roslyn was handed neither the 1.15 content nor the 1.16
+/// content, but a tear of the two: the 1.15 definition (no <c>shared=</c> entry) over the 1.16
+/// source files (a <c>FleetWatch</c> that needs the shared file). Nothing read anything partially and
+/// no resolver dropped anything — the definition at v458 genuinely declared no sources; it had simply
+/// stopped being the definition by the time it was compiled. A freshly started pod on the same image
+/// baked the same type cleanly.</para>
+///
+/// <para>Every case runs the sweep's own code: the enumeration through
+/// <see cref="DynamicTypePreWarmer.DynamicTypesOf"/>, discovery through
+/// <see cref="NodeTypeBatchBake.ResolveSources(IMeshService, AccessService, IReadOnlyDictionary{string, NodeTypeDefinition}, IReadOnlyCollection{string}, Microsoft.Extensions.Logging.ILogger)"/>,
+/// the compile through <see cref="NodeTypeBatchBake.BakeOne"/> and the real Roslyn pipeline. Nothing
+/// is mocked. The controls pin both directions: a definition that did not move still compiles from
+/// the batch's own set, and a compile error — whether or not the definition moved — still gates.</para>
+/// </summary>
+public class ABakeCompilesTheDefinitionItResolvedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string OwnSource = "namespace:Source scope:subtree";
+    private static readonly TimeSpan PerTypeBudget = TimeSpan.FromMinutes(3);
+
+    private const string SelfContained =
+        "public static class ConsumerApi { public static int Answer() => 1; }";
+    private const string CallsTheSharedFile =
+        "public static class ConsumerApi { public static int Answer() => LibAnswers.Answer(); }";
+    private const string CallsWhatNothingDeclares =
+        "public static class ConsumerApi { public static int Answer() => LibAnswers.NotDeclaredAnywhere(); }";
+
+    private readonly string suffix = Guid.NewGuid().ToString("N")[..8];
+    private string LibPath => $"{TestPartition}/Lib{suffix}";
+    private string TypePath => $"{TestPartition}/Consumer{suffix}";
+    private string MainPath => $"{TypePath}/Source/Main";
+    private string SharedPath => $"{LibPath}/Source/Answers";
+    private string SharedEntry => $"shared=@{SharedPath}";
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private MeshNode TypeNode(string id, IReadOnlyList<string>? sources) => new(id, TestPartition)
+    {
+        NodeType = MeshNode.NodeTypePath,
+        Name = id,
+        State = MeshNodeState.Active,
+        Content = new NodeTypeDefinition { Configuration = "config => config", Sources = sources },
+    };
+
+    private static MeshNode Code(string id, string ns, string code) => new(id, ns)
+    {
+        NodeType = "Code",
+        State = MeshNodeState.Active,
+        Content = new CodeConfiguration { Language = "csharp", Code = code },
+    };
+
+    /// <summary>A library whose ONE shared file the consumer may pull in, and the consumer itself.</summary>
+    private async Task Seed(string consumerCode, IReadOnlyList<string>? consumerSources)
+    {
+        foreach (var node in new[]
+                 {
+                     TypeNode($"Lib{suffix}", null),
+                     Code("Answers", $"{LibPath}/Source",
+                         "public static class LibAnswers { public static int Answer() => 42; }"),
+                     TypeNode($"Consumer{suffix}", consumerSources),
+                     Code("Main", $"{TypePath}/Source", consumerCode),
+                 })
+            await MeshService.CreateNode(node).Take(1)
+                .Should().Within(TestTimeouts.Convergence).Emit($"{node.Path} must exist before the sweep reads it");
+    }
+
+    /// <summary>
+    /// The sweep's enumeration, exactly as <c>WarmDynamicTypes</c> takes it — a listing typed through
+    /// <see cref="DynamicTypePreWarmer.DynamicTypesOf"/> — waited on until the listing shows the state
+    /// under test (the index trails the store, so "listed" implies "stored").
+    /// </summary>
+    private async Task<DynamicTypePreWarmer.DynamicTypes> Enumerate(Func<NodeTypeDefinition, bool> state, string because)
+        => await Observable.Interval(200.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => MeshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{TypePath}").AsSystem())
+                .Take(1))
+            .Select(change => DynamicTypePreWarmer.DynamicTypesOf(change.Items, Mesh.JsonSerializerOptions, null))
+            .Where(types => types.Definitions.TryGetValue(TypePath, out var d) && d is not null && state(d))
+            .FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit(because);
+
+    private async Task UntilListed(string path, string marker)
+        => await Observable.Interval(200.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => MeshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}").AsSystem())
+                .Take(1))
+            .Where(change => change.Items.Any(n =>
+                n.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)?.Code?.Contains(marker) == true))
+            .FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit($"the discovery pass must be able to see '{marker}' in {path}");
+
+    /// <summary>The module update, landing in the order a repository sync lands it: the file, then the definition.</summary>
+    private async Task LandTheUpdate(string newCode, IReadOnlyList<string> newSources)
+    {
+        var workspace = Mesh.GetWorkspace();
+        await workspace.GetMeshNodeStream(MainPath)
+            .Update(node => node with { Content = new CodeConfiguration { Language = "csharp", Code = newCode } })
+            .Should().Within(TestTimeouts.Convergence).Emit("the source half of the update lands");
+        await workspace.GetMeshNodeStream(TypePath)
+            .Update(node => node with
+            {
+                Content = node.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)! with { Sources = newSources },
+            })
+            .Should().Within(TestTimeouts.Convergence).Emit("the definition half of the update lands");
+    }
+
+    /// <summary>The sweep's batch pass for this one type: discovery from the ENUMERATED definitions, then the compile.</summary>
+    private async Task<(IReadOnlyList<MeshNode> Batch, PreWarmOutcome Outcome)> Bake(
+        DynamicTypePreWarmer.DynamicTypes enumerated)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var sets = await NodeTypeBatchBake
+            .ResolveSources(MeshService, access, enumerated.Definitions, [TypePath], null)
+            .Should().Within(TestTimeouts.Convergence).Emit("the batched discovery pass must establish the source sets");
+        var batch = sets[TypePath];
+        var outcome = await NodeTypeBatchBake
+            .BakeOne(Mesh, enumerated.Nodes[TypePath], batch, PerTypeBudget, null)
+            .Should().Within(PerTypeBudget + TimeSpan.FromMinutes(1)).Emit("BakeOne always reaches exactly one outcome");
+        Output.WriteLine("batch set: {0}", string.Join(", ", batch.Select(n => n.Path)));
+        Output.WriteLine("outcome: {0} — {1}", outcome.Status, outcome.Detail ?? "(no detail)");
+        return (batch, outcome);
+    }
+
+    /// <summary>
+    /// 🚨 THE REPRO. The definition moves between the enumeration and the compile — as Hosting/Issue's
+    /// did — and the verdict must be the one the CURRENT content earns: a clean compile when it is
+    /// sound, and still a gating <see cref="PreWarmStatus.CompileError"/> when it is not.
+    /// </summary>
+    [Theory(Timeout = 300_000)]
+    [InlineData(CallsTheSharedFile, PreWarmStatus.Compiled)]
+    [InlineData(CallsWhatNothingDeclares, PreWarmStatus.CompileError)]
+    public async Task ADefinitionThatMovedDuringTheSweep_IsJudgedAsItNowStands(string newCode, PreWarmStatus expected)
+    {
+        await Seed(SelfContained, consumerSources: null);
+        var enumerated = await Enumerate(d => d.Sources is null,
+            "the sweep enumerates the type BEFORE the module update, with no declared sources");
+
+        await LandTheUpdate(newCode, [OwnSource, SharedEntry]);
+        await UntilListed(MainPath, newCode == CallsTheSharedFile ? "LibAnswers.Answer()" : "NotDeclaredAnywhere");
+        await Enumerate(d => d.Sources?.Contains(SharedEntry) == true,
+            "the updated definition is stored before the compile runs — as v471 was, ~1 min before the pod compiled");
+
+        var (batch, outcome) = await Bake(enumerated);
+
+        batch.Select(n => n.Path).Should().Contain(MainPath).And.NotContain(SharedPath,
+            "precondition — the pass selected the set with the ENUMERATED queries, which never named the shared "
+            + "file; this is the half of the tear the compile has to see past");
+        outcome.Status.Should().Be(expected,
+            $"the compile must judge the definition the mesh holds now, not the enumeration's ({outcome.Detail})");
+        if (expected is PreWarmStatus.CompileError)
+            outcome.Detail.Should().Contain("NotDeclaredAnywhere",
+                "the gating verdict names the genuine defect, not a phantom about the shared file");
+    }
+
+    /// <summary>🚨 CONTROL — a definition that did NOT move compiles from the batch's own set, as it always has.</summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ADefinitionThatDidNotMove_CompilesFromTheBatchSet()
+    {
+        await Seed(CallsTheSharedFile, [OwnSource, SharedEntry]);
+        await UntilListed(MainPath, "LibAnswers.Answer()");
+        var enumerated = await Enumerate(d => d.Sources?.Contains(SharedEntry) == true,
+            "the sweep enumerates the already-updated definition");
+
+        var (batch, outcome) = await Bake(enumerated);
+
+        batch.Select(n => n.Path).Should().Contain(new[] { MainPath, SharedPath },
+            "the batch resolves the single-node shared= entry through its path: leg");
+        outcome.Status.Should().Be(PreWarmStatus.Compiled, outcome.Detail ?? "(no detail)");
+    }
+
+    /// <summary>🚨 CONTROL — a genuine compile error on a definition that did not move still gates.</summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AGenuineCompileError_StillGates()
+    {
+        await Seed(CallsWhatNothingDeclares, [OwnSource, SharedEntry]);
+        await UntilListed(MainPath, "NotDeclaredAnywhere");
+        var enumerated = await Enumerate(d => d.Sources?.Contains(SharedEntry) == true,
+            "the sweep enumerates the definition it compiles");
+
+        var (_, outcome) = await Bake(enumerated);
+
+        outcome.Status.Should().Be(PreWarmStatus.CompileError, outcome.Detail ?? "(no detail)");
+        outcome.Detail.Should().Contain("NotDeclaredAnywhere");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/ABakeCompilesTheDefinitionItResolvedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ABakeCompilesTheDefinitionItResolvedTest.cs
@@ -45,7 +45,8 @@ namespace MeshWeaver.Hosting.Test;
 /// <see cref="NodeTypeBatchBake.ResolveSources(IMeshService, AccessService, IReadOnlyDictionary{string, NodeTypeDefinition}, IReadOnlyCollection{string}, Microsoft.Extensions.Logging.ILogger)"/>,
 /// the compile through <see cref="NodeTypeBatchBake.BakeOne"/> and the real Roslyn pipeline. Nothing
 /// is mocked. The controls pin both directions: a definition that did not move still compiles from
-/// the batch's own set, and a compile error — whether or not the definition moved — still gates.</para>
+/// the batch's own set, and a compile error — whether or not the definition moved — still gates.
+/// The last three cases pin the review's findings on the fix (#4051).</para>
 /// </summary>
 public class ABakeCompilesTheDefinitionItResolvedTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -140,15 +141,15 @@ public class ABakeCompilesTheDefinitionItResolvedTest(ITestOutputHelper output) 
 
     /// <summary>The sweep's batch pass for this one type: discovery from the ENUMERATED definitions, then the compile.</summary>
     private async Task<(IReadOnlyList<MeshNode> Batch, PreWarmOutcome Outcome)> Bake(
-        DynamicTypePreWarmer.DynamicTypes enumerated)
+        DynamicTypePreWarmer.DynamicTypes enumerated, TimeSpan? budget = null)
     {
         var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
         var sets = await NodeTypeBatchBake
             .ResolveSources(MeshService, access, enumerated.Definitions, [TypePath], null)
             .Should().Within(TestTimeouts.Convergence).Emit("the batched discovery pass must establish the source sets");
-        var batch = sets[TypePath];
+        var batch = sets.TryGetValue(TypePath, out var set) ? set : [];
         var outcome = await NodeTypeBatchBake
-            .BakeOne(Mesh, enumerated.Nodes[TypePath], batch, PerTypeBudget, null)
+            .BakeOne(Mesh, enumerated.Nodes[TypePath], batch, budget ?? PerTypeBudget, null)
             .Should().Within(PerTypeBudget + TimeSpan.FromMinutes(1)).Emit("BakeOne always reaches exactly one outcome");
         Output.WriteLine("batch set: {0}", string.Join(", ", batch.Select(n => n.Path)));
         Output.WriteLine("outcome: {0} — {1}", outcome.Status, outcome.Detail ?? "(no detail)");
@@ -215,5 +216,106 @@ public class ABakeCompilesTheDefinitionItResolvedTest(ITestOutputHelper output) 
 
         outcome.Status.Should().Be(PreWarmStatus.CompileError, outcome.Detail ?? "(no detail)");
         outcome.Detail.Should().Contain("NotDeclaredAnywhere");
+    }
+
+    // ── The review's findings (#4051) ──────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The same queries are NOT the same set. A source edited after the batch resolved it — the
+    /// type's queries untouched — is compiled as it now stands once the type's own source-version
+    /// record has moved: the batch holds the broken edit it saw, the mesh holds the repair.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ASourceEditedUnderUnchangedQueries_IsCompiledAsItNowStands()
+    {
+        await Seed(CallsWhatNothingDeclares, consumerSources: null);
+        await UntilListed(MainPath, "NotDeclaredAnywhere");
+        var enumerated = await Enumerate(d => d.Sources is null, "the sweep enumerates the type");
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var sets = await NodeTypeBatchBake
+            .ResolveSources(MeshService, access, enumerated.Definitions, [TypePath], null)
+            .Should().Within(TestTimeouts.Convergence).Emit("the batch resolves the broken edit");
+        var batch = sets[TypePath];
+
+        // The repair lands under the SAME queries, after the batch took its set.
+        await Mesh.GetWorkspace().GetMeshNodeStream(MainPath)
+            .Update(node => node with { Content = new CodeConfiguration { Language = "csharp", Code = SelfContained } })
+            .Should().Within(TestTimeouts.Convergence).Emit("the repair lands");
+        var repaired = await Observable.Interval(200.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => MeshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{MainPath}").AsSystem()).Take(1))
+            .Select(change => change.Items.FirstOrDefault(n =>
+                n.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)?.Code == SelfContained))
+            .Where(n => n is not null)
+            .FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit("the repair is listed");
+        var repairedVersion = NodeTypeDefinition.SourceVersionOf(repaired!);
+
+        // The type's own sources watcher records the repair — its hub activated by reading its stream.
+        using var activation = Mesh.GetWorkspace().GetMeshNodeStream(TypePath).Subscribe(
+            _ => { }, ex => Output.WriteLine("type stream faulted: {0}", ex.Message));
+        await Enumerate(d => d.CurrentSourceVersions is { } record
+                && record.TryGetValue(MainPath, out var v) && v == repairedVersion,
+            "the type's source-version record names the repair before the compile runs");
+
+        batch.Select(n => n.ContentAs<CodeConfiguration>(Mesh.JsonSerializerOptions)?.Code)
+            .Should().Contain(CallsWhatNothingDeclares, "precondition — the batch still holds the broken edit");
+        var outcome = await NodeTypeBatchBake
+            .BakeOne(Mesh, enumerated.Nodes[TypePath], batch, PerTypeBudget, null)
+            .Should().Within(PerTypeBudget + TimeSpan.FromMinutes(1)).Emit("BakeOne always reaches exactly one outcome");
+        Output.WriteLine("outcome: {0} — {1}", outcome.Status, outcome.Detail ?? "(no detail)");
+
+        outcome.Status.Should().Be(PreWarmStatus.Compiled,
+            $"the record says the source moved, so the batch's copy is not the set ({outcome.Detail})");
+    }
+
+    /// <summary>
+    /// 🚨 A moved definition whose CURRENT source set cannot be established is "not evaluated" —
+    /// never a compile of the stale pair and never a gating verdict. Driven by the per-type deadline:
+    /// every discovery query waits out a one-second quiet window, so an 800 ms budget cannot
+    /// establish the set, structurally rather than by timing luck.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AMovedDefinitionWhoseSourcesCannotBeEstablished_IsNotEvaluated()
+    {
+        await Seed(SelfContained, consumerSources: null);
+        var enumerated = await Enumerate(d => d.Sources is null, "the sweep enumerates the type first");
+        await LandTheUpdate(CallsTheSharedFile, [OwnSource, SharedEntry]);
+        await UntilListed(MainPath, "LibAnswers.Answer()");
+        await Enumerate(d => d.Sources?.Contains(SharedEntry) == true, "the moved definition is stored");
+
+        var (_, outcome) = await Bake(enumerated, TimeSpan.FromMilliseconds(800));
+
+        outcome.Status.Should().Be(PreWarmStatus.TimedOut,
+            $"an unestablished input is not a verdict about the code ({outcome.Detail})");
+        outcome.Detail.Should().Contain("not evaluated");
+    }
+
+    /// <summary>
+    /// 🚨 A type its repository pruned during the sweep is <see cref="PreWarmStatus.Removed"/>, and
+    /// the bake does NOT write it back: the stamp's insert-if-absent used to re-create it.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ATypePrunedDuringTheSweep_IsRemoved_AndNotRecreated()
+    {
+        await MeshService.CreateNode(TypeNode($"Consumer{suffix}", null)).Take(1)
+            .Should().Within(TestTimeouts.Convergence).Emit("the type exists when the sweep enumerates it");
+        var enumerated = await Enumerate(_ => true, "the sweep enumerates the type");
+
+        await MeshService.DeleteNode(TypePath).Take(1).DefaultIfEmpty()
+            .Should().Within(TestTimeouts.Convergence).Emit("the repository prunes the type");
+        await Observable.Interval(200.Milliseconds()).StartWith(0L)
+            .SelectMany(_ => DynamicTypePreWarmer.TypeNodeExists(Mesh, TypePath, null).Take(1))
+            .Where(exists => !exists)
+            .FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit("the prune is visible to a listing");
+
+        var (_, outcome) = await Bake(enumerated);
+
+        outcome.Status.Should().Be(PreWarmStatus.Removed, outcome.Detail ?? "(no detail)");
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var row = await storage.Read(TypePath, Mesh.JsonSerializerOptions).Take(1).DefaultIfEmpty()
+            .Should().Within(TestTimeouts.Convergence).Emit("the storage read answers");
+        row.Should().BeNull("the bake must not re-create a type its repository pruned");
     }
 }


### PR DESCRIPTION
## What happened

memex.systemorph.com's rollout to `3.0.0-ci.8372` was held for about 30 minutes. A new pod's bake gate refused readiness: `1 NodeType(s) regressed on this image: Hosting/Issue` (`CS0103: The name 'ObservationQueries' does not exist`).

The failing compile had **no `shared=` entry**. It executed exactly two queries (`namespace:Hosting/Issue/Source …` and `…/Test …`), yet its source set already held the Hosting 1.16 file `FleetWatch`, which calls `ObservationQueries`.

## The mechanism: the compile input was torn, the resolver was fine

The mesh's own version history shows `Hosting/Issue` moving **during that pod's bake**:

| When (UTC) | `Hosting/Issue` |
|---|---|
| 18:53:04, v458 | no `sources` (the defaults); module 1.15; fingerprint `ca01bf82…`, `AdoptedVerified` |
| 18:53:51, v462 | `sources` = its own `Source` + `shared=@Hosting/InstanceAction/Source/ObservationQueries`; module 1.16; `FleetWatch` in the source set |
| about 18:55, the pod's batch compile | the v458 definition compiled over a set holding `FleetWatch` → CS0103 |

The sweep enumerates every definition once, at its start (`DynamicTypePreWarmer.cs:415`). The batched discovery pass resolves source sets from those enumerated definitions later. Then `DynamicTypePreWarmer.cs:964-965` handed the **enumerated** node to `NodeTypeBatchBake.BakeOne`, which compiled it (`NodeTypeBatchBake.cs:808`) against the **later** set.

Nothing was read partially, and no resolver dropped the `shared=` entry:
- v458 genuinely declared no sources.
- The #2813 decline of the 1.16 bundle was correct when it was taken.
- A fresh pod on the same image baked the type cleanly.

**This is not a regression in `45306a33e..74d4c8527`.** The repro fails identically on both ends.

## The fix

`NodeTypeBatchBake.CurrentCompileInput` re-reads the type's row immediately before the compile and compiles that row, with typed content. It uses the same `IStorageAdapter.Read` the compile stamp uses, never a routed point read.

- **When the batch set is reused.** Only when both witnesses agree. The declared queries must be unchanged, and the row's `CurrentSourceVersions` record must either be absent or name exactly the batch's versions.
- **When it is not.** The sources are resolved again through the batch's own bounded, truncation-checked `RunQuery`, under the same `DiscoveryUnestablished` invariant. The row is then read once more.
- **One deadline** covers the re-read, any re-resolution, the compile and the stamp. The compile gets only the time that is left.
- **Every input nobody can vouch for is `TimedOut`** ("not evaluated"), never a compile of the stale pair. That covers:
  - a re-read that faults or runs out of budget;
  - a row that no longer reads as a `NodeTypeDefinition`;
  - a current source set that cannot be established;
  - a definition that moved again after its sources were resolved.
- **A row absent from storage, confirmed by a listing, is `Removed`**, with no compile and no stamp. The stamp's insert-if-absent used to re-create the pruned type.
- **Not an atomic snapshot.** Neither a row read nor a query is a transaction, so a source edited in the last instant can still be compiled at its earlier version. That residue heals itself through `CompiledSources` and the dirty check, and the docs say so.

## Evidence

`ABakeCompilesTheDefinitionItResolvedTest` (MeshWeaver.Hosting.Test) runs the sweep's own enumeration (`DynamicTypesOf`), discovery (`ResolveSources`) and compile (`BakeOne`, real Roslyn) against a monolith mesh. Nothing is mocked.

| Case | `45306a33e` | `main` `ffe6a6010` (pre-fix) | this branch |
|---|---|---|---|
| definition moves mid-sweep, sound content → `Compiled` | ❌ CS0103 `LibAnswers` | ❌ same | ✅ |
| definition moves mid-sweep, broken content → `CompileError` naming the real defect | ❌ phantom CS0103 | ❌ same | ✅ |
| source edited under UNCHANGED queries, version record moved → `Compiled` | n/a | ❌ CS0103 | ✅ |
| moved definition, current set not establishable within the deadline → `TimedOut` | n/a | ❌ `CompileError` | ✅ |
| type pruned during the sweep → `Removed`, not re-created | n/a | ❌ "found Compiled" (compiled + stamped a pruned type) | ✅ |
| control: unmoved definition compiles from the batch set | ✅ | ✅ | ✅ |
| control: a genuine compile error still gates | ✅ | ✅ | ✅ |

The neighbouring bake and gate tests all pass (36): `EmptySourceSetNeedsAWitnessTest`, `ARetiredNodeTypeIsNotARegressionTest`, `SourceDiscoveryChunkTimingTest`, `BakeCensusRegistryTest`, `RefusedProcessDoesNotJoinTheMeshTest`, `DeclaredSourcesMissingIsNotAnImageVerdictTest`.

Builds: I ran `dotnet build -c Release -p:CIRun=true -warnaserror` separately on `test/MeshWeaver.Hosting.Test` (which builds `src/MeshWeaver.Hosting`) and on `src/MeshWeaver.Documentation`. Both reported 0 Warning(s) and 0 Error(s).

## Residue, named rather than closed

A mesh that is itself torn when the compile runs (the file has landed, its definition has not) still earns a `CompileError`, because that is what the content is at that instant. Its cure remains #1214's `WatchForRecovery`. That watch may be starved when the type's hub lives on a previous-generation pod. That would fit this incident's hold, but it was **not** established here.

## Declarations

- **Public surface:** unchanged. `BakeOne`'s signature is the same; only `internal`/`private` members were added. No public type or member is removed, and no interface member is added.
- **Pairs-with:** none. Nothing outside core is affected.
- **i18n:** no catalog key is added or changed.

**Docs:**
- `NodeTypeCompilation.md`: a new section.
- `CrossRepoPairGate.md`: this is recorded as a shape-7 suspect that was **not** shape 7, with the discriminating read to take before bisecting.
- What's New entry (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
