### PR TITLE
Public web presence: crawler-readable bodies, a sitemap that descends, one public host (#4056)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -280,6 +280,19 @@ data:
   # app-relative path; empty = none. Per-install brand assets ship at
   # _content/Memex.Portal.Shared/brand/{systemorph,prod,local}-180.png (or a mesh asset / absolute URL).
   Portal__AppleTouchIcon: "{{ .Values.config.memex_portal.Portal__AppleTouchIcon | default "" }}"
+  # ---- Public web site (Doc/Architecture/PublicWebPresence) — optional -----
+  # SiteName is the brand in <title> separators and og:site_name ("MeshWeaver"); empty = "Memex".
+  # PublicHost names the ONE host search engines rank the site under (www.meshweaver.cloud):
+  # every canonical, og:url and sitemap entry is built on it whichever host served the request,
+  # and a request on any OTHER host is the app host — noindex, robots Disallow: /, and a stranger's
+  # HTML GET for a public page answers 301 to the public host. Empty = single-host, unchanged.
+  # LandingPath is the node a signed-out visitor sees at "/" (the landing Space); empty = the
+  # portal's own welcome route. The public host must ALSO be an ingress rule to this service —
+  # the chart renders one host (ingress.host); the second is the overlay's (memex-cloud:
+  # Memex.Website/k8s/brand-site.yaml).
+  Portal__SiteName: "{{ .Values.config.memex_portal.Portal__SiteName | default "" }}"
+  Portal__PublicHost: "{{ .Values.config.memex_portal.Portal__PublicHost | default "" }}"
+  Portal__LandingPath: "{{ .Values.config.memex_portal.Portal__LandingPath | default "" }}"
 {{- if (.Values.instancesAdmin).clusterRead }}
   # ---- Platform-admin Instances overview (see .Values.instancesAdmin) -------
   # The SAME flag that grants the cluster-read RBAC also enables the Settings tab, so the

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Text.Json;
 using System.Xml.Linq;
 using Memex.Portal.Shared.Seo;
 using MeshWeaver.Mesh;
@@ -8,7 +7,9 @@ using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -68,28 +69,74 @@ public static class SeoEndpoints
                 + "for it", nodePath);
     }
 
-    /// <summary>Node types whose top-level mains are sitemap candidates.</summary>
+    /// <summary>Node types whose top-level mains are sitemap candidates (the partition roots).</summary>
     private static readonly string[] CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
+
+    /// <summary>
+    /// 🚨 WHAT COUNTS AS A PAGE below a public root — the node types whose instances are documents
+    /// a person reads, as opposed to the data, code, releases and registrations a partition also
+    /// holds. A reinsurance plugin's partition carries hundreds of amount types, cashflows, source
+    /// files and release markers; none of those is a page, and listing them would bury the twenty
+    /// pages that are. Anonymous readability is decided separately, per node, by the gate — this
+    /// list only says which readable nodes are worth a search engine's visit.
+    /// </summary>
+    internal static readonly string[] PageNodeTypes =
+        ["Markdown", "Space", "Store/Plugin", "Store/Catalog", "Edu/Module", "Edu/Page"];
+
+    /// <summary>
+    /// Path segments that route to a partition's SATELLITE tables — code, tests, release markers —
+    /// never to a page. Underscore segments (<c>_Thread</c>, <c>_Access</c>, <c>_GitSync</c>, …) are
+    /// the satellite convention itself.
+    /// </summary>
+    private static readonly string[] SatelliteSegments = ["Source", "Test", "Release"];
+
+    /// <summary>Descendants read per public root; a partition with more pages than this is a
+    /// sitemap-index job, not a bigger number.</summary>
+    private const int DescendantLimit = 2000;
+
+    /// <summary>Concurrent per-node gate checks while enumerating one root's pages.</summary>
+    private const int GateConcurrency = 8;
+
+    /// <summary>
+    /// Whether a path below a root can be a page at all: no satellite segment anywhere in it.
+    /// Pure; the gate decides readability afterwards.
+    /// </summary>
+    internal static bool IsPagePath(string path)
+        => path.Split('/').All(segment =>
+            segment.Length > 0
+            && segment[0] != '_'
+            && !SatelliteSegments.Contains(segment, StringComparer.Ordinal));
 
     public static IEndpointRouteBuilder MapSeo(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/robots.txt", (HttpContext http) =>
+        app.MapGet("/robots.txt", (HttpContext http, IConfiguration configuration) =>
         {
-            var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}";
+            var baseUrl = PublicSite.CanonicalBaseUrl(configuration, http.Request);
+            // The app host is the same site under a second name: nothing on it is for the index,
+            // and the sitemap it points at is the public host's. See PublicSite.
+            var rules = PublicSite.IsAppOnlyHost(configuration, http.Request)
+                ? "Disallow: /"
+                : """
+                  Disallow: /login
+                  Disallow: /welcome
+                  Disallow: /api/
+                  Disallow: /_blazor
+                  Disallow: /dev/
+                  """.TrimEnd();
             return Results.Text(
                 $"""
                  User-agent: *
-                 Disallow: /login
-                 Disallow: /api/
-                 Disallow: /_blazor
-                 Disallow: /dev/
+                 {rules}
                  Sitemap: {baseUrl}/sitemap.xml
                  """, "text/plain");
         }).AllowAnonymous();
 
