### PR TITLE
feat(Graph): mount the e-Signature package's Signature block on every document page

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-documents-signatures-show-on-its-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-documents-signatures-show-on-its-page.md
@@ -1,0 +1,20 @@
+---
+Name: A document's signatures show on its page
+Category: Feature
+Description: When the e-Signature package (DeepSign, Skribble) is installed on a mesh, every markdown document page renders its signature block right after its approvals — signed requests as signatures, open ones with their Sign button. Without the package nothing changes.
+Icon: Signature
+Order: -20260911
+---
+
+# A document's signatures show on its page
+
+A document you sent for signature through the **e-Signature** package (DeepSign or Skribble, from
+MeshWeaver.Plugins) now shows the result **on its own page**: right after the approvals section, a
+**Signatures** block lists each request — signed ones as the signature (signer, signed-at in your
+time zone, level, jurisdiction, provider, the signed PDF), open ones as awaiting with their
+**✍️ Sign** button.
+
+The platform delegates the block to the package exactly as it delegates approvals: it asks the
+index whether the package's shared desk (`DeepSign/Workspace`) is on this mesh — a bounded probe,
+never a hub call — and mounts the desk's `Signature` area with the document as its reference. On a
+mesh without the package nothing is rendered and nothing is paid.

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -271,6 +271,13 @@ public static class MarkdownOverviewLayoutArea
         // whether THIS document has anything to show. No package ⇒ no section, no cost.
         container = container.WithView(ApprovalsSection(host, nodePath));
 
+        // Signatures section — the same delegation to the e-Signature PACKAGE (DeepSign / Skribble,
+        // MeshWeaver.Plugins#1682): its shared desk renders this document's signature block — signed
+        // requests as signatures, open ones with their Sign button — and decides whether there is
+        // anything to show. Same bounded index probe, same reference-id hand-over. No package ⇒ no
+        // section, no cost.
+        container = container.WithView(SignaturesSection(host, nodePath));
+
         // Standard inline comments section (if comments enabled)
         if (!hideHeader && host.Hub.Configuration.HasComments())
         {
@@ -296,6 +303,25 @@ public static class MarkdownOverviewLayoutArea
             .Exists(host.Hub.ServiceProvider.GetService<IMeshService>(), ApprovalDeskPath)
             .Select(installed => installed
                 ? (UiControl?)Controls.LayoutArea(ApprovalDeskPath, ApprovalsArea, nodePath)
+                    .WithShowProgress(false)
+                : Controls.Stack);
+
+    /// <summary>The e-Signature package's shared desk — the instance that serves every document.</summary>
+    internal const string SignatureDeskPath = "DeepSign/Workspace";
+
+    /// <summary>The desk area rendering one document's signature block.</summary>
+    internal const string SignatureArea = "Signature";
+
+    /// <summary>
+    /// The document's signatures, rendered by the e-Signature package when that package is on the
+    /// mesh — an empty stack otherwise, never an "area not found" card. The document path rides as
+    /// the layout-area REFERENCE, exactly as the approvals section hands it over.
+    /// </summary>
+    private static IObservable<UiControl?> SignaturesSection(LayoutAreaHost host, string nodePath)
+        => PluginSurfaceProbe
+            .Exists(host.Hub.ServiceProvider.GetService<IMeshService>(), SignatureDeskPath)
+            .Select(installed => installed
+                ? (UiControl?)Controls.LayoutArea(SignatureDeskPath, SignatureArea, nodePath)
                     .WithShowProgress(false)
                 : Controls.Stack);
 


### PR DESCRIPTION
## Why

Systemorph/MeshWeaver.Plugins#1682 (item 5, "when signed, add signature") makes the e-Signature package (DeepSign, Skribble) render a document's signatures as a block — signed requests as the signature (signer, signed-at in the viewer's zone, level, jurisdiction, provider, signed PDF), open ones as awaiting with their **Sign** button — on the shared desk `DeepSign/Workspace`, area `Signature`, resolving the document from the layout-area reference id. The one thing that PR could not carry is the platform seam that puts that block on every document page: the markdown overview mounts the Approvals package's section through a seam hard-coded to `Approvals/Workspace` (`MarkdownOverviewLayoutArea.ApprovalsSection`), and there is no generic contribution point.

## What

`MarkdownOverviewLayoutArea.SignaturesSection`, a sibling of `ApprovalsSection` rendered right after it, mirroring it exactly: `PluginSurfaceProbe.Exists(mesh, "DeepSign/Workspace")` → `Controls.LayoutArea("DeepSign/Workspace", "Signature", nodePath).WithShowProgress(false)`; package absent → an empty `Controls.Stack`, never an "area not found" card, and no cost beyond the one bounded index probe. Plus a What's New entry.

No core test pins `ApprovalsSection` (the Graph tests assert the overview renders a Stack and the `UiContribution` hrefs; `PluginSurfaceProbe` has no direct test), so there is no sibling case to mirror; the package side is pinned by its own `Tests` areas in #1682 (the block's rendering, the reference-id/`?doc=` resolution).

## How tested

- `dotnet build src/MeshWeaver.Graph -c Release -p:CIRun=true -warnaserror` — 0 warnings, 0 errors.
- `dotnet build test/MeshWeaver.Graph.Test -c Release -p:CIRun=true -warnaserror`, then `dotnet test … --filter FullyQualifiedName~OverviewLayoutAreaTest` — `Passed! - Failed: 0, Passed: 10, Skipped: 0, Total: 10` (MeshWeaver.Graph.Test, net10.0).

Counterpart: Systemorph/MeshWeaver.Plugins#1682 (additive on both sides; neither side removes a public surface, so no pair declaration is needed).
Mirror-sync: none — no catalog key touched.

Reaches the portals with the next platform image roll; #1682's `Signature` area is already shaped for this mount.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R6Cbf8RzXXHJvsjMBYLmjg
