### PR TITLE
ci(compile-check): --modules selects the atomic unit; the ratchet judges it alone

### DIFF
--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -133,8 +133,13 @@ def discover_nodetypes(root: Path):
 # ── scope: the atomic unit the caller asks for ───────────────────────────────────────────────────
 
 def known_packages(root: Path) -> list:
-    """Every top-level folder that is a node repo — the same set `discover_nodetypes` walks."""
-    return sorted(d.name for d in root.iterdir() if d.is_dir() and d.name not in SKIP)
+    """Every PACKAGE: a top-level folder carrying an `index.json` — the node-repo package
+    convention (`node-repo-scope.py`, `affected-modules.py`), NOT every non-SKIP folder
+    `discover_nodetypes` walks. A checkout also carries `clients/`, `tools/`, `devtools/` … and
+    accepting one of those as "known" would let a caller name a non-package, compile zero
+    NodeTypes and read a green verdict (Copilot on MeshWeaver#4052)."""
+    return sorted(d.name for d in root.iterdir()
+                  if d.is_dir() and d.name not in SKIP and (d / "index.json").is_file())
 
 
 def parse_modules(arg: "str | None", known) -> tuple:
@@ -956,6 +961,12 @@ def _self_test() -> int:
                 (fixture / pkg / f"{t}.json").write_text(
                     '{"content": {"$type": "NodeTypeDefinition"}}', encoding="utf-8")
         (fixture / "scripts").mkdir()          # a SKIP dir is never a package
+        # A non-package folder a checkout carries anyway (clients/, tools/, devtools/): it has no
+        # index.json, so it is not a package even though discovery walks it — and naming it must
+        # be refused, or an empty unit reads as a green verdict.
+        (fixture / "clients").mkdir()
+        (fixture / "clients" / "Stray.json").write_text(
+            '{"content": {"$type": "NodeTypeDefinition"}}', encoding="utf-8")
         global ROOT
         saved_root = ROOT
         ROOT = fixture
@@ -982,6 +993,10 @@ def _self_test() -> int:
             sel, err = parse_modules("scripts", pkgs)
             if sel is not None or not err:
                 scope_failures.append("  unknown id: a SKIP dir must not be selectable as a package")
+            sel, err = parse_modules("clients", pkgs)
+            if sel is not None or not err or "clients" not in err:
+                scope_failures.append("  unknown id: a folder with no index.json is not a package, "
+                                      f"even though discovery walks it — got ({sel!r}, {err!r})")
             # an empty list is refused — never 'compile nothing' silently
             for empty in ("", ",", " , "):
                 sel, err = parse_modules(empty, pkgs)

--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -28,6 +28,15 @@ Ratcheting allowlist (`scripts/compile-check.allow`): the tree carries KNOWN UWD
 debt. An allowlisted type that still fails is reported as known-debt (no gate fail); one that now
 compiles clean FAILS the gate ("remove it — it compiles now") so debt only ever shrinks. A
 NON-allowlisted failure fails the gate — a real regression. Exit non-zero iff any gate-fail.