-        app.MapGet("/sitemap.xml", (IMessageHub hub, HttpContext http, CancellationToken ct) =>
+        // [FromServices] on the hub, explicitly: minimal-API parameter inference classifies an
+        // unregistered reference type as the request BODY, so a host that maps these routes
+        // without a mesh (a test of robots.txt alone) failed at map time with "Body was inferred".
+        app.MapGet("/sitemap.xml", ([FromServices] IMessageHub hub, HttpContext http, IConfiguration configuration, CancellationToken ct) =>
         {
-            var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}";
+            var baseUrl = PublicSite.CanonicalBaseUrl(configuration, http.Request);
             return BuildSitemap(hub, baseUrl)
                 .Select(xml => Results.Text(xml, "application/xml"))
                 .FirstAsync()
@@ -121,7 +168,7 @@ public static class SeoEndpoints
     /// </summary>
     private static void MapShareCard(IEndpointRouteBuilder app) =>
         app.MapGet("/api/og/{**path}", (
-            IMessageHub hub, OgCardRenderer renderer, HttpContext http, string path,
+            [FromServices] IMessageHub hub, [FromServices] OgCardRenderer renderer, HttpContext http, string path,
             CancellationToken ct) =>
         {
             var nodePath = (path ?? "").Trim('/');
@@ -169,7 +216,7 @@ public static class SeoEndpoints
     /// </summary>
     private static void MapNodeIcon(IEndpointRouteBuilder app) =>
         app.MapGet("/api/icon/{**path}", (
-            IMessageHub hub, HttpContext http, string path, CancellationToken ct) =>
+            [FromServices] IMessageHub hub, HttpContext http, string path, CancellationToken ct) =>
         {
             var nodePath = (path ?? "").Trim('/');
             if (nodePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
@@ -261,8 +308,8 @@ public static class SeoEndpoints
 
     /// <summary>
     /// The sitemap XML, built reactively: candidate roots from the (System-read) type queries,
-    /// each gated through the REAL anonymous permission check, public-segment children of store
-    /// plugins verified to exist before listing. Cold; never errors (fail-open to fewer URLs).
+    /// each gated through the REAL anonymous permission check, then every page-shaped descendant
+    /// of an admitted root, each gated the same way. Cold; never errors (fail-open to fewer URLs).
     /// </summary>
     public static IObservable<string> BuildSitemap(IMessageHub hub, string baseUrl) =>
         EnumeratePublished(hub)
@@ -285,9 +332,8 @@ public static class SeoEndpoints
     public static IObservable<IReadOnlyList<PublishedPage>> EnumeratePublished(IMessageHub hub)
     {
         var mesh = hub.ServiceProvider.GetService<IMeshService>();
-        var adapter = hub.ServiceProvider.GetService<IStorageAdapter>();
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        if (mesh is null || adapter is null)
+        if (mesh is null)
             return Observable.Return<IReadOnlyList<PublishedPage>>([]);
 
         // Candidate enumeration runs as System (an anonymous HTTP entry has no query identity);
@@ -320,7 +366,7 @@ public static class SeoEndpoints
                     .Select(root => AnonymousGate.AllowAnonymous(hub, root.Path)
                         .Take(1)
                         .SelectMany(allowed => allowed
-                            ? PagesOf(adapter, hub, root)
+                            ? PagesOf(mesh, accessService, hub, root)
                             : Observable.Return<IReadOnlyList<(MeshNode, string)>>([])))
                     .ToObservable().Concat().ToList()
                     .Select(pages => pages.SelectMany(p => p).ToList()))
@@ -334,36 +380,60 @@ public static class SeoEndpoints
                 Observable.Return<IReadOnlyList<PublishedPage>>([]));
     }
 
-    // The sitemap pages of one anonymous-readable root: the root itself plus, for store
-    // plugins, each declared public segment whose node actually exists (the brochures).
+    /// <summary>
+    /// The sitemap pages of one anonymous-readable root: the root itself plus every page-shaped
+    /// descendant (<see cref="PageNodeTypes"/>, <see cref="IsPagePath"/>) the
+    /// <see cref="AnonymousGate"/> admits — checked PER NODE, because a public course is a root
+    /// grant plus a deny on every chapter that is not free, and a commercial plugin's cover can be
+    /// public while its content is not. The descendant listing runs as System (a listing is a
+    /// valid query use: a stale negative here costs a URL, never a leak — every candidate still
+    /// passes the gate before it is listed).
+    ///
+    /// <para>🚨 This REPLACES the read of each store plugin's declared <c>publicSegments</c>
+    /// (#4056). That read went through the raw storage adapter from an anonymous HTTP entry and
+    /// came back empty on the partitioned Postgres deployment, so no course chapter was ever in the
+    /// sitemap; and it could only ever see one level of one node type, so the documentation tree
+    /// was never in it either. The gate is the one definition of "public" and it already encodes
+    /// the declared segments as grants and denies — asking it per node is both the fix and the
+    /// feature.</para>
+    /// </summary>
     private static IObservable<IReadOnlyList<(MeshNode, string)>> PagesOf(
-        IStorageAdapter adapter, IMessageHub hub, MeshNode root)
+        IMeshService mesh, AccessService? accessService, IMessageHub hub, MeshNode root)
     {
         var self = (root, root.Path);
-        var segments = PublicSegments(root);
-        if (segments.Count == 0)
-            return Observable.Return<IReadOnlyList<(MeshNode, string)>>([self]);
-        return segments
-            .Select(segment => adapter
-                .Read($"{root.Path}/{segment}", hub.JsonSerializerOptions)
-                .Take(1)
-                .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null)))
-            .ToObservable().Concat().ToList()
-            .Select(children => (IReadOnlyList<(MeshNode, string)>)
-                new[] { self }
-                    .Concat(children.Where(c => c is not null).Select(c => (c!, c!.Path)))
-                    .ToList());
+        var types = string.Join("|", PageNodeTypes.Select(t => $"\"{t}\""));
+        return accessService.RunAsSystem(() => mesh.Query<MeshNode>(DescendantsOf(root, types)))
+            .Take(1)
+            .Select(change => change.Items
+                .Where(n => n.Path.Length > root.Path.Length
+                            && n.Path.StartsWith(root.Path + "/", StringComparison.Ordinal)
+                            && IsPagePath(n.Path[(root.Path.Length + 1)..]))
+                .DistinctBy(n => n.Path)
+                .ToList())
+            .SelectMany(candidates => candidates.Count == 0
+                ? Observable.Return<IReadOnlyList<(MeshNode, string)>>([self])
+                : candidates
+                    // Same boolean projection as the roots: "not public" and "the gate could not
+                    // decide" both OMIT the page, which is the fail-closed action (#2901).
+                    .Select(node => AnonymousGate.AllowAnonymous(hub, node.Path)
+                        .Take(1)
+                        .Select(allowed => allowed ? node : null))
+                    .Merge(GateConcurrency)
+                    .Where(node => node is not null)
+                    .ToList()
+                    .Select(admitted => (IReadOnlyList<(MeshNode, string)>)
+                        new[] { self }
+                            .Concat(admitted
+                                .OrderBy(n => n!.Path, StringComparer.Ordinal)
+                                .Select(n => (n!, n!.Path)))
+                            .ToList()))
+            .Catch<IReadOnlyList<(MeshNode, string)>, Exception>(
+                _ => Observable.Return<IReadOnlyList<(MeshNode, string)>>([self]));
     }
 
-    private static IReadOnlyList<string> PublicSegments(MeshNode root) =>
-        root.Content is JsonElement { ValueKind: JsonValueKind.Object } je
-            && je.TryGetProperty("publicSegments", out var segs)
-            && segs.ValueKind == JsonValueKind.Array
-            ? segs.EnumerateArray()
-                .Where(s => s.ValueKind == JsonValueKind.String)
-                .Select(s => s.GetString()!)
-                .ToList()
-            : [];
+    private static MeshQueryRequest DescendantsOf(MeshNode root, string types)
+        => MeshQueryRequest.FromQuery(
+            $"namespace:\"{root.Path}\" scope:descendants is:main nodeType:{types} limit:{DescendantLimit}");
 
     private static string Render(string baseUrl, IReadOnlyList<(MeshNode Node, string Url)> pages)
     {

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Xml.Linq;
 using Memex.Portal.Shared.Seo;
@@ -70,7 +71,7 @@ public static class SeoEndpoints
     }
 
     /// <summary>Node types whose top-level mains are sitemap candidates (the partition roots).</summary>
-    private static readonly string[] CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
+    private static readonly ImmutableArray<string> CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
 
     /// <summary>
     /// 🚨 WHAT COUNTS AS A PAGE below a public root — the node types whose instances are documents
@@ -80,7 +81,7 @@ public static class SeoEndpoints
     /// pages that are. Anonymous readability is decided separately, per node, by the gate — this
     /// list only says which readable nodes are worth a search engine's visit.
     /// </summary>
-    internal static readonly string[] PageNodeTypes =
+    internal static readonly ImmutableArray<string> PageNodeTypes =
         ["Markdown", "Space", "Store/Plugin", "Store/Catalog", "Edu/Module", "Edu/Page"];
 
     /// <summary>
@@ -88,11 +89,8 @@ public static class SeoEndpoints
     /// never to a page. Underscore segments (<c>_Thread</c>, <c>_Access</c>, <c>_GitSync</c>, …) are
     /// the satellite convention itself.
     /// </summary>
-    private static readonly string[] SatelliteSegments = ["Source", "Test", "Release"];
-
-    /// <summary>Descendants read per public root; a partition with more pages than this is a
-    /// sitemap-index job, not a bigger number.</summary>
-    private const int DescendantLimit = 2000;
+    private static readonly ImmutableHashSet<string> SatelliteSegments =
+        ImmutableHashSet.Create(StringComparer.Ordinal, "Source", "Test", "Release");
 
     /// <summary>Concurrent per-node gate checks while enumerating one root's pages.</summary>
     private const int GateConcurrency = 8;
@@ -105,7 +103,7 @@ public static class SeoEndpoints
         => path.Split('/').All(segment =>
             segment.Length > 0
             && segment[0] != '_'
-            && !SatelliteSegments.Contains(segment, StringComparer.Ordinal));
+            && !SatelliteSegments.Contains(segment));
 
     public static IEndpointRouteBuilder MapSeo(this IEndpointRouteBuilder app)
     {
@@ -431,9 +429,13 @@ public static class SeoEndpoints
                 _ => Observable.Return<IReadOnlyList<(MeshNode, string)>>([self]));
     }
 
+    // `limit:all` — this is an ENUMERATION, so every match comes back (MeshQueryRequest.NoLimit);
+    // a stated cap would silently truncate the one list that claims to be complete. The sitemap
+    // protocol's own bound is 50,000 URLs per file; that is a sitemap-index job for the day a
+    // deployment publishes that many pages, not a reason to clip the query.
     private static MeshQueryRequest DescendantsOf(MeshNode root, string types)
         => MeshQueryRequest.FromQuery(
-            $"namespace:\"{root.Path}\" scope:descendants is:main nodeType:{types} limit:{DescendantLimit}");
+            $"namespace:\"{root.Path}\" scope:descendants is:main nodeType:{types} limit:all");
 
     private static string Render(string baseUrl, IReadOnlyList<(MeshNode Node, string Url)> pages)
     {

--- a/memex/Memex.Portal.Shared/Seo/PublicSite.cs
+++ b/memex/Memex.Portal.Shared/Seo/PublicSite.cs
@@ -1,8 +1,10 @@
+using System.Reactive.Linq;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Seo;
 
@@ -88,13 +90,22 @@ public static class PublicSite
     /// a link shared from inside the app keeps working for its author and lands a stranger on the
     /// address search engines know.</para>
     ///
-    /// <para><paramref name="isPublicPage"/> decides publicness; the default asks the mesh through
-    /// <see cref="SeoResolver.ResolveAsync"/> — the same gate the head is built from — and a test
-    /// hands in its own decision so the routing rule is pinned without a mesh. Register AFTER
-    /// authentication (it reads <c>User.Identity</c>) and before the page endpoints.</para>
+    /// <para><paramref name="isPublicPage"/> decides publicness, reactively; the default asks the
+    /// mesh through <see cref="SeoResolver.Resolve"/> — the same gate the head is built from — and
+    /// a test hands in its own decision so the routing rule is pinned without a mesh. The ONE
+    /// <c>Task</c> bridge is here, at the ASP.NET middleware boundary, through
+    /// <see cref="ReactiveCompletion.ObserveCompletion{T}(IObservable{T}, Action{Exception}, System.Threading.CancellationToken)"/>
+    /// (never <c>.ToTask()</c>). Register AFTER authentication (it reads <c>User.Identity</c>) and
+    /// before the page endpoints.</para>
+    ///
+    /// <para>The decision is the boolean projection of the gate on purpose: "not public" and "the
+    /// gate could not decide" both mean NO redirect here, and no redirect is the fail-closed
+    /// action — the request continues into the app's own handling, which evaluates the tri-state
+    /// gate itself and answers the visitor (sign-in, or unavailable). A 301 that named a page on
+    /// the public host on an undetermined verdict would be the assertion this avoids.</para>
     /// </summary>
     public static IApplicationBuilder UsePublicHostRedirect(
-        this IApplicationBuilder app, Func<HttpContext, string, Task<bool>>? isPublicPage = null)
+        this IApplicationBuilder app, Func<HttpContext, string, IObservable<bool>>? isPublicPage = null)
     {
         var decide = isPublicPage ?? DefaultIsPublicPage;
         return app.Use(async (http, next) =>
@@ -118,7 +129,14 @@ public static class PublicSite
                 return;
             }
 
-            if (!await decide(http, nodePath))
+            var logger = http.RequestServices.GetService<ILoggerFactory>()?.CreateLogger(typeof(PublicSite));
+            var isPublic = await decide(http, nodePath)
+                .FirstAsync()
+                .Catch<bool, Exception>(_ => Observable.Return(false))
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex, "Public-host decision for '{Path}' faulted after the response had settled", nodePath),
+                    http.RequestAborted);
+            if (!isPublic)
             {
                 await next(http);
                 return;
@@ -148,6 +166,7 @@ public static class PublicSite
                 await next(http);
                 return;
             }
