### PR TITLE
test(#1605): pin the teardown's collectible-unload wiring; correct the provider-release claim

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -1796,6 +1796,22 @@ The progression, each step measured the same way:
 
 The 12 that remain are reported and named, never waited on.
 
+**Correction, the same day: the last row is two changes, and only one of them is shown to matter.**
+That step shipped the frame yield and the teardown's release of its own service provider together, and the two
+were never measured apart. `TeardownWaitsForCollectibleUnloadsTest` (core `MeshWeaver.Graph.Test`) then tried
+to pin the release on its own, and could not. With the provider disposed cleanly, keeping it roots nothing a
+harness can build:
+- Autofac clears the singletons it built when it is disposed. A container-built holder of a collectible
+  instance was collected with the release reverted, whether it was resolved from the root provider or from
+  the mesh hub.
+- Anything *registered* — a provided instance, a factory's captures — is also held by the fixture's own
+  `Services` collection, so it stays rooted whether the provider is kept or not.
+
+The release stays: the first in-drain `gcroot` put the provider on the chain, and it costs nothing. But the
+126 / 12 row is not evidence for it. What that test does pin, each by revert: deleting the per-test drain turns
+3 of its 4 cases red, deleting the shared-mesh drain turns the shared case red, and swallowing a faulted unload
+turns the fault case red.
+
 **The residual has no managed root, and the cutoff is measured, not guessed.**
 - A second heap dump taken *inside* the drain, with both fixes active, shows **no** non-weak root on either
   still-unloading LoaderAllocator. None is a stack root, a strong or pinned handle, a dependent handle, or a

--- a/test/MeshWeaver.Graph.Test/TeardownWaitsForCollectibleUnloadsTest.cs
+++ b/test/MeshWeaver.Graph.Test/TeardownWaitsForCollectibleUnloadsTest.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
@@ -54,7 +55,7 @@ public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
     [Fact]
     public async Task PerTestTeardown_ReturnsOnlyAfterTheContextItRetired_IsCollected()
     {
-        var fixture = new Teardown1605CollectedFixture(output);
+        await using var fixture = new Teardown1605CollectedFixture(output);
         await fixture.InitializeAsync();
         var unloads = fixture.Unloads;
         var weakContext = LoadIntoHolderAndRetire(unloads, fixture.Holder, "TeardownCollected1605");
@@ -85,36 +86,45 @@ public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
     [Fact]
     public async Task PerTestTeardown_ReportsARetainedContext_AndReturnsInsteadOfWaitingOnIt()
     {
-        var fixture = new Teardown1605RetainedFixture(output);
+        await using var fixture = new Teardown1605RetainedFixture(output);
         await fixture.InitializeAsync();
         var unloads = fixture.Unloads;
         // Rooted by THIS test, not by the fixture: something live the teardown cannot release.
         var root = new CollectibleInstanceHolder();
         var weakContext = LoadIntoHolderAndRetire(unloads, root, "TeardownRetained1605");
-        var offset = TraceLength();
+        CollectibleUnloadOutcome released;
+        try
+        {
+            var offset = TraceLength();
 
-        await fixture.DisposeAsync();
+            await fixture.DisposeAsync();
 
-        DisposePhases(offset, nameof(Teardown1605RetainedFixture)).Should().Contain(
-            "DISPOSE_ALC_RETAINED",
-            "a context something live still roots can never unload, so teardown must REPORT it and "
-            + "return — waiting on it would hang the suite, and calling it collected would hide it");
-        weakContext.IsAlive.Should().BeTrue("the test itself still roots it — that is what makes it retained");
-        unloads.PendingContextNames.Should().Contain(
-            name => name.EndsWith("TeardownRetained1605", StringComparison.Ordinal),
-            "a retained context stays tracked, so the next drain still sees it");
+            DisposePhases(offset, nameof(Teardown1605RetainedFixture)).Should().Contain(
+                "DISPOSE_ALC_RETAINED",
+                "a context something live still roots can never unload, so teardown must REPORT it and "
+                + "return — waiting on it would hang the suite, and calling it collected would hide it");
+            weakContext.IsAlive.Should().BeTrue("the test itself still roots it — that is what makes it retained");
+            unloads.PendingContextNames.Should().Contain(
+                name => name.EndsWith("TeardownRetained1605", StringComparison.Ordinal),
+                "a retained context stays tracked, so the next drain still sees it");
+        }
+        finally
+        {
+            // Released and drained on EVERY path, so a failing assertion above never leaves this
+            // synthetic context loaded for the rest of the host; that failure still propagates.
+            root.Instance = null;
+            released = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+        }
 
         // Released, the same drain collects it — and this test leaves nothing loaded behind.
-        root.Instance = null;
-        var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
-        outcome.Collected.Should().BeTrue($"with its last root gone the context must unload ({outcome})");
+        released.Collected.Should().BeTrue($"with its last root gone the context must unload ({released})");
         weakContext.IsAlive.Should().BeFalse("and it must actually be gone");
     }
 
     [Fact]
     public async Task PerTestTeardown_FailsWhenAnUnloadFaulted_InsteadOfHangingOnIt()
     {
-        var fixture = new Teardown1605FaultedFixture(output);
+        await using var fixture = new Teardown1605FaultedFixture(output);
         await fixture.InitializeAsync();
         LoadHookAndRetire(fixture.Unloads, "TeardownFault1605");
         var offset = TraceLength();
@@ -136,7 +146,9 @@ public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
     {
         // The scope the runner opens around a collection, opened here so this test owns the moment
         // the collection's shared mesh is torn down. It is Current for this method only.
-        var scope = TestCollectionScope.Begin("Plugins#1605 shared-mesh teardown");
+        // `await using` disposes it on every failure path; the explicit disposal below is the one
+        // under test, and TestCollectionScope.DisposeAsync is a no-op the second time.
+        await using var scope = TestCollectionScope.Begin("Plugins#1605 shared-mesh teardown");
         var weakContext = await RunOneSharedCaseAsync(output);
         var offset = TraceLength();
 
@@ -158,9 +170,17 @@ public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
     private static async Task<WeakReference> RunOneSharedCaseAsync(ITestOutputHelper output)
     {
         var fixture = new Teardown1605SharedFixture(output);
-        await fixture.InitializeAsync();
-        var weakContext = LoadIntoHolderAndRetire(fixture.Unloads, fixture.Holder, "TeardownShared1605");
-        await fixture.DisposeAsync();
+        WeakReference weakContext;
+        try
+        {
+            await fixture.InitializeAsync();
+            weakContext = LoadIntoHolderAndRetire(fixture.Unloads, fixture.Holder, "TeardownShared1605");
+        }
+        finally
+        {
+            // On every path, exactly once: the per-test half of a shared class's teardown.
+            await fixture.DisposeAsync();
+        }
         // xUnit drops a test instance once its teardown returns; so does this.
         fixture = null!;
         return weakContext;
@@ -255,6 +275,18 @@ public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
         // mesh's own container, which the teardown disposes.
         public CollectibleInstanceHolder Holder =>
             ServiceProvider.GetRequiredService<CollectibleInstanceHolder>();
+
+        private int disposed;
+
+        // Exactly once. Each test calls it explicitly (that call is the subject) and `await using`
+        // calls it again on every path, so a setup step or assertion that fails first never leaves a
+        // live mesh — or its provider and contexts — behind in the host.
+        public override async ValueTask DisposeAsync()
+        {
+            if (Interlocked.Exchange(ref disposed, 1) != 0)
+                return;
+            await base.DisposeAsync();
+        }
     }
 
     // One type per case: the teardown traces under the fixture's type name, so each case reads only

--- a/test/MeshWeaver.Graph.Test/TeardownWaitsForCollectibleUnloadsTest.cs
+++ b/test/MeshWeaver.Graph.Test/TeardownWaitsForCollectibleUnloadsTest.cs
@@ -1,0 +1,272 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using MeshWeaver.Testing.Xunit;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Plugins#1605 at the FIXTURE level: <see cref="MonolithMeshTestBase"/>'s own teardown — the thing
+/// xUnit awaits before it builds the next test's mesh — must not finish while a collectible context
+/// its mesh retired is still unloading. <c>RetiredContextCollectedSignalTest</c> pins the signal and
+/// the drain in isolation; these pin the WIRING, by driving real fixtures through their real
+/// <c>DisposeAsync</c> (and, for a shared mesh, through the collection teardown that disposes it):
+/// teardown waits until the context is collected, reports one that something live still roots and
+/// returns, and fails on an unload that faulted.
+///
+/// <para>The verdict is read from the phase line the teardown itself writes to
+/// <see cref="TestTraceLog"/> — the same line CI's artifact carries — scoped to this process and to
+/// the bytes appended during the teardown under test. "The context is gone afterwards" alone would
+/// not do: teardown ends with a forced-GC memory trace that can collect a simple context by itself,
+/// so a teardown with no drain at all could still leave it collected.</para>
+///
+/// <para>🚨 What these do NOT pin, measured: the fixture releasing its disposed service provider before
+/// the drain (#4046 per-test, #4048 shared). With the provider disposed cleanly, holding it roots
+/// nothing this harness can build: Autofac clears the singletons it built when it is disposed (a
+/// container-built holder, resolved from the root provider or from the mesh hub, was collected with
+/// the release reverted), and anything REGISTERED — a provided instance, a factory's captures — is
+/// rooted by the fixture's own <c>Services</c> collection whether the provider is kept or not. The
+/// release stays because an in-drain gcroot of a FutuRe teardown showed the provider on the chain;
+/// that chain is not reproduced here.</para>
+/// </summary>
+public class TeardownWaitsForCollectibleUnloadsTest(ITestOutputHelper output)
+{
+    private const string Source =
+        "namespace Dyn1605 { public sealed class Widget { public int Value { get; set; } = 42; } }";
+
+    [Fact]
+    public async Task PerTestTeardown_ReturnsOnlyAfterTheContextItRetired_IsCollected()
+    {
+        var fixture = new Teardown1605CollectedFixture(output);
+        await fixture.InitializeAsync();
+        var unloads = fixture.Unloads;
+        var weakContext = LoadIntoHolderAndRetire(unloads, fixture.Holder, "TeardownCollected1605");
+
+        var aliveWhenReleased = new ReplaySubject<bool>(1);
+        using var subscription = unloads.AllCollected
+            .Select(_ => weakContext.IsAlive)
+            .Subscribe(aliveWhenReleased);
+        unloads.Pending.Should().Be(1, "the retired context is tracked until it is collected");
+        var offset = TraceLength();
+
+        await fixture.DisposeAsync();
+
+        DisposePhases(offset, nameof(Teardown1605CollectedFixture)).Should().Contain(
+            "DISPOSE_UNLOADS_COLLECTED",
+            "the fixture's teardown must itself wait until the context its mesh retired has REALLY "
+            + "unloaded — a teardown that returns first hands xUnit the overlap every FutuRe crash "
+            + "dump shows");
+        weakContext.IsAlive.Should().BeFalse(
+            "xUnit builds the next test's mesh the moment DisposeAsync returns, so by then the context "
+            + "must be GONE — returning while it is still unloading is the overlap every FutuRe crash "
+            + "dump shows");
+        var alive = await aliveWhenReleased.FirstAsync().Timeout(TimeSpan.FromSeconds(10)).Await();
+        alive.Should().BeFalse("a start sequenced on the signal is released only after the collection");
+        unloads.Pending.Should().Be(0, "a collected retirement stops counting as pending");
+    }
+
+    [Fact]
+    public async Task PerTestTeardown_ReportsARetainedContext_AndReturnsInsteadOfWaitingOnIt()
+    {
+        var fixture = new Teardown1605RetainedFixture(output);
+        await fixture.InitializeAsync();
+        var unloads = fixture.Unloads;
+        // Rooted by THIS test, not by the fixture: something live the teardown cannot release.
+        var root = new CollectibleInstanceHolder();
+        var weakContext = LoadIntoHolderAndRetire(unloads, root, "TeardownRetained1605");
+        var offset = TraceLength();
+
+        await fixture.DisposeAsync();
+
+        DisposePhases(offset, nameof(Teardown1605RetainedFixture)).Should().Contain(
+            "DISPOSE_ALC_RETAINED",
+            "a context something live still roots can never unload, so teardown must REPORT it and "
+            + "return — waiting on it would hang the suite, and calling it collected would hide it");
+        weakContext.IsAlive.Should().BeTrue("the test itself still roots it — that is what makes it retained");
+        unloads.PendingContextNames.Should().Contain(
+            name => name.EndsWith("TeardownRetained1605", StringComparison.Ordinal),
+            "a retained context stays tracked, so the next drain still sees it");
+
+        // Released, the same drain collects it — and this test leaves nothing loaded behind.
+        root.Instance = null;
+        var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
+        outcome.Collected.Should().BeTrue($"with its last root gone the context must unload ({outcome})");
+        weakContext.IsAlive.Should().BeFalse("and it must actually be gone");
+    }
+
+    [Fact]
+    public async Task PerTestTeardown_FailsWhenAnUnloadFaulted_InsteadOfHangingOnIt()
+    {
+        var fixture = new Teardown1605FaultedFixture(output);
+        await fixture.InitializeAsync();
+        LoadHookAndRetire(fixture.Unloads, "TeardownFault1605");
+        var offset = TraceLength();
+
+        var teardown = async () => await fixture.DisposeAsync();
+
+        (await teardown.Should().ThrowAsync<InvalidOperationException>(
+                "an unload that faulted will never complete, so teardown must FAIL the class naming it "
+                + "— a teardown that waits on it hangs, and one that swallows it hides a context that "
+                + "stays loaded"))
+            .WithMessage("*unload was abandoned*")
+            .And.Which.ToString().Should().Contain("unloading handler fault 1605",
+                "the failure must carry the fault that abandoned the unload");
+        DisposePhases(offset, nameof(Teardown1605FaultedFixture)).Should().Contain("DISPOSE_UNLOAD_FAULTED");
+    }
+
+    [Fact]
+    public async Task SharedMeshTeardown_ReturnsOnlyAfterTheContextItsMeshRetired_IsCollected()
+    {
+        // The scope the runner opens around a collection, opened here so this test owns the moment
+        // the collection's shared mesh is torn down. It is Current for this method only.
+        var scope = TestCollectionScope.Begin("Plugins#1605 shared-mesh teardown");
+        var weakContext = await RunOneSharedCaseAsync(output);
+        var offset = TraceLength();
+
+        await scope.DisposeAsync();
+
+        DisposePhases(offset, nameof(Teardown1605SharedFixture)).Should().Contain(
+            "DISPOSE_SHARED_UNLOADS_COLLECTED",
+            "the collection's teardown must wait until the contexts its shared mesh retired have REALLY "
+            + "unloaded — the next collection's mesh is built the moment it returns");
+        weakContext.IsAlive.Should().BeFalse("the collection's teardown returns only after it is gone");
+    }
+
+    /// <summary>
+    /// One case of a shared-mesh class: build (or join) the collection's mesh, retire a context into
+    /// it, run the per-test teardown — which leaves the shared mesh up. Out of line, so no local of the
+    /// caller's frame keeps the fixture, and with it the provider, alive.
+    /// </summary>
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static async Task<WeakReference> RunOneSharedCaseAsync(ITestOutputHelper output)
+    {
+        var fixture = new Teardown1605SharedFixture(output);
+        await fixture.InitializeAsync();
+        var weakContext = LoadIntoHolderAndRetire(fixture.Unloads, fixture.Holder, "TeardownShared1605");
+        await fixture.DisposeAsync();
+        // xUnit drops a test instance once its teardown returns; so does this.
+        fixture = null!;
+        return weakContext;
+    }
+
+    private static long TraceLength() =>
+        File.Exists(TestTraceLog.Path) ? new FileInfo(TestTraceLog.Path).Length : 0;
+
+    /// <summary>
+    /// The phases <paramref name="fixtureName"/> wrote in THIS process after <paramref name="offset"/>.
+    /// The file is shared by every test host and never truncated locally, so both scopes matter: a
+    /// stale line from an earlier run under a recycled pid must not satisfy the assertion.
+    /// </summary>
+    private static IReadOnlyList<string> DisposePhases(long offset, string fixtureName)
+    {
+        using var stream = new FileStream(
+            TestTraceLog.Path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        stream.Seek(offset, SeekOrigin.Begin);
+        using var reader = new StreamReader(stream);
+        var marker = $"pid={Environment.ProcessId} [{fixtureName}] ";
+        return reader.ReadToEnd()
+            .Split('\n')
+            .Select(line => line.TrimEnd('\r'))
+            .Where(line => line.Contains(marker, StringComparison.Ordinal))
+            .Select(line => line[(line.IndexOf(marker, StringComparison.Ordinal) + marker.Length)..].Split(' ')[0])
+            .ToArray();
+    }
+
+    // Out-of-line and non-inlined so no local keeps the assembly, type or instance rooted on the
+    // caller's frame: the holder is the ONLY root of the context once this returns.
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static WeakReference LoadIntoHolderAndRetire(
+        CollectibleContextUnloads unloads, CollectibleInstanceHolder holder, string nodeName)
+    {
+        using var cache = NewCache(unloads);
+        var assembly = cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
+        holder.Instance = Activator.CreateInstance(assembly.GetType("Dyn1605.Widget")!);
+        var weak = new WeakReference(cache.GetOrCreateLoadContext(nodeName));
+        cache.UnloadContext(nodeName);
+        return weak;
+    }
+
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    private static void LoadHookAndRetire(CollectibleContextUnloads unloads, string nodeName)
+    {
+        using var cache = NewCache(unloads);
+        cache.LoadAssemblyFromBytes(nodeName, Compile(), pdbBytes: null);
+        cache.GetOrCreateLoadContext(nodeName).Unloading +=
+            _ => throw new InvalidOperationException("unloading handler fault 1605");
+        cache.UnloadContext(nodeName);
+    }
+
+    private static CompilationCacheService NewCache(CollectibleContextUnloads unloads) =>
+        new(Options.Create(new CompilationCacheOptions { EnableDiskCache = false }),
+            NullLogger<CompilationCacheService>.Instance, unloads);
+
+    private static byte[] Compile()
+    {
+        var compilation = CSharpCompilation.Create(
+            $"Dyn1605_{Guid.NewGuid():N}",
+            [CSharpSyntaxTree.ParseText(Source)],
+            [MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+             MetadataReference.CreateFromFile(Path.Combine(
+                 Path.GetDirectoryName(typeof(object).Assembly.Location)!, "System.Runtime.dll"))],
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+        result.Success.Should().BeTrue(string.Join("; ", result.Diagnostics));
+        return ms.ToArray();
+    }
+
+    /// <summary>A singleton of the fixture's mesh that holds one instance of a collectible type.</summary>
+    private sealed class CollectibleInstanceHolder
+    {
+        public object? Instance { get; set; }
+    }
+
+    /// <summary>A real fixture, driven by hand so its teardown is the subject rather than the harness.</summary>
+    private abstract class TeardownFixture(ITestOutputHelper output) : MonolithMeshTestBase(output)
+    {
+        // Built by the container, never PROVIDED: a provided instance also sits in the fixture's own
+        // service collection, which the fixture keeps for its whole lifetime, so it would be rooted
+        // whatever the teardown did with the provider.
+        protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+            base.ConfigureMesh(builder)
+                .ConfigureServices(services => services.AddSingleton(_ => new CollectibleInstanceHolder()));
+
+        public CollectibleContextUnloads Unloads =>
+            Mesh.ServiceProvider.GetRequiredService<CollectibleContextUnloads>();
+
+        // Resolved from the fixture's ROOT provider, so the collectible instance's only root is the
+        // mesh's own container, which the teardown disposes.
+        public CollectibleInstanceHolder Holder =>
+            ServiceProvider.GetRequiredService<CollectibleInstanceHolder>();
+    }
+
+    // One type per case: the teardown traces under the fixture's type name, so each case reads only
+    // its own lines.
+    private sealed class Teardown1605CollectedFixture(ITestOutputHelper output) : TeardownFixture(output);
+
+    private sealed class Teardown1605RetainedFixture(ITestOutputHelper output) : TeardownFixture(output);
+
+    private sealed class Teardown1605FaultedFixture(ITestOutputHelper output) : TeardownFixture(output);
+
+    private sealed class Teardown1605SharedFixture(ITestOutputHelper output) : TeardownFixture(output)
+    {
+        protected override bool ShareMeshAcrossTests => true;
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -273,8 +273,15 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     private sealed class SharedMeshProvider(IServiceProvider serviceProvider, string testClassName)
         : IAsyncDisposable
     {
+        // Nullable, and cleared by DisposeAsync BEFORE the unload drain: while this holder keeps the
+        // disposed provider, it roots the mesh and its MeshContentTypeRegistry, and with them the very
+        // collectible contexts the drain waits for (Plugins#1605) - the shared twin of the per-test
+        // path's `ServiceProvider = null!`.
+        private IServiceProvider? serviceProvider = serviceProvider;
+
         /// <summary>The provider every test of the class shares.</summary>
-        public IServiceProvider ServiceProvider { get; } = serviceProvider;
+        public IServiceProvider ServiceProvider =>
+            serviceProvider ?? throw new ObjectDisposedException(nameof(SharedMeshProvider), testClassName);
 
         /// <summary>
         /// Disposes the shared provider, then — like the per-test path (Plugins#1605) — waits until
@@ -284,13 +291,20 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         /// </summary>
         public async ValueTask DisposeAsync()
         {
-            var unloads = ServiceProvider.GetService<CollectibleContextUnloads>();
-            try { (ServiceProvider as IDisposable)?.Dispose(); }
+            var provider = serviceProvider;
+            if (provider is null)
+                return;
+            var unloads = provider.GetService<CollectibleContextUnloads>();
+            try { (provider as IDisposable)?.Dispose(); }
             catch (Exception ex)
             {
                 Fixture.TestTraceLog.AppendPhase(
                     testClassName, "DISPOSE_SHARED_SP_ERROR", 0, $"{ex.GetType().Name}: {ex.Message}");
             }
+            // Release the disposed provider before waiting on the contexts it roots: neither this
+            // holder's field nor this frame's local may keep the mesh reachable across the drain.
+            serviceProvider = null;
+            provider = null;
             var outcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(unloads);
             Fixture.TestTraceLog.AppendPhase(testClassName,
                 outcome.Fault is not null ? "DISPOSE_SHARED_UNLOAD_FAULTED"

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -273,10 +273,11 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     private sealed class SharedMeshProvider(IServiceProvider serviceProvider, string testClassName)
         : IAsyncDisposable
     {
-        // Nullable, and cleared by DisposeAsync BEFORE the unload drain: while this holder keeps the
-        // disposed provider, it roots the mesh and its MeshContentTypeRegistry, and with them the very
-        // collectible contexts the drain waits for (Plugins#1605) - the shared twin of the per-test
-        // path's `ServiceProvider = null!`.
+        // Nullable, and cleared by DisposeAsync BEFORE the unload drain: the shared twin of the per-test
+        // path's `ServiceProvider = null!` (Plugins#1605). The drain waits for contexts this mesh retired,
+        // so the holder must not keep the disposed mesh reachable across it. Like the per-test release it
+        // is not observable when the provider disposes cleanly (TeardownWaitsForCollectibleUnloadsTest:
+        // Autofac clears what it built); it costs nothing.
         private IServiceProvider? serviceProvider = serviceProvider;
 
         /// <summary>The provider every test of the class shares.</summary>
@@ -1723,9 +1724,11 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // after the reactive "all collected" signal: xUnit does not construct it until this
             // DisposeAsync returns. A faulted unload fails the class like a dirty teardown; a
             // retained context (rooted by something live) is REPORTED, never waited on.
-            // The fixture must not itself hold the mesh it is waiting to see unloaded: the disposed
-            // provider still reaches every singleton, the mesh hub and its content-type registry, whose
-            // discriminator claims hold the collectible types (gcroot inside the drain, #1605).
+            // The fixture must not itself hold the mesh it is waiting to see unloaded. An in-drain gcroot
+            // of a FutuRe teardown (#1605) showed this provider on the chain to the content-type
+            // registry's claims on collectible types. With the provider disposed cleanly that chain does
+            // not reproduce (TeardownWaitsForCollectibleUnloadsTest: Autofac clears the singletons it
+            // built), so this is a release that costs nothing, not a measured fix.
             ServiceProvider = null!;
             var unloadOutcome = await CollectibleUnloadDrain.WaitUntilCollectedAsync(collectibleUnloads);
             TestPhaseTrace(testName,

--- a/test/MeshWeaver.Testing.Xunit/MeshWeaver.Testing.Xunit.csproj
+++ b/test/MeshWeaver.Testing.Xunit/MeshWeaver.Testing.Xunit.csproj
@@ -12,11 +12,12 @@
     <PackageReference Include="xunit.v3.extensibility.core" />
   </ItemGroup>
   <ItemGroup>
-    <!-- TestCollectionScope.Begin is internal on purpose: only the assembly runner may open a
-         scope. The runner's own tests need to construct one without a framework. -->
+    <!-- TestCollectionScope.Begin is internal on purpose: only the assembly runner opens a scope in
+         normal use. Two test assemblies need to OWN a scope's lifetime and so may open one too:
+         the runner's own tests, which construct one without a framework, and (Plugins#1605)
+         MeshWeaver.Graph.Test's TeardownWaitsForCollectibleUnloadsTest, which drives a shared-mesh
+         fixture through a collection teardown it controls. Nothing else may open one. -->
     <InternalsVisibleTo Include="MeshWeaver.Testing.Xunit.Test" />
-    <!-- Plugins#1605: TeardownWaitsForCollectibleUnloadsTest drives a SHARED-mesh fixture through a
-         collection teardown it owns, so it opens its own scope exactly as the runner does. -->
     <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Testing.Xunit/MeshWeaver.Testing.Xunit.csproj
+++ b/test/MeshWeaver.Testing.Xunit/MeshWeaver.Testing.Xunit.csproj
@@ -15,5 +15,8 @@
     <!-- TestCollectionScope.Begin is internal on purpose: only the assembly runner may open a
          scope. The runner's own tests need to construct one without a framework. -->
     <InternalsVisibleTo Include="MeshWeaver.Testing.Xunit.Test" />
+    <!-- Plugins#1605: TeardownWaitsForCollectibleUnloadsTest drives a SHARED-mesh fixture through a
+         collection teardown it owns, so it opens its own scope exactly as the runner does. -->
+    <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Fixture-level regression tests for the Plugins#1605 teardown contract. They answer the review requests on #4048 (a shared-path teardown test) and on Systemorph/MeshWeaver.Plugins#1677 (per-test `DisposeAsync` outcomes). They also correct a claim that #4046 and #4048 made and the tests could not back up.

`test/MeshWeaver.Graph.Test/TeardownWaitsForCollectibleUnloadsTest.cs` drives real `MonolithMeshTestBase` fixtures by hand, through their real `DisposeAsync`. The shared case goes through the collection teardown that disposes `SharedMeshProvider`. Each case retires a real collectible context into the fixture's own mesh, then reads the teardown's own phase line from `TestTraceLog`. The read is scoped to this pid and to the bytes appended during that teardown.

| case | pins |
|---|---|
| per-test, collected | teardown returns only after `DISPOSE_UNLOADS_COLLECTED`, and the context is gone when it returns |
| per-test, retained | a context something live still roots is reported as `DISPOSE_ALC_RETAINED` and teardown returns; once released, the same drain collects it |
| per-test, faulted | an unload that faulted fails teardown with the fault (`DISPOSE_UNLOAD_FAULTED`) instead of hanging |
| shared mesh | the collection's teardown returns only after `DISPOSE_SHARED_UNLOADS_COLLECTED` |

The verdict comes from the trace line, not only from "the context is gone afterwards". Teardown ends with a forced-GC memory trace that can collect a simple context by itself, so a teardown with no drain at all could still leave it collected.

`MeshWeaver.Testing.Xunit` grants `InternalsVisibleTo` to `MeshWeaver.Graph.Test`, so the shared case can open its own `TestCollectionScope` exactly as the runner does.

## Falsified by revert (each with its own red)

| revert in `MonolithMeshTestBase` | result |
|---|---|
| delete the per-test drain | 3 of 4 red, e.g. `Expected collection {"DISPOSE_START", …, "DISPOSE_DONE", "DISPOSE_MEM"} to contain "DISPOSE_UNLOADS_COLLECTED" because the fixture's teardown must itself wait until the context its mesh retired has REALLY unloaded …` |
| delete the shared-mesh drain | shared case red: `Expected collection {} to contain "DISPOSE_SHARED_UNLOADS_COLLECTED" because the collection's teardown must wait until the contexts its shared mesh retired have REALLY unloaded …` |
| swallow a faulted unload | fault case red: `Expected a InvalidOperationException because an unload that faulted will never complete, so teardown must FAIL the class naming it … but no exception was thrown` |
| restored | 4/4 green |

## Correction: the provider release in #4046 / #4048 is not shown to matter

I tried to pin "the fixture releases its disposed provider before the drain" (the #4048 review asked for exactly this) and could not. With the provider disposed cleanly, keeping it roots nothing a harness can build. I measured three root shapes:
- **A container-built holder resolved through the mesh hub:** collected with the release reverted.
- **A container-built holder resolved from the fixture's root provider:** collected with the release reverted. Autofac clears the singletons it built when it is disposed.
- **A provided instance:** retained with or without the release. It sits in the fixture's own `Services` collection, which the fixture keeps for its whole lifetime.

The release stays. An in-drain `gcroot` of a FutuRe teardown put the provider on the chain, and the release costs nothing. But the comments in `MonolithMeshTestBase` and the "+ the teardown releasing its own mesh first | 126 | 12" row in `Doc/Architecture/DebuggingNativeCrashes` presented it as measured. That row shipped the frame yield and the release together, and the two were never measured apart. Both the comments and the doc now say so. The test's summary states, as measured, what it does not pin.

## Verification

- `dotnet build test/MeshWeaver.Graph.Test -c Release -warnaserror`: 0 warnings, 0 errors. This also builds `MeshWeaver.Testing.Xunit` and `MeshWeaver.Hosting.Monolith.TestBase`.
- `TeardownWaitsForCollectibleUnloadsTest`: 4/4 green on the restored source, and the falsification table above.
- `MeshWeaver.Documentation.Test`: see the check run.

Pairs-with: none — test-only and doc; no public `src/` surface changes. The Plugins copy of the per-test cases goes in a separate Plugins PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