+
+Scope (`--modules A,B,C`): compile ONLY the NodeTypes of the named packages (top-level folders).
+The compile was always atomic — every type resolves its own declared source set and builds alone —
+but the SELECTION was not: a pull request compiled all 92 NodeTypes of MeshWeaver.Plugins for a
+one-package diff ("we wanted to disentangle in atomic units", maintainer, 2026-09-11). The caller
+(the repo's CI) decides the unit from `affected-modules.py`; this flag is the per-unit mechanism.
+An unknown id and an empty list are both RED — a scoped run that silently compiled nothing would
+render exactly like a green gate. The allow-file ratchet is evaluated over the selected set ONLY:
+an allowlisted type outside the scope was not compiled, so it is neither "now compiles" nor a ghost.
 """
 import argparse
 import glob
@@ -119,6 +128,93 @@ def discover_nodetypes(root: Path):
             if is_nodetype(node):
                 out.append((f, node))
     return out
+
+
+# ── scope: the atomic unit the caller asks for ───────────────────────────────────────────────────
+
+def known_packages(root: Path) -> list:
+    """Every top-level folder that is a node repo — the same set `discover_nodetypes` walks."""
+    return sorted(d.name for d in root.iterdir() if d.is_dir() and d.name not in SKIP)
+
+
+def parse_modules(arg: "str | None", known) -> tuple:
+    """Turn `--modules A,B,C` into (sorted selected ids | None for full, error | None).
+
+    🚨 Two refusals, both on purpose. An EMPTY list (`--modules ''`, `--modules ,`) is not "compile
+    nothing" — a caller whose selection step produced no ids has a broken selector, and a green
+    verdict over zero types is indistinguishable from a green verdict over the unit. An UNKNOWN id
+    is refused by name: the ids come from another script's output, so a typo, a renamed package or
+    a package deleted on the branch under test would otherwise silently narrow the unit to whatever
+    else was in the list."""
+    if arg is None:
+        return None, None
+    ids = [p.strip() for p in arg.split(",")]
+    ids = [p for p in ids if p]
+    if not ids:
+        return None, ("--modules names no package — an empty selection is a broken selector, "
+                      "not 'nothing to compile'. Pass the unit's package ids, or omit the flag "
+                      "for a full run.")
+    known_set = set(known)
+    unknown = sorted(set(ids) - known_set)
+    if unknown:
+        return None, (f"--modules names {len(unknown)} unknown package(s): {', '.join(unknown)} "
+                      f"— not a top-level node repo folder under {ROOT} "
+                      f"(known: {', '.join(known) or '(none)'})")
+    return sorted(set(ids)), None
+
+
+def package_of(name: str) -> str:
+    """The package (top-level folder) a node path or allow-file entry belongs to."""
+    return name.split("/", 1)[0]
+
+
+def in_scope(types, selected) -> list:
+    """The discovered (json_path, node) pairs whose package is selected; all of them for None."""
+    if selected is None:
+        return list(types)
+    sel = set(selected)
+    return [(p, n) for p, n in types if package_of(p.relative_to(ROOT).as_posix()) in sel]
+
+
+def scope_allow(allow: dict, selected) -> dict:
+    """The allow-file entries the ratchet may judge on this run: only those inside the scope.
+
+    An out-of-scope entry was NOT compiled here, so it can be neither reported as "now compiles —
+    remove it" (it was never built) nor as a ghost (its type was never discovered). Judging it
+    would make every narrowed leg red on debt that belongs to another unit."""
+    if selected is None:
+        return dict(allow)
+    sel = set(selected)
+    return {n: fp for n, fp in allow.items() if package_of(n) in sel}
+
+
+def evaluate_gate(result: dict, allow: dict, node_set: dict) -> dict:
+    """The ratchet, as a pure function of (what compiled, what is allowlisted, what was discovered).
+
+    `result`   node-path -> (status, errors) for every type that was compiled on THIS run;
+    `allow`    the allow-file entries ALREADY scoped to this run (see `scope_allow`);
+    `node_set` node-path -> source set for every type discovered on this run."""
+    clean = sorted(n for n, (st, _) in result.items() if st == "ok")
+    unverifiable = sorted(n for n, (st, _) in result.items() if st == "unverifiable")
+    failing = {n for n, (st, _) in result.items() if st == "fail"}
+    allow_names = set(allow)
+    new_breaks = sorted(failing - allow_names)
+    # allowlisted-and-still-failing: split into genuine known-debt (fingerprint matches) vs.
+    # fingerprint-drift (allowlisted, but a NEW/changed error the entry does not cover → gate FAIL).
+    known_debt, fp_drift = [], []
+    for n in sorted(failing & allow_names):
+        cur_fp = failure_fingerprint(result[n][1])
+        exp_fp = allow[n]
+        if exp_fp is not None and cur_fp != exp_fp:
+            fp_drift.append((n, exp_fp, cur_fp))
+        else:
+            known_debt.append(n)
+    stale_allow = sorted(n for n in allow_names if result.get(n, (None,))[0] == "ok")
+    # allowlisted types that vanished from discovery (renamed/removed) — warn, don't gate
+    ghosts = sorted(n for n in allow if n not in node_set)
+    return {"clean": clean, "unverifiable": unverifiable, "failing": sorted(failing),
+            "new_breaks": new_breaks, "known_debt": known_debt, "fp_drift": fp_drift,
+            "stale_allow": stale_allow, "ghosts": ghosts}
 
 
 # ── source resolution (mirror the mesh's three source queries) ─────────────────────────────────────
@@ -844,6 +940,88 @@ def _self_test() -> int:
             failures.append("  module-refs discovery returned a RELATIVE path")
 
 
+    # 🚨 THE SCOPE MUST SELECT EXACTLY THE UNIT AND REFUSE EVERYTHING ELSE. `--modules` turns
+    # one full run into one leg per atomic unit (Plugins CI, 2026-09-11), and every failure mode
+    # of a narrowing is silent: a leg that compiled nothing, a typo that dropped a package, or a
+    # ratchet that reds the leg on another unit's debt all render as verdicts. Asserted over a
+    # fixture tree with no dotnet — pure selection and gate arithmetic.
+    scope_failures = []
+    with tempfile.TemporaryDirectory() as tmp:
+        fixture = Path(tmp)
+        for pkg, ntypes in (("Alpha", ("One", "Two")), ("Beta", ("Three",)), ("Gamma", ())):
+            (fixture / pkg).mkdir()
+            (fixture / pkg / "index.json").write_text('{"content": {"$type": "PluginContent"}}',
+                                                     encoding="utf-8")
+            for t in ntypes:
+                (fixture / pkg / f"{t}.json").write_text(
+                    '{"content": {"$type": "NodeTypeDefinition"}}', encoding="utf-8")
+        (fixture / "scripts").mkdir()          # a SKIP dir is never a package
+        global ROOT
+        saved_root = ROOT
+        ROOT = fixture
+        try:
+            pkgs = known_packages(fixture)
+            if pkgs != ["Alpha", "Beta", "Gamma"]:
+                scope_failures.append(f"  known_packages = {pkgs!r}, expected Alpha/Beta/Gamma")
+            types = discover_nodetypes(fixture)
+            names = lambda ts: sorted(p.relative_to(fixture).as_posix() for p, _ in ts)
+            # a subset selects ONLY those packages
+            sel, err = parse_modules("Beta,Alpha", pkgs)
+            if err or sel != ["Alpha", "Beta"]:
+                scope_failures.append(f"  subset: parse_modules -> ({sel!r}, {err!r})")
+            if names(in_scope(types, ["Alpha"])) != ["Alpha/One.json", "Alpha/Two.json"]:
+                scope_failures.append(f"  subset: in_scope(Alpha) = {names(in_scope(types, ['Alpha']))!r}")
+            if names(in_scope(types, ["Gamma"])) != []:
+                scope_failures.append("  subset: a package with no NodeTypes must select zero, not error")
+            if names(in_scope(types, None)) != names(types):
+                scope_failures.append("  full: in_scope(None) must be every discovered type")
+            # an unknown id is refused BY NAME
+            sel, err = parse_modules("Alpha,Zeta", pkgs)
+            if sel is not None or not err or "Zeta" not in err:
+                scope_failures.append(f"  unknown id: expected a refusal naming Zeta, got ({sel!r}, {err!r})")
+            sel, err = parse_modules("scripts", pkgs)
+            if sel is not None or not err:
+                scope_failures.append("  unknown id: a SKIP dir must not be selectable as a package")
+            # an empty list is refused — never 'compile nothing' silently
+            for empty in ("", ",", " , "):
+                sel, err = parse_modules(empty, pkgs)
+                if sel is not None or not err:
+                    scope_failures.append(f"  empty: {empty!r} must be refused, got ({sel!r}, {err!r})")
+            if parse_modules(None, pkgs) != (None, None):
+                scope_failures.append("  omitted flag must mean a full run")
+            # the ratchet ignores out-of-scope allow entries in BOTH directions
+            allow = {"Alpha/One": "CS0246:1", "Beta/Three": "CS0246:1", "Gamma/Gone": None}
+            scoped = scope_allow(allow, ["Alpha"])
+            if set(scoped) != {"Alpha/One"}:
+                scope_failures.append(f"  scope_allow(Alpha) = {sorted(scoped)!r}, expected Alpha/One only")
+            if scope_allow(allow, None) != allow:
+                scope_failures.append("  scope_allow(None) must keep every entry")
+            # Alpha's leg: Alpha/One now compiles → stale (ratchet reds it); Beta/Three's entry is
+            # outside the scope → neither stale nor ghost; Gamma/Gone → not a ghost here either.
+            result = {"Alpha/One": ("ok", []), "Alpha/Two": ("ok", [])}
+            node_set = {"Alpha/One": frozenset(), "Alpha/Two": frozenset()}
+            v = evaluate_gate(result, scoped, node_set)
+            if v["stale_allow"] != ["Alpha/One"] or v["ghosts"] or v["new_breaks"] or v["known_debt"]:
+                scope_failures.append(f"  ratchet in scope: {v!r}")
+            # Beta's leg, still failing with the pinned fingerprint → known debt, nothing red.
+            v = evaluate_gate({"Beta/Three": ("fail", ["CS0246: x"])}, scope_allow(allow, ["Beta"]),
+                              {"Beta/Three": frozenset()})
+            if v["known_debt"] != ["Beta/Three"] or v["stale_allow"] or v["ghosts"] or v["new_breaks"]:
+                scope_failures.append(f"  ratchet known-debt: {v!r}")
+            # …and a changed error inside an allowlisted type is drift, a new type is a break.
+            v = evaluate_gate({"Beta/Three": ("fail", ["CS0246: x", "CS0103: y"]),
+                               "Beta/Four": ("fail", ["CS0246: z"])},
+                              scope_allow(allow, ["Beta"]), {"Beta/Three": frozenset(), "Beta/Four": frozenset()})
+            if [d[0] for d in v["fp_drift"]] != ["Beta/Three"] or v["new_breaks"] != ["Beta/Four"]:
+                scope_failures.append(f"  ratchet drift/break: {v!r}")
+            # The FULL run still sees the whole allow-file — Gamma/Gone is a ghost there.
+            v = evaluate_gate(result, scope_allow(allow, None), node_set)
+            if v["ghosts"] != ["Beta/Three", "Gamma/Gone"]:
+                scope_failures.append(f"  full-run ghosts: {v['ghosts']!r}")
+        finally:
+            ROOT = saved_root
+    failures.extend(scope_failures)
+
     if failures:
         print("✗ using-directive parser self-test FAILED:")
         print("\n".join(failures))
@@ -851,6 +1029,8 @@ def _self_test() -> int:
     print(f"✓ using-directive parser: {len(cases)} shape(s) OK")
     print(f"✓ module-refs guard: detects a short reference set, collects exactly "
           f"{len(MODULE_REFS_NOT_IN_IMAGE)} registry-served assemblies, absolutized")
+    print("✓ --modules scope: a subset selects only its packages, an unknown id and an empty list "
+          "are refused, the ratchet judges the unit's allow entries only")
     return 0
 
 
@@ -865,10 +1045,26 @@ def main() -> int:
                     help="check the using-directive parser against its known shapes and exit")
     ap.add_argument("--gen-allow", action="store_true",
                     help="regenerate scripts/compile-check.allow from the current failures")
+    ap.add_argument("--modules", metavar="A,B,C",
+                    help="compile ONLY the NodeTypes of these packages (top-level folders) — the "
+                         "atomic unit the caller selected; the allow-file ratchet is judged over "
+                         "them alone. An unknown id or an empty list is RED. Omit for a full run.")
     args = ap.parse_args()
 
     if args.self_test:
         return _self_test()
+
+    # Resolve the scope BEFORE touching the reference set: a broken selection must be refused in
+    # milliseconds and by name, not after an image pull.
+    packages = known_packages(ROOT)
+    selected, scope_error = parse_modules(args.modules, packages)
+    if scope_error:
+        print(f"error: {scope_error}")
+        return 1
+    if selected is None:
+        print(f"scope: full — every NodeType in all {len(packages)} package(s)")
+    else:
+        print(f"scope: {len(selected)} of {len(packages)} package(s) — {', '.join(selected)}")
 
     refs_arg = args.refs
     if args.image:
@@ -935,7 +1131,11 @@ def main() -> int:
         print("mode: IMPLEMENTATION frameworks — compiling against the image's own assemblies "
               "(no SDK ref pack), exactly as the mesh compiles a NodeType")
 
-    types = discover_nodetypes(ROOT)
+    all_types = discover_nodetypes(ROOT)
+    types = in_scope(all_types, selected)
+    if selected is not None:
+        print(f"scope: {len(types)} of {len(all_types)} discovered NodeType(s) are in the unit; "
+              f"{len(all_types) - len(types)} outside it are not compiled here")
     # Group by (resolved source set, configuration lambda). The lambda is part of the KEY, not just
     # of the payload: two NodeTypes can share a source set while carrying different lambdas, and one
     # compile can only prove the lambda it actually contains. Types that share BOTH still collapse to
@@ -1015,14 +1215,22 @@ def main() -> int:
         result[name] = ("fail", [f"no resolvable source: {reason}"])
         print(f"  [--] {'FAIL':12} {name}    no resolvable source: {reason}")
 
-    allow = read_allow()
+    allow_all = read_allow()
+    allow = scope_allow(allow_all, selected)
+    if selected is not None and len(allow) != len(allow_all):
+        print(f"\nallow: {len(allow)} of {len(allow_all)} entr(ies) are inside the unit; the other "
+              f"{len(allow_all) - len(allow)} belong to packages not compiled here and are not judged")
 
     # ── gate evaluation ──
-    clean = [n for n, (st, _) in result.items() if st == "ok"]
-    unverifiable = [n for n, (st, _) in result.items() if st == "unverifiable"]
     failing = {n for n, (st, _) in result.items() if st == "fail"}
 
     if args.gen_allow:
+        if selected is not None:
+            # A regenerated allow-file describes the WHOLE tree; a scoped run has only seen part
+            # of it and would silently drop every other unit's debt from the ratchet.
+            print("error: --gen-allow needs a full run — it rewrites the allow-file for every "
+                  "package, and a scoped run has not compiled the others. Drop --modules.")
+            return 1
         lines = [
             "# compile-check.allow — the compile-debt backlog (RATCHET: must only ever SHRINK).",
             "#",
@@ -1059,19 +1267,10 @@ def main() -> int:
         print(f"\nwrote {ALLOW_FILE.relative_to(ROOT)} with {len(failing)} known-broken type(s).")
         return 0
 
-    allow_names = set(allow)
-    new_breaks = sorted(failing - allow_names)
-    # allowlisted-and-still-failing: split into genuine known-debt (fingerprint matches) vs.
-    # fingerprint-drift (allowlisted, but a NEW/changed error the entry does not cover → gate FAIL).
-    known_debt, fp_drift = [], []
-    for n in sorted(failing & allow_names):
-        cur_fp = failure_fingerprint(result[n][1])
-        exp_fp = allow[n]
-        if exp_fp is not None and cur_fp != exp_fp:
-            fp_drift.append((n, exp_fp, cur_fp))
-        else:
-            known_debt.append(n)
-    stale_allow = sorted(n for n in allow_names if result.get(n, (None,))[0] == "ok")
+    verdict = evaluate_gate(result, allow, node_set)
+    clean, unverifiable = verdict["clean"], verdict["unverifiable"]
+    new_breaks, fp_drift = verdict["new_breaks"], verdict["fp_drift"]
+    known_debt, stale_allow, ghosts = verdict["known_debt"], verdict["stale_allow"], verdict["ghosts"]
 
     print(f"\n── summary ──  {len(clean)} clean · {len(known_debt)} known-debt · "
           f"{len(new_breaks)} NEW break(s) · {len(fp_drift)} fingerprint-drift · "
@@ -1111,14 +1310,13 @@ def main() -> int:
         for n in unverifiable:
             print(f"  - {n}")
 
-    # allowlisted types that vanished from discovery (renamed/removed) — warn, don't gate
-    ghosts = sorted(n for n in allow if n not in node_set)
     if ghosts:
         print(f"\n⚠ {len(ghosts)} allowlisted type(s) no longer exist (clean up allow): "
               + ", ".join(ghosts))
 
     if not gate_fail:
-        print(f"\n✓ compile gate GREEN: {len(clean)} clean, {len(known_debt)} known-debt "
+        unit = "full tree" if selected is None else f"unit {', '.join(selected)}"
+        print(f"\n✓ compile gate GREEN ({unit}): {len(clean)} clean, {len(known_debt)} known-debt "
               f"(shrinking), no new breaks.")
     return 1 if gate_fail else 0
 


### PR DESCRIPTION
## Why

The NodeType compile gate was always atomic at COMPILE time — every type resolves its declared source set and builds alone (`[17/92] OK DeepSign/Credential`) — but its SELECTION was not: it only knew `--refs`/`--image`/`--self-test`/`--gen-allow`, read the whole tree at `MW_REPO_ROOT`, and a MeshWeaver.Plugins pull request compiled all 92 NodeTypes of 61 packages for a one-package diff.

Maintainer directive (Roland, 2026-09-11): *"we wanted to disentangle in atomic units"* — and, refined the same day, *"atomic unit == all dependency patterns in repo"*: the unit is a dependency NETWORK (the changed packages plus everything that transitively depends on them). The caller's CI decides the unit from its `affected-modules.py`; this flag is the per-unit mechanism.

## What

`.github/scripts/compile-check.py` gains `--modules A,B,C`:

- compiles only the NodeTypes whose package (top-level folder) is in the list, same order and format as today; prints the selection loudly (`scope: N of M package(s) — …` / `scope: full`)
- an **unknown id is RED naming it**; an **empty list is RED** — a scoped leg that silently compiled nothing renders exactly like a green gate
- the **allow-file ratchet is evaluated over the selected set ONLY**: an allowlisted type outside the unit was not compiled here, so it is neither reported as "now compiles — remove it" nor as a ghost; `--gen-allow` refuses a scoped run (it would rewrite the whole tree's debt from a partial view)
- the gate arithmetic moved into `evaluate_gate()` (pure) so `--self-test` asserts it over a fixture tree with no dotnet: subset selects only its packages; unknown id refused; empty refused (`''`, `,`, ` , `); the ratchet ignores out-of-scope entries in both directions while a full run still sees every entry (ghosts included)

No caller changes here; without the flag the behaviour is byte-identical (`scope: full`). The consumer is Systemorph/MeshWeaver.Plugins (one compile-check leg per affected dependency network, receipts + a stable aggregate context), which detects this flag on the fetched script and runs full with a notice until a sealed set carries it.

Related: the selector's over-selection for `scripts/` is core #4050 (adds `devtools/` to NOOP_DIRS) and Plugins #1679 — narrowing on Plugins PRs only takes effect once those are in.

## Verification

- `python3 .github/scripts/compile-check.py --self-test` — green (9 using shapes, module-refs guard, the four new scope cases)
- `--modules Store,Nope` → `error: --modules names 1 unknown package(s): Nope …` exit 1; `--modules ''` → refused, exit 1
- `head -c 400` still names `compile-check` (the fetch-side identity check in `node-repo-compile-check.yml`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6Cbf8RzXXHJvsjMBYLmjg