+            var method = http.Request.Method;
             http.Request.Method = HttpMethods.Get;
             var body = http.Response.Body;
             http.Response.Body = Stream.Null;
@@ -157,6 +176,9 @@ public static class PublicSite
             }
             finally
             {
+                // Restore both: middleware that resumes after `next` (logging, tracing) must see
+                // the request as the HEAD it was.
+                http.Request.Method = method;
                 http.Response.Body = body;
             }
         });
@@ -172,13 +194,12 @@ public static class PublicSite
     // The production decision: the same anonymous-gated resolution the crawler head is built
     // from. A page the gate refuses — or a mesh that does not answer — is "not public", and the
     // request continues to the app's own handling (sign-in redirect), never to a redirect that
-    // would name a page on the public host.
-    private static async Task<bool> DefaultIsPublicPage(HttpContext http, string nodePath)
+    // would name a page on the public host. Cold, reactive; bridged once by the caller.
+    private static IObservable<bool> DefaultIsPublicPage(HttpContext http, string nodePath)
     {
         var hub = http.RequestServices.GetService<IMessageHub>();
-        if (hub is null)
-            return false;
-        var data = await SeoResolver.ResolveAsync(hub, nodePath);
-        return data is not null && data.Remainder is null;
+        return hub is null
+            ? Observable.Return(false)
+            : SeoResolver.Resolve(hub, nodePath).Select(data => data is not null && data.Remainder is null);
     }
 }

--- a/memex/Memex.Portal.Shared/Seo/PublicSite.cs
+++ b/memex/Memex.Portal.Shared/Seo/PublicSite.cs
@@ -1,0 +1,184 @@
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Memex.Portal.Shared.Seo;
+
+/// <summary>
+/// 🚨 THE ONE PLACE THAT KNOWS WHICH HOST IS THE PUBLIC WEB SITE.
+///
+/// <para>A portal can serve two hosts from one process: a PUBLIC host (<c>www.meshweaver.cloud</c>)
+/// that is the canonical address of everything a signed-out visitor may read — the landing, the
+/// documentation, the store, the courses — and an APP host (<c>memex.meshweaver.cloud</c>) that
+/// carries sign-in, the APIs, MCP, gRPC and the plugin registry. Search engines key ranking to the
+/// host, so public content must have exactly ONE address: the canonical link, the sitemap, the
+/// Open Graph URL and robots.txt all read the public host from here, and the app host answers a
+/// signed-out request for a public page with a permanent redirect to it
+/// (<see cref="UsePublicHostRedirect"/>).</para>
+///
+/// <para>Nothing here is on when <c>Portal:PublicHost</c> is unset: a single-host deployment
+/// keeps behaving exactly as before, with the request's own host as the canonical one. Full
+/// design: <c>Doc/Architecture/PublicWebPresence</c>.</para>
+/// </summary>
+public static class PublicSite
+{
+    /// <summary>The public host name, e.g. <c>www.meshweaver.cloud</c>. Unset ⇒ single-host.</summary>
+    public const string PublicHostKey = "Portal:PublicHost";
+
+    /// <summary>
+    /// The node a signed-out visitor sees at <c>/</c> — the landing page, e.g. <c>MeshWeaver</c>.
+    /// Unset ⇒ the root is not a node page (the portal's own welcome route answers it).
+    /// </summary>
+    public const string LandingPathKey = "Portal:LandingPath";
+
+    /// <summary>The configured public host, trimmed, or null when the deployment has one host.</summary>
+    public static string? PublicHost(IConfiguration configuration)
+    {
+        var value = configuration[PublicHostKey];
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim().TrimEnd('/');
+    }
+
+    /// <summary>The configured landing node path, trimmed of slashes, or null.</summary>
+    public static string? LandingPath(IConfiguration configuration)
+    {
+        var value = configuration[LandingPathKey];
+        return string.IsNullOrWhiteSpace(value) ? null : value.Trim().Trim('/');
+    }
+
+    /// <summary>
+    /// The base URL every crawler-facing absolute link is built on: <c>https://{PublicHost}</c>
+    /// when a public host is configured, else the request's own scheme and host. The public host
+    /// is always <c>https</c> — it is a name on the internet, not a listener.
+    /// </summary>
+    public static string CanonicalBaseUrl(IConfiguration configuration, HttpRequest request)
+        => PublicHost(configuration) is { } host
+            ? $"https://{host}"
+            : $"{request.Scheme}://{request.Host}";
+
+    /// <summary>
+    /// True when this request arrived on a host that is NOT the public one while a public host is
+    /// configured — i.e. on the app host. Such a response must never be indexed: it is the same
+    /// page under a second address.
+    /// </summary>
+    public static bool IsAppOnlyHost(IConfiguration configuration, HttpRequest request)
+        => PublicHost(configuration) is { } host
+           && !string.Equals(request.Host.Value, host, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The node path a request path stands for: the landing node for <c>/</c> when one is
+    /// configured, otherwise the path itself with its slashes trimmed. Empty for <c>/</c> with no
+    /// landing configured.
+    /// </summary>
+    public static string NodePathFor(IConfiguration configuration, string? requestPath)
+    {
+        var trimmed = (requestPath ?? "").Trim('/');
+        return trimmed.Length == 0 ? LandingPath(configuration) ?? "" : trimmed;
+    }
+
+    /// <summary>
+    /// 🚨 THE APP HOST DOES NOT SERVE PUBLIC PAGES TO STRANGERS — it sends them to the public host.
+    ///
+    /// <para>A signed-out <c>GET</c> for HTML on the app host, for a path that resolves to a page
+    /// the <see cref="MeshWeaver.Mesh.Security.AnonymousGate"/> admits, answers <c>301</c> to the
+    /// same path on the public host. Everything else is untouched: a signed-in user (their session
+    /// cookie lives on the app host), a private page (which goes on to the sign-in redirect as
+    /// before), an API or asset request, and every request when no public host is configured. So
+    /// a link shared from inside the app keeps working for its author and lands a stranger on the
+    /// address search engines know.</para>
+    ///
+    /// <para><paramref name="isPublicPage"/> decides publicness; the default asks the mesh through
+    /// <see cref="SeoResolver.ResolveAsync"/> — the same gate the head is built from — and a test
+    /// hands in its own decision so the routing rule is pinned without a mesh. Register AFTER
+    /// authentication (it reads <c>User.Identity</c>) and before the page endpoints.</para>
+    /// </summary>
+    public static IApplicationBuilder UsePublicHostRedirect(
+        this IApplicationBuilder app, Func<HttpContext, string, Task<bool>>? isPublicPage = null)
+    {
+        var decide = isPublicPage ?? DefaultIsPublicPage;
+        return app.Use(async (http, next) =>
+        {
+            var configuration = http.RequestServices.GetRequiredService<IConfiguration>();
+            var publicHost = PublicHost(configuration);
+            if (publicHost is null
+                || !IsAppOnlyHost(configuration, http.Request)
+                || !HttpMethods.IsGet(http.Request.Method)
+                || http.User.Identity?.IsAuthenticated == true
+                || !AcceptsHtml(http.Request))
+            {
+                await next(http);
+                return;
+            }
+
+            var nodePath = NodePathFor(configuration, http.Request.Path.Value);
+            if (nodePath.Length == 0 || !SeoResolver.IsCandidatePath(nodePath))
+            {
+                await next(http);
+                return;
+            }
+
+            if (!await decide(http, nodePath))
+            {
+                await next(http);
+                return;
+            }
+
+            var target = $"https://{publicHost}{http.Request.Path}{http.Request.QueryString}";
+            http.Response.Redirect(target, permanent: true);
+        });
+    }
+
+    /// <summary>
+    /// 🚨 <c>HEAD</c> IS ANSWERED, NOT REFUSED. Razor component endpoints accept only <c>GET</c>
+    /// and <c>POST</c>, so a link checker, an uptime probe or a crawler asking <c>HEAD /Doc</c> got
+    /// <c>405</c> from a page that serves fine — measured 2026-09-11. This runs the request as a
+    /// <c>GET</c> and discards the body, which is what <c>HEAD</c> means.
+    ///
+    /// <para>🚨 Register BEFORE <c>UseRouting</c>: an endpoint is matched by method, so once routing
+    /// has run the GET-only page route has already failed to match and the rewrite changes
+    /// nothing (the 405 is routing's own answer). A host that never calls <c>UseRouting</c>
+    /// explicitly gets one inserted ahead of its first middleware, which puts this after it.</para>
+    /// </summary>
+    public static IApplicationBuilder UseHeadAsGet(this IApplicationBuilder app)
+        => app.Use(async (http, next) =>
+        {
+            if (!HttpMethods.IsHead(http.Request.Method))
+            {
+                await next(http);
+                return;
+            }
+            http.Request.Method = HttpMethods.Get;
+            var body = http.Response.Body;
+            http.Response.Body = Stream.Null;
+            try
+            {
+                await next(http);
+            }
+            finally
+            {
+                http.Response.Body = body;
+            }
+        });
+
+    private static bool AcceptsHtml(HttpRequest request)
+    {
+        var accept = request.Headers.Accept.ToString();
+        return accept.Length == 0
+               || accept.Contains("text/html", StringComparison.OrdinalIgnoreCase)
+               || accept.Contains("*/*", StringComparison.Ordinal);
+    }
+
+    // The production decision: the same anonymous-gated resolution the crawler head is built
+    // from. A page the gate refuses — or a mesh that does not answer — is "not public", and the
+    // request continues to the app's own handling (sign-in redirect), never to a redirect that
+    // would name a page on the public host.
+    private static async Task<bool> DefaultIsPublicPage(HttpContext http, string nodePath)
+    {
+        var hub = http.RequestServices.GetService<IMessageHub>();
+        if (hub is null)
+            return false;
+        var data = await SeoResolver.ResolveAsync(hub, nodePath);
+        return data is not null && data.Remainder is null;
+    }
+}

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -1,6 +1,8 @@
+using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Graph;
+using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -48,9 +50,40 @@ public sealed record PageIcon(string Href, string? Type)
 /// </summary>
 public sealed record SeoPageData(MeshNode Node, string? Description, string? Image)
 {
-    /// <summary>The node's pre-rendered markdown body, when it carries one — served inside
-    /// <c>&lt;noscript&gt;</c> so non-JS crawlers index the actual page content.</summary>
+    /// <summary>The node's pre-rendered markdown body, when the node CARRIES one. Prefer
+    /// <see cref="Body"/>: this is null for every node whose markdown was never mirrored onto the
+    /// node (a plugin cover's <c>body</c>, a node read through a projection that drops the mirror),
+    /// and a crawler served nothing for exactly those pages (#4056).</summary>
     public string? PreRenderedHtml => Node.PreRenderedHtml;
+
+    /// <summary>
+    /// The part of the request path BEYOND the resolved node — a layout-area route
+    /// (<c>/{node}/{area}/{id}</c>) or a path that does not exist and fell back to its nearest
+    /// ancestor. Null when the URL named the node exactly. The head reads it to keep a fallback
+    /// page out of the index: the framework answers such a URL with the ancestor and HTTP 200,
+    /// which a search engine otherwise files as a soft 404 against the ancestor.
+    ///
+    /// <para><c>init</c> property, not a primary-constructor parameter — the record's constructor is
+    /// a binary contract with every module compiled against it (see <see cref="PageIcon.Rel"/>).</para>
+    /// </summary>
+    public string? Remainder { get; init; }
+
+    /// <summary>
+    /// 🚨 THE PAGE BODY A CRAWLER READS — the node's content as HTML, rendered on the server so the
+    /// FIRST HTTP response carries it. A Blazor Server page otherwise ships an empty
+    /// <c>&lt;body&gt;</c> and fills it over the circuit, and a crawler does not hold a circuit:
+    /// measured 2026-09-11 on memex.meshweaver.cloud, every public page — documentation, course
+    /// lessons, plugin covers — arrived at Googlebot with a rich head and no text at all, and the
+    /// host had zero pages in Google's index.
+    ///
+    /// <para>Resolution order: the prerendered HTML the node already carries; else the
+    /// <c>prerenderedHtml</c> member of its content; else its markdown (<c>content</c> for a
+    /// markdown node, <c>body</c> for a plugin cover) rendered now. Null when the node has no
+    /// document-shaped content (a data node, a pure layout-area page). Only ever produced for a
+    /// node the <see cref="AnonymousGate"/> admitted, like every other member here — a gated
+    /// chapter is refused before this is computed.</para>
+    /// </summary>
+    public string? Body => PreRenderedHtml ?? SeoResolver.RenderBody(Node);
 }
 
 /// <summary>
@@ -105,6 +138,11 @@ public static class SeoResolver
                     .Take(1)
                     .Select(allowed => allowed
                         ? new SeoPageData(node, ExtractDescription(node), ShareImage(node))
+                        {
+                            Remainder = string.IsNullOrEmpty(resolution.Remainder)
+                                ? null
+                                : resolution.Remainder,
+                        }
                         : null))
             .Timeout(TimeSpan.FromSeconds(3))
             .Catch<SeoPageData?, Exception>(_ => Observable.Return<SeoPageData?>(null));
@@ -130,6 +168,24 @@ public static class SeoResolver
             .FirstAsync()
             .ObserveCompletion(ex => logger?.LogWarning(
                 ex, "SEO resolution for '{Path}' faulted after the head had already been produced", path));
+    }
+
+    /// <summary>
+    /// The node's document body as HTML, for <see cref="SeoPageData.Body"/>: the content's own
+    /// <c>prerenderedHtml</c> when it carries one, else its markdown — <c>content</c> (a markdown
+    /// node) or <c>body</c> (a plugin cover) — rendered through the SAME pipeline the portal renders
+    /// it with, so the crawler reads what a visitor reads. Both content shapes (typed record,
+    /// untyped JSON) resolve through <see cref="ContentString"/>. Null for content that is not a
+    /// document. Pure: no hub, no IO.
+    /// </summary>
+    public static string? RenderBody(MeshNode node)
+    {
+        if (ContentString(node, "prerenderedHtml") is { Length: > 0 } prerendered)
+            return prerendered;
+        var markdown = FirstNonEmpty(ContentString(node, "content"), ContentString(node, "body"));
+        return markdown is null
+            ? null
+            : MarkdownContent.Parse(markdown, node.Path, node.Path).PrerenderedHtml;
     }
 
     /// <summary>
@@ -320,6 +376,32 @@ public static class SeoResolver
             JsonElement or null => null,
             var typed => TypedMember(typed, property) as string,
         };
+
+    /// <summary>
+    /// A string-to-string map member of the node's content, by camelCase JSON name (both shapes) —
+    /// e.g. a course's <c>translations</c> (<c>{"de-CH": "AgenticPrimerDe"}</c>), which the head
+    /// turns into <c>hreflang</c> links. Empty when absent or not a map of strings.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ContentStringMap(MeshNode node, string property)
+    {
+        switch (node.Content)
+        {
+            case JsonElement { ValueKind: JsonValueKind.Object } je
+                when je.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.Object:
+                return value.EnumerateObject()
+                    .Where(p => p.Value.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(p.Value.GetString()))
+                    .ToDictionary(p => p.Name, p => p.Value.GetString()!, StringComparer.OrdinalIgnoreCase);
+            case JsonElement or null:
+                return ImmutableDictionary<string, string>.Empty;
+            default:
+                return TypedMember(node.Content, property) switch
+                {
+                    IReadOnlyDictionary<string, string> typed => typed,
+                    IDictionary<string, string> typed => new Dictionary<string, string>(typed, StringComparer.OrdinalIgnoreCase),
+                    _ => ImmutableDictionary<string, string>.Empty,
+                };
+        }
+    }
 
     /// <summary>A decimal member of the node's content, by camelCase JSON name (both shapes).</summary>
     public static decimal? ContentDecimal(MeshNode node, string property) =>

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -83,7 +83,7 @@ public sealed record SeoPageData(MeshNode Node, string? Description, string? Ima
     /// node the <see cref="AnonymousGate"/> admitted, like every other member here — a gated
     /// chapter is refused before this is computed.</para>
     /// </summary>
-    public string? Body => PreRenderedHtml ?? SeoResolver.RenderBody(Node);
+    public string? Body => PreRenderedHtml is { Length: > 0 } mirrored ? mirrored : SeoResolver.RenderBody(Node);
 }
 
 /// <summary>
@@ -102,8 +102,9 @@ public static class SeoResolver
     /// plugin) whose cover renders at <c>/Mcp</c>, so it resolves like any node page; MCP
     /// protocol traffic never reaches the page render path this resolver serves (the endpoint
     /// route and <c>NonfileRouteConstraint</c> keep it off).</summary>
-    private static readonly string[] NonNodePrefixes =
-        ["login", "api", "_blazor", "_framework", "_content", "dev", "static", "webhooks"];
+    private static readonly ImmutableHashSet<string> NonNodePrefixes = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase,
+        "login", "api", "_blazor", "_framework", "_content", "dev", "static", "webhooks");
 
     /// <summary>Whether the request path can be a node page worth resolving.</summary>
     public static bool IsCandidatePath(string? path)
@@ -112,7 +113,7 @@ public static class SeoResolver
         if (trimmed.Length == 0)
             return false;
         var first = trimmed.Split('/')[0];
-        return !NonNodePrefixes.Any(p => string.Equals(p, first, StringComparison.OrdinalIgnoreCase));
+        return !NonNodePrefixes.Contains(first);
     }
 
     /// <summary>
@@ -390,14 +391,14 @@ public static class SeoResolver
                 when je.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.Object:
                 return value.EnumerateObject()
                     .Where(p => p.Value.ValueKind == JsonValueKind.String && !string.IsNullOrWhiteSpace(p.Value.GetString()))
-                    .ToDictionary(p => p.Name, p => p.Value.GetString()!, StringComparer.OrdinalIgnoreCase);
+                    .ToImmutableDictionary(p => p.Name, p => p.Value.GetString()!, StringComparer.OrdinalIgnoreCase);
             case JsonElement or null:
                 return ImmutableDictionary<string, string>.Empty;
             default:
                 return TypedMember(node.Content, property) switch
                 {
-                    IReadOnlyDictionary<string, string> typed => typed,
-                    IDictionary<string, string> typed => new Dictionary<string, string>(typed, StringComparer.OrdinalIgnoreCase),
+                    IEnumerable<KeyValuePair<string, string>> typed =>
+                        typed.ToImmutableDictionary(kv => kv.Key, kv => kv.Value, StringComparer.OrdinalIgnoreCase),
                     _ => ImmutableDictionary<string, string>.Empty,
                 };
         }

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -225,6 +225,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Controls That Cannot Fail](ControlsThatCannotFail)
 - [Catalog Action Identity](CatalogActionIdentity) — a retained click keeps its package when the catalog refreshes
 - [Link Previews](LinkPreviews)
+- [Public Web Presence](PublicWebPresence) — one public host, a body in the first response, a sitemap that descends to every page a stranger may open
 - [Local-First Client & Bootstrap](LocalFirstClient)
 - [PDF Export — one browser, two fidelities](PixelFaithfulExport)
 - [UI Extensibility](UiExtensibility)

--- a/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
@@ -14,7 +14,7 @@ on Google".
 
 ## What was measured on 2026-09-11
 
-The three brand hosts had already collapsed into one: `systemorph.com`, `www.systemorph.com`,
+The brand hosts had already collapsed into one: `systemorph.com`, `www.systemorph.com`,
 `meshweaver.cloud` and `portal.meshweaver.cloud` all answered `301` to `www.meshweaver.cloud`, a
 static one-page nginx site with no meta description, no Open Graph card, no `robots.txt` and no
 sitemap. It was the only MeshWeaver page Google showed. Google also still listed the old WordPress
@@ -118,10 +118,13 @@ whose node type is a **page** — `Markdown`, `Space`, `Store/Plugin`, `Store/Ca
 `Edu/Page` — skipping any path with a satellite segment (`_Thread`, `_Access`, `_GitSync`, `Source`,
 `Test`, `Release`), and asks the gate about each. A reinsurance plugin's partition carries hundreds
 of amount types, cashflows, source files and release markers; none of them is a page, and listing
-them would bury the twenty that are. The listing runs as System (a stale negative here costs a URL,
-never a leak, because every candidate still passes the gate), the gate checks run eight at a time,
-and the same enumeration feeds **Administration → Published to the web**, so the list a person
-reads and the list a crawler gets cannot drift.
+them would bury the twenty that are. The listing runs as System and unbounded (`limit:all` — a
+stated cap would silently clip the one list that claims to be complete; a stale negative here costs
+a URL, never a leak, because every candidate still passes the gate), the gate checks run eight at a
+time, and the same enumeration feeds **Administration → Published to the web**, so the list a
+person reads and the list a crawler gets cannot drift. The sitemap protocol bounds one file at
+50,000 URLs; a deployment that publishes that many pages needs a sitemap index, which is a
+follow-up, not a reason to cap the query.
 
 ### The rest of the crawl surface
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
@@ -1,0 +1,164 @@
+---
+Name: Public Web Presence
+Category: Architecture
+Description: How the portal is also the company's public web site — one canonical host for everything a signed-out visitor may read, a body in the first HTTP response so a crawler can read it, a sitemap that descends to every public page, and the measurements that showed none of it held before.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M3 12h18"/><path d="M12 3a14 14 0 0 1 0 18"/><path d="M12 3a14 14 0 0 0 0 18"/></svg>
+---
+
+# Public Web Presence
+
+The portal serves two audiences from one process: people who sign in and work, and everybody else,
+including search engines. This page is the design for the second audience. It replaces a separate
+static marketing site, and it is the reference for every question of the form "why is this page not
+on Google".
+
+## What was measured on 2026-09-11
+
+The three brand hosts had already collapsed into one: `systemorph.com`, `www.systemorph.com`,
+`meshweaver.cloud` and `portal.meshweaver.cloud` all answered `301` to `www.meshweaver.cloud`, a
+static one-page nginx site with no meta description, no Open Graph card, no `robots.txt` and no
+sitemap. It was the only MeshWeaver page Google showed. Google also still listed the old WordPress
+addresses on `systemorph.com` (`/team/`, `/contact/`, `/imprint/`, `/privacy-policy/`), every one of
+which landed on the homepage, which a search engine files as a soft 404.
+
+`memex.meshweaver.cloud`, the portal, had good crawler plumbing in its `<head>`: a per-page title,
+description, canonical link, Open Graph card, Course and Product JSON-LD for store items, a real
+`robots.txt` and a sitemap of 103 public roots. It had **zero pages in Google's index**, and the
+reason was in the `<body>`:
+
+```
+$ curl -sA Googlebot/2.1 https://memex.meshweaver.cloud/Doc/Architecture/Localization
+<title>Localization · Memex</title>
+<link rel="canonical" href="https://memex.meshweaver.cloud/Doc/Architecture/Localization" />
+…
+<body>
+  <div id="components-reconnect-modal"> Reconnecting… </div>
+  <script src="_framework/blazor.web.js" autostart="false">
+</body>
+```
+
+A Blazor Server page ships an empty body and fills it over the SignalR circuit. Googlebot runs
+JavaScript, but it does not hold a circuit, so it indexed nothing. Three separate defects stacked
+up behind that one symptom:
+
+1. **The only body source was the node-level mirror.** `SeoNoScriptBody` rendered
+   `MeshNode.PreRenderedHtml` inside `<noscript>`. That mirror is set by the file-system and
+   partition storage readers, and only when the content deserialises as a typed `MarkdownContent`.
+   The page resolver issues a mesh-wide `path:` query, which on the partitioned Postgres deployment
+   runs through the cross-schema reader, and that reader never sets the mirror. A plugin cover
+   (`PluginContent.body`) never had one to begin with. So even the noscript fallback was empty.
+2. **The interactive page skipped prerender for strangers.** `ApplicationPage` fetched cached HTML
+   during prerender only for authenticated visitors, on the theory that serving it to a stranger
+   could leak a page the anonymous gate would later refuse. The gate already decides the head; the
+   body had simply never been wired to the same decision.
+3. **The sitemap stopped at the roots.** It listed partition roots of three node types, plus each
+   store plugin's declared `publicSegments`, read through the raw storage adapter from an
+   anonymous HTTP entry. On the partitioned deployment that read returned nothing, so no course
+   chapter was ever listed; and nothing below `Doc` was ever a candidate at all.
+
+Smaller findings in the same sweep: a path that does not exist renders its nearest ancestor with
+HTTP 200 (the canonical link limits the damage, the status does not); `HEAD` answered 405 from
+every page; the default site name was "Memex Portal" because `Portal:SiteName` was unset on the
+public instance; the signed-out landing (`/welcome`) was a generic sign-in page with half of its
+copy hard-coded in English.
+
+## The shape
+
+One process, two hosts, one address per page.
+
+| Host | Role | Indexed |
+|---|---|---|
+| `www.meshweaver.cloud` | **Public.** The landing, the documentation, the store, every course cover and free chapter, every public space. Canonical for all of it. | yes |
+| `memex.meshweaver.cloud` | **App.** Sign-in, the workspace, `/api`, `/mcp`, gRPC, the plugin registry. A stranger asking it for a public page is sent to the public host with `301`. | no |
+| the brand hosts | `301` to the public host, per path, so the old WordPress addresses land on real pages. | — |
+
+Why not rename the portal host to `www`: the Entra, GitHub, Google, Apple and LinkedIn redirect
+URIs, every other deployment's plugin-registry URL, every MCP client configuration and every shared
+link name the app host, and each of those is its own outage class. The two-host shape gets the same
+public result and leaves that decision open.
+
+### Configuration
+
+Two keys, both read through `PublicSite` and both off by default so a single-host deployment is
+unchanged:
+
+- `Portal:PublicHost` — the public host name (`www.meshweaver.cloud`). When set, the canonical
+  link, `og:url`, every sitemap `<loc>` and the `Sitemap:` line of `robots.txt` are built on
+  `https://{PublicHost}` whichever host served the request; a request on any other host is on the
+  **app host**, whose `robots.txt` reads `Disallow: /` and whose pages carry `noindex`.
+- `Portal:LandingPath` — the node a signed-out visitor sees at `/` (the landing Space). Unset, the
+  root stays the portal's own welcome route.
+
+### Publicness is decided by one gate, per node
+
+Nothing here has its own notion of "public". A page is public because its node carries an
+Anonymous Read grant, and `AnonymousGate` is the single instrument that reads it. The head, the
+body, the sitemap, the Open Graph card and the app-host redirect all ask that gate for the exact
+node in question and withhold everything on a refusal or on an undetermined answer. That is what
+makes descending the tree safe: the installer expresses a course's free and paid chapters as a root
+grant plus a deny on every chapter that is not free (see `PackageInstaller.EnsureDeclaredAccess`),
+and a commercial plugin's cover can be public while its content is not. Asking per node is both the
+fix for the empty sitemap and the reason the body can be served.
+
+### The body is in the first response
+
+`SeoPageData.Body` is the page text a crawler reads: the node's mirrored HTML when it carries one,
+else the content's own `prerenderedHtml`, else its markdown (`content` for a markdown node, `body`
+for a plugin cover) rendered through the portal's own pipeline, anchored on the node so links
+resolve as they do for a signed-in visitor. It is computed only for a node the gate admitted, and it
+is rendered **visibly** in the static server pass of the page, not inside `<noscript>`: Googlebot
+renders with JavaScript on and may ignore noscript content, and the visible article is what the
+interactive circuit replaces on hydration. The interactive page reads the same per-request stash
+the head resolved into, so the mesh is asked once per request.
+
+### The sitemap descends
+
+For every root the gate admits, `SeoEndpoints.EnumeratePublished` lists the root's descendants
+whose node type is a **page** — `Markdown`, `Space`, `Store/Plugin`, `Store/Catalog`, `Edu/Module`,
+`Edu/Page` — skipping any path with a satellite segment (`_Thread`, `_Access`, `_GitSync`, `Source`,
+`Test`, `Release`), and asks the gate about each. A reinsurance plugin's partition carries hundreds
+of amount types, cashflows, source files and release markers; none of them is a page, and listing
+them would bury the twenty that are. The listing runs as System (a stale negative here costs a URL,
+never a leak, because every candidate still passes the gate), the gate checks run eight at a time,
+and the same enumeration feeds **Administration → Published to the web**, so the list a person
+reads and the list a crawler gets cannot drift.
+
+### The rest of the crawl surface
+
+- A path with a remainder beyond the resolved node (a layout-area route, or a missing page that
+  fell back to its ancestor) carries `noindex` and a canonical link to the node it actually
+  rendered, so a fallback never competes with the real page.
+- `HEAD` is answered as a `GET` with the body discarded (`PublicSite.UseHeadAsGet`).
+- The public host's `robots.txt` keeps `/login`, `/welcome`, `/api/`, `/_blazor` and `/dev/` out.
+- Course covers keep their `Course` JSON-LD with Systemorph as the provider and the price as an
+  `Offer`; the English and German twins of a course point at each other with `hreflang`.
+
+## Verifying a deployment
+
+Each check is one command, and each has a negative control: run it on the app host too, where the
+answer must differ.
+
+```
+# the body: the article text, not the reconnect modal
+curl -sA Googlebot/2.1 https://www.meshweaver.cloud/Doc/Architecture/Localization | grep -c '<article'
+# the sitemap descends: a chapter and a doc page are listed
+curl -s https://www.meshweaver.cloud/sitemap.xml | grep -c 'AgenticPrimer/01-TheMagicWish'
+curl -s https://www.meshweaver.cloud/sitemap.xml | grep -c 'Doc/Architecture/'
+# the app host sends strangers away and keeps crawlers out
+curl -sI https://memex.meshweaver.cloud/Doc | grep -i '^location: https://www.meshweaver.cloud/Doc'
+curl -s https://memex.meshweaver.cloud/robots.txt | grep -c 'Disallow: /$'
+# HEAD is answered
+curl -sI https://www.meshweaver.cloud/Doc | head -1
+```
+
+Search Console's URL inspection, "rendered HTML" view, is the acceptance test for the whole design:
+it must show the article text for a documentation page, a course cover, a course lesson and a plugin
+cover. Indexing before that view shows text only fills the report with "crawled, currently not
+indexed".
+
+## Related
+
+- [Access Control](../AccessControl) — the anonymous grant and the gate.
+- [Localization](../Localization) — the landing renders as authored, in English and German.
+- [Operating from the portal](../OperatingFromThePortal) — how the ingress change that adds the
+  public host is rolled.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-search-engines-can-now-read-every-public-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-search-engines-can-now-read-every-public-page.md
@@ -1,0 +1,38 @@
+---
+Name: Search engines can now read every public page
+Category: Fix
+Description: A public page — a course lesson, a documentation chapter, a plugin's cover — reached a search engine with its title and description but no text, and the sitemap named only the top of each tree. Every public page now ships its content in the first response, the sitemap lists every page a stranger may open, and a deployment can name one public host that all of it is filed under.
+Icon: Globe
+Order: -20260911
+---
+
+# Search engines can now read every public page
+
+Some pages here are public on purpose: course covers and their free lessons, the platform
+documentation, the plugin store, the showcases. Each of them already told a search engine what it
+was — a title, a description, a share card — and then handed it an empty page, because the text
+only arrived once the browser had opened a live connection, which a crawler never does. Measured on
+the public instance on 2026-09-11: not one of its pages was in Google's index.
+
+Three things change.
+
+**The page arrives with its text.** A public page now carries its content in the very first
+response, rendered on the server from the same source a signed-in visitor sees. The rule that
+decides whether a stranger may read a page is unchanged and still decides this: a lesson behind a
+paywall is refused before any of its text is produced.
+
+**The sitemap goes all the way down.** It used to name the top of each public tree — the course,
+never its lessons; the documentation, never a chapter. It now lists every page below a public root
+that a stranger may open, and only those: data records, source files and release markers in the
+same tree are not pages and are not listed. **Administration → Published to the web** reads the
+same list, so what you see there is what a search engine is told.
+
+**One address per page.** A deployment that serves its public site and its signed-in workspace on
+two host names can now say which one is the public one. Every canonical link and every sitemap
+entry then names that host, the workspace host tells crawlers to stay out, and a stranger who
+follows a shared workspace link to a public page is sent to the public address instead. A
+deployment with one host is unchanged.
+
+Also in this change: a `HEAD` request to a page is answered instead of refused, and a URL that does
+not exist and falls back to its nearest page is marked so that fallback never competes with the real
+page in search results.

--- a/test/Memex.Portal.Shared.Test/PublicSiteTest.cs
+++ b/test/Memex.Portal.Shared.Test/PublicSiteTest.cs
@@ -1,0 +1,184 @@
+using System.Net;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Seo;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins the two-host rule (<see cref="PublicSite"/>): with a public host configured, the app host
+/// sends a stranger's request for a public page to the public host with a permanent redirect,
+/// declares itself off-limits to crawlers, and every absolute crawler-facing URL names the public
+/// host — while a deployment with ONE host behaves exactly as before. Also pins that <c>HEAD</c>
+/// is answered (it was a 405 from every page, measured 2026-09-11).
+/// </summary>
+public class PublicSiteTest
+{
+    private const string Public = "www.example.test";
+    private const string App = "memex.example.test";
+
+    private static IConfiguration Config(string? publicHost, string? landing = null)
+        => new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [PublicSite.PublicHostKey] = publicHost,
+            [PublicSite.LandingPathKey] = landing,
+        }).Build();
+
+    private static HttpRequest RequestOn(string host, string path = "/")
+    {
+        var http = new DefaultHttpContext();
+        http.Request.Scheme = "https";
+        http.Request.Host = new HostString(host);
+        http.Request.Path = path;
+        return http.Request;
+    }
+
+    [Fact]
+    public void WithNoPublicHost_TheRequestHostIsCanonical_AndNothingIsAppOnly()
+    {
+        var configuration = Config(null);
+        Assert.Equal("https://memex.example.test", PublicSite.CanonicalBaseUrl(configuration, RequestOn(App)));
+        Assert.False(PublicSite.IsAppOnlyHost(configuration, RequestOn(App)));
+    }
+
+    [Fact]
+    public void WithAPublicHost_ItIsCanonicalFromEveryHost_AndTheOtherHostIsAppOnly()
+    {
+        var configuration = Config(Public);
+        Assert.Equal("https://www.example.test", PublicSite.CanonicalBaseUrl(configuration, RequestOn(App)));
+        Assert.Equal("https://www.example.test", PublicSite.CanonicalBaseUrl(configuration, RequestOn(Public)));
+        Assert.True(PublicSite.IsAppOnlyHost(configuration, RequestOn(App)));
+        Assert.False(PublicSite.IsAppOnlyHost(configuration, RequestOn("WWW.EXAMPLE.TEST")));
+    }
+
+    [Fact]
+    public void TheRootIsTheLandingNode_OnlyWhenOneIsConfigured()
+    {
+        Assert.Equal("MeshWeaver", PublicSite.NodePathFor(Config(Public, "/MeshWeaver/"), "/"));
+        Assert.Equal("", PublicSite.NodePathFor(Config(Public), "/"));
+        Assert.Equal("Doc/Architecture", PublicSite.NodePathFor(Config(Public, "MeshWeaver"), "/Doc/Architecture/"));
+    }
+
+    /// <summary>
+    /// The pipeline under test: the redirect and HEAD middleware over a TestServer, a stub
+    /// publicness decision (a real one asks the mesh through the anonymous gate), and one ordinary
+    /// page route so "not redirected" is proved against something that answers.
+    /// </summary>
+    private static WebApplication Host(string? publicHost, string? landing = null)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [PublicSite.PublicHostKey] = publicHost,
+            [PublicSite.LandingPathKey] = landing,
+        });
+        var app = builder.Build();
+        // HEAD→GET must run BEFORE routing: an endpoint is matched by method, and a GET-only page
+        // route never matches HEAD. Explicit UseRouting here is what the portal's pipeline has;
+        // without it WebApplication would insert routing ahead of every middleware.
+        app.UseHeadAsGet();
+        app.UseRouting();
+        app.UsePublicHostRedirect((_, nodePath) =>
+            Task.FromResult(nodePath is "PublicSpace" or "PublicSpace/Guide" or "Landing"));
+        app.MapSeo();
+        app.MapGet("/{**path}", (string? path) => Results.Text($"page:{path}", "text/html"));
+        app.Start();
+        return app;
+    }
+
+    private static HttpRequestMessage On(string host, string path, string method = "GET", string accept = "text/html")
+    {
+        var request = new HttpRequestMessage(new HttpMethod(method), path);
+        request.Headers.Host = host;
+        request.Headers.TryAddWithoutValidation("Accept", accept);
+        return request;
+    }
+
+    [Fact]
+    public async Task AStrangerAskingTheAppHostForAPublicPage_IsSentToThePublicHost_Permanently()
+    {
+        using var app = Host(Public);
+        var client = app.GetTestClient();
+        var response = await client.SendAsync(On(App, "/PublicSpace/Guide?tab=1"));
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("https://www.example.test/PublicSpace/Guide?tab=1", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task ThePublicHostServesThePage_AndNeverRedirectsToItself()
+    {
+        using var app = Host(Public);
+        var response = await app.GetTestClient().SendAsync(On(Public, "/PublicSpace/Guide"));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("page:PublicSpace/Guide", await response.Content.ReadAsStringAsync());
+    }
+
+    [Fact]
+    public async Task APrivatePage_AnApiRoute_AndANonHtmlRequest_StayOnTheAppHost()
+    {
+        using var app = Host(Public);
+        var client = app.GetTestClient();
+        // Private: the decision says no → the app's own handling (sign-in) answers, no redirect.
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(On(App, "/PrivateSpace"))).StatusCode);
+        // Not a node path.
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(On(App, "/api/version"))).StatusCode);
+        // A JSON client is never bounced between hosts.
+        Assert.Equal(HttpStatusCode.OK, (await client.SendAsync(On(App, "/PublicSpace", accept: "application/json"))).StatusCode);
+    }
+
+    [Fact]
+    public async Task WithOneHost_NothingRedirects()
+    {
+        using var app = Host(publicHost: null);
+        var response = await app.GetTestClient().SendAsync(On(App, "/PublicSpace"));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task TheRootOnTheAppHost_IsTheLandingPage_AndRedirectsLikeOne()
+    {
+        using var app = Host(Public, landing: "Landing");
+        var response = await app.GetTestClient().SendAsync(On(App, "/"));
+        Assert.Equal(HttpStatusCode.MovedPermanently, response.StatusCode);
+        Assert.Equal("https://www.example.test/", response.Headers.Location?.ToString());
+    }
+
+    [Fact]
+    public async Task RobotsOnTheAppHost_DisallowsEverything_AndPointsAtThePublicSitemap()
+    {
+        using var app = Host(Public);
+        var body = await (await app.GetTestClient().SendAsync(On(App, "/robots.txt", accept: "*/*"))).Content.ReadAsStringAsync();
+        Assert.Contains("Disallow: /\n", body.Replace("\r\n", "\n") + "\n");
+        Assert.Contains("Sitemap: https://www.example.test/sitemap.xml", body);
+        Assert.DoesNotContain("Disallow: /login", body);
+    }
+
+    [Fact]
+    public async Task RobotsOnThePublicHost_KeepsThePageSurfaceOpen()
+    {
+        using var app = Host(Public);
+        var body = await (await app.GetTestClient().SendAsync(On(Public, "/robots.txt", accept: "*/*"))).Content.ReadAsStringAsync();
+        Assert.Contains("Disallow: /login", body);
+        Assert.Contains("Disallow: /welcome", body);
+        Assert.Contains("Disallow: /api/", body);
+        Assert.DoesNotContain("Disallow: /\n", body.Replace("\r\n", "\n"));
+        Assert.Contains("Sitemap: https://www.example.test/sitemap.xml", body);
+    }
+
+    [Fact]
+    public async Task Head_IsAnsweredLikeGet_WithNoBody()
+    {
+        using var app = Host(publicHost: null);
+        var response = await app.GetTestClient().SendAsync(On(App, "/Doc", method: "HEAD"));
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal("", await response.Content.ReadAsStringAsync());
+    }
+}

--- a/test/Memex.Portal.Shared.Test/PublicSiteTest.cs
+++ b/test/Memex.Portal.Shared.Test/PublicSiteTest.cs
@@ -1,4 +1,5 @@
 using System.Net;
+using System.Reactive.Linq;
 using Memex.Portal.Shared.Api;
 using Memex.Portal.Shared.Seo;
 using Microsoft.AspNetCore.Builder;
@@ -87,7 +88,7 @@ public class PublicSiteTest
         app.UseHeadAsGet();
         app.UseRouting();
         app.UsePublicHostRedirect((_, nodePath) =>
-            Task.FromResult(nodePath is "PublicSpace" or "PublicSpace/Guide" or "Landing"));
+            Observable.Return(nodePath is "PublicSpace" or "PublicSpace/Guide" or "Landing"));
         app.MapSeo();
         app.MapGet("/{**path}", (string? path) => Results.Text($"page:{path}", "text/html"));
         app.Start();

--- a/test/Memex.Portal.Shared.Test/SeoPageBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoPageBodyTest.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins <see cref="SeoPageData.Body"/> — the page text a crawler reads from the FIRST HTTP response.
+/// Measured 2026-09-11 on memex.meshweaver.cloud (#4056): every public page shipped a rich head
+/// and an empty body, because the only body source was the node's mirrored
+/// <see cref="MeshNode.PreRenderedHtml"/>, which a plugin cover never carries and a cross-partition
+/// read drops. The body must therefore come from the CONTENT, in every shape content arrives in.
+/// </summary>
+public class SeoPageBodyTest
+{
+    private static MeshNode Node(object? content) =>
+        new("Page", "Space") { Name = "Page", Content = content };
+
+    private static JsonElement Json(object value) =>
+        JsonSerializer.SerializeToElement(value);
+
+    [Fact]
+    public void ANodeThatCarriesTheMirror_ServesItUnchanged()
+    {
+        var node = Node(new MarkdownContent { Content = "# Ignored" }) with { PreRenderedHtml = "<p>mirrored</p>" };
+        Assert.Equal("<p>mirrored</p>", new SeoPageData(node, null, null).Body);
+    }
+
+    [Fact]
+    public void TypedMarkdown_WithoutTheMirror_ServesItsOwnPrerenderedHtml()
+    {
+        // The exact shape the partitioned Postgres cross-schema read returns for a documentation
+        // page: typed content that carries prerenderedHtml, and a node-level mirror that is null.
+        var node = Node(new MarkdownContent { Content = "# Title", PrerenderedHtml = "<h1>Title</h1>" });
+        Assert.Null(node.PreRenderedHtml);
+        Assert.Equal("<h1>Title</h1>", new SeoPageData(node, null, null).Body);
+    }
+
+    [Fact]
+    public void TypedMarkdown_WithNoPrerender_IsRenderedNow()
+    {
+        var body = new SeoPageData(Node(new MarkdownContent { Content = "Hello **world**" }), null, null).Body;
+        Assert.NotNull(body);
+        Assert.Contains("<strong>world</strong>", body);
+    }
+
+    [Fact]
+    public void UntypedJson_PrerenderedHtmlMember_WinsOverMarkdown()
+    {
+        var node = Node(Json(new { content = "# raw", prerenderedHtml = "<h1>ready</h1>" }));
+        Assert.Equal("<h1>ready</h1>", new SeoPageData(node, null, null).Body);
+    }
+
+    [Fact]
+    public void APluginCover_RendersItsBodyMarkdown()
+    {
+        // A store plugin's cover (a course, the reinsurance suite) is `PluginContent { body }` —
+        // markdown, never prerendered. This is the page a search for "agentic underwriting" must
+        // be able to read.
+        var node = Node(Json(new
+        {
+            body = "## Agentic underwriting\n\nTreaties, acceptances and sections as first-class nodes.",
+            price = 900,
+        }));
+        var body = new SeoPageData(node, null, null).Body;
+        Assert.NotNull(body);
+        Assert.Contains("Agentic underwriting</h2>", body);
+        Assert.Contains("<p>Treaties, acceptances and sections as first-class nodes.</p>", body);
+    }
+
+    [Fact]
+    public void ADataNode_HasNoBody()
+    {
+        Assert.Null(new SeoPageData(Node(Json(new { amount = 12, currency = "CHF" })), null, null).Body);
+        Assert.Null(new SeoPageData(Node(null), null, null).Body);
+    }
+
+    [Fact]
+    public void RenderBody_IsPure_AndRewritesLinksAgainstTheNodePath()
+    {
+        // Rendering goes through the portal's own markdown pipeline, anchored on the node — the
+        // same HTML a signed-in visitor sees, not a second renderer that drifts from it.
+        var html = SeoResolver.RenderBody(Node(Json(new { content = "See [next](Next)." })));
+        Assert.NotNull(html);
+        Assert.Contains("<a href=", html);
+        Assert.Contains("next</a>", html);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/SeoPageBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoPageBodyTest.cs
@@ -29,6 +29,13 @@ public class SeoPageBodyTest
     }
 
     [Fact]
+    public void AnEmptyMirror_FallsThroughToTheContent_LikeANullOne()
+    {
+        var node = Node(new MarkdownContent { Content = "# Title", PrerenderedHtml = "<h1>Title</h1>" }) with { PreRenderedHtml = "" };
+        Assert.Equal("<h1>Title</h1>", new SeoPageData(node, null, null).Body);
+    }
+
+    [Fact]
     public void TypedMarkdown_WithoutTheMirror_ServesItsOwnPrerenderedHtml()
     {
         // The exact shape the partitioned Postgres cross-schema read returns for a documentation

--- a/test/Memex.Portal.Shared.Test/SitemapDescentTest.cs
+++ b/test/Memex.Portal.Shared.Test/SitemapDescentTest.cs
@@ -1,0 +1,89 @@
+using System.Reactive.Linq;
+using Memex.Portal.Shared.Api;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Pins what "published to the web" enumerates (<see cref="SeoEndpoints.EnumeratePublished"/>):
+/// every PAGE below a public root that the anonymous gate admits — and nothing else. Before #4056
+/// the list stopped at the partition roots, so the documentation tree and every course chapter
+/// were invisible to search engines; and the one descent it did attempt (a store plugin's declared
+/// public segments) read through the raw storage adapter and came back empty on the partitioned
+/// deployment. The gate, asked per node, is now the one definition — the same grants and denies
+/// the installer writes for a course's free and paid chapters.
+/// </summary>
+public class SitemapDescentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .AddMeshNodes(
+                // A public space: the root carries the Anonymous Viewer grant, which flows down.
+                new MeshNode("PublicSpace") { Name = "Public Space", NodeType = "Space" },
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", "PublicSpace",
+                    accessObject: WellKnownUsers.Anonymous),
+                // Pages, at two depths.
+                new MeshNode("Guide", "PublicSpace") { Name = "Guide", NodeType = "Markdown" },
+                new MeshNode("Deep", "PublicSpace/Guide") { Name = "Deep", NodeType = "Markdown" },
+                new MeshNode("Lesson1", "PublicSpace") { Name = "Lesson 1", NodeType = "Edu/Module" },
+                // A paid chapter: the per-child Anonymous DENY the installer writes.
+                new MeshNode("Lesson2", "PublicSpace") { Name = "Lesson 2", NodeType = "Edu/Module" },
+                AssignmentNodeFactory.UserRole(
+                    WellKnownUsers.Anonymous, "Viewer", "PublicSpace/Lesson2",
+                    denied: true, accessObject: WellKnownUsers.Anonymous),
+                // Not pages: a data node, code under a satellite segment, an underscore satellite.
+                new MeshNode("GNPI", "PublicSpace/AmountType") { Name = "GNPI", NodeType = "Reinsurance/AmountType" },
+                new MeshNode("Foo", "PublicSpace/Source") { Name = "Foo", NodeType = "Markdown" },
+                new MeshNode("t1", "PublicSpace/_Thread") { Name = "Thread", NodeType = "Markdown", MainNode = "PublicSpace" },
+                // A private space with a page: no grant, so neither is listed.
+                new MeshNode("PrivateSpace") { Name = "Private Space", NodeType = "Space" },
+                new MeshNode("Page", "PrivateSpace") { Name = "Page", NodeType = "Markdown" });
+
+    // Granular permissions — no blanket admin seed, so the anonymous subject holds exactly what
+    // the nodes above grant.
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact]
+    public async Task EveryAdmittedPageBelowAPublicRoot_IsPublished_AndNothingElse()
+    {
+        var pages = await SeoEndpoints.EnumeratePublished(Mesh)
+            .Timeout(TestTimeouts.Convergence);
+        var paths = pages.Select(p => p.Path).OrderBy(p => p, StringComparer.Ordinal).ToList();
+
+        Assert.Equal(
+            ["PublicSpace", "PublicSpace/Guide", "PublicSpace/Guide/Deep", "PublicSpace/Lesson1"],
+            paths);
+    }
+
+    [Fact]
+    public async Task TheSitemap_NamesEachPageOnTheCanonicalHost_WithItsLastModified()
+    {
+        var xml = await SeoEndpoints.BuildSitemap(Mesh, "https://www.example.test")
+            .Timeout(TestTimeouts.Convergence);
+
+        Assert.Contains("<loc>https://www.example.test/PublicSpace/Guide/Deep</loc>", xml);
+        Assert.Contains("<loc>https://www.example.test/PublicSpace/Lesson1</loc>", xml);
+        Assert.DoesNotContain("Lesson2", xml);
+        Assert.DoesNotContain("PrivateSpace", xml);
+        Assert.DoesNotContain("_Thread", xml);
+        Assert.DoesNotContain("AmountType", xml);
+    }
+
+    [Theory]
+    [InlineData("Guide", true)]
+    [InlineData("Guide/Deep", true)]
+    [InlineData("_Thread/t1", false)]
+    [InlineData("Source/Foo", false)]
+    [InlineData("Cedent/Test/CedentTests", false)]
+    [InlineData("Acceptance/Release/20260812", false)]
+    public void APagePath_HasNoSatelliteSegment(string relative, bool isPage)
+        => Assert.Equal(isPage, SeoEndpoints.IsPagePath(relative));
+}


### PR DESCRIPTION
## Why

Measured 2026-09-11 on memex.meshweaver.cloud: **zero pages in Google's index.** Every public page — documentation, course lessons, plugin covers — reached Googlebot with a rich `<head>` and an empty `<body>` (a Blazor Server page fills its body over the circuit, which a crawler never holds), and the sitemap listed only the 103 partition roots. Full design and measurements: `Doc/Architecture/PublicWebPresence`.

## What

- **`SeoPageData.Body`** — the page text for the first response: the node's mirrored HTML, else the content's `prerenderedHtml`, else its markdown (`content` for a markdown node, `body` for a plugin cover) rendered through the portal's own pipeline. Only for a node the anonymous gate admitted. `Remainder` records a URL that resolved past its node, so the head can `noindex` the ancestor-fallback.
- **Sitemap descends.** `EnumeratePublished` lists every page-shaped descendant (`Markdown`, `Space`, `Store/*`, `Edu/Module`, `Edu/Page`; no satellite segments) of an admitted root and asks `AnonymousGate` **per node** — the same grants and denies the installer writes for free and paid chapters. This replaces the `publicSegments` read through the raw storage adapter, which returned nothing on the partitioned deployment (no course chapter was ever listed).
- **`PublicSite`** (`Portal:PublicHost`, `Portal:LandingPath`): canonical, `og:url`, sitemap `<loc>` and robots' `Sitemap:` name the public host; the app host's robots is `Disallow: /`; `UsePublicHostRedirect` sends a stranger's HTML GET for a public page on the app host to the public host with 301; `UseHeadAsGet` answers `HEAD` (was 405 from every page). All off when the key is unset.
- Minimal-API endpoints taking `IMessageHub` declare `[FromServices]` explicitly (parameter inference classified it as the body in a host without a mesh).
- Chart renders `Portal__SiteName`, `Portal__PublicHost`, `Portal__LandingPath`.

## Verified locally

Release `-warnaserror` clean on `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`; `helm lint` clean.

| Suite | Result |
|---|---|
| `SeoPageBodyTest` (7), `PublicSiteTest` (11), `SitemapDescentTest` (8, real mesh + RLS) | 26/26 pass |
| `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest` | 2/2 pass |

## Counterparts

The Plugins half (Postgres readers mirror `prerenderedHtml` on the cross-schema path; `ApplicationPage` renders the stashed body visibly for signed-out visitors; landing at `/`; `/welcome` and `/login` noindex; middleware wiring) follows once this merges and the pin moves. The Memex config repo half adds the keys and points `www.meshweaver.cloud` at the portal.

Pairs-with: none — no public type or member leaves core (`PagesOf`/`PublicSegments` were private).
Implementers: none — no interface member added.
Mirror-sync: none — no catalog key added or re-worded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X2nC2Harw9NPHNrMRbAkBB