### PR TITLE
fix(ci): arm auto-merge only onto the repository's default branch

### DIFF
--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -37,6 +37,9 @@
 #     that is the intended way to say "not ready", rather than withholding the arm.
 #   * forks are skipped: arming a PR from a fork would let an outside branch merge itself the
 #     moment the required set passes.
+#   * a PR whose BASE is not the default branch is NOT armed, and is told so. Auto-merge waits for
+#     the base's required contexts, and an unprotected base has none — so an arm there is an
+#     immediate merge, not a deferred one. See the base step for the measured instance.
 #
 # 🚨🚨 THE ARM CREDENTIAL IS LEAD, NOT TRIM — it decides whether main's push lanes run at all.
 # This lane armed with `secrets.GITHUB_TOKEN` for six hours on 2026-09-01, and the consequence was
@@ -111,15 +114,17 @@ jobs:
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
     steps:
-      # No `if:` on any step that DECIDES anything below. The assert, the mint and the arm run
-      # unconditionally: they assert and fail, they do not choose whether to run. The ONE exemption
-      # is on the job, and it is a property of the EVENT (draft, fork), never a question about
-      # whether a credential happens to be set — invariant #3.
+      # No `if:` on any step that ASSERTS anything. The credential assert, the base read and the
+      # mint run unconditionally: they assert and fail, they do not choose whether to run. Every
+      # exemption in this file is a property of the EVENT (draft, fork, base branch), never a
+      # question about whether a credential happens to be set — invariant #3.
       #
-      # The single `if:` further down is on a step that only PRINTS, and it is conditioned on a
-      # failure having already happened. A diagnostic that can turn nothing green is not a
-      # trapdoor — the distinction that matters is whether an `if:` can make a gate not run, and
-      # that one cannot.
+      # The `if:`s further down govern ACTIONS and DIAGNOSTICS, not gates: one prints because a
+      # failure already happened, one comments because the base already disqualified the arm, and
+      # the arm itself runs only when there is a token to arm with and a protected base to arm
+      # onto. None of them can make a verification not run, which is the distinction that matters —
+      # and the job itself is never skipped by any of them, so "not armed" and "the lane never ran"
+      # stay two different things a reader can tell apart.
       - name: The App credential, or a red run naming what to provision
         env:
           MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
@@ -134,6 +139,75 @@ jobs:
             exit 1
           fi
           echo "App credential present."
+
+      # 🚨🚨 ARM ONLY ONTO THE DEFAULT BRANCH. On any other base, `--auto` does not mean
+      # "merge when green" — it means "merge NOW".
+      #
+      # Auto-merge waits for exactly the contexts BRANCH PROTECTION requires of the pull request's
+      # BASE. In this fleet protection is configured on the default branch and nowhere else (core:
+      # ruleset `main pr protection`; the satellites: classic protection on `main`). A STACKED pull
+      # request — one opened against another pull request's feature branch, which is how a change
+      # set gets split for review — therefore has a base that is protected by nothing, an EMPTY
+      # required set, and a condition that is satisfied the instant GitHub first reads it.
+      #
+      # Measured 2026-09-11: MeshWeaver.Plugins#1685 was opened against the feature branch of
+      # #1681, this lane armed it, and GitHub merged it at 21:03:23Z — 61 seconds after it was
+      # opened, BEFORE its own CI had started a single job. Nothing failed and nothing was
+      # bypassed: the stack simply collapsed unreviewed, exactly as configured. This lane is the
+      # fleet's only copy, so the same hole was open in all eight repositories at once.
+      #
+      # 🚨 The default branch is READ, never assumed. Every repo in the fleet uses `main` today —
+      # which is precisely why a literal `main` here would be indistinguishable from a correct
+      # check while quietly being a copy of a fact, the drift this file's header exists to stop.
+      # `github.event.repository.default_branch` is on the pull-request payload in BOTH modes (a
+      # caller forwards its own event), so there is one reading and no fallback to get wrong.
+      #
+      # 🚨 This is NOT a skip-trapdoor. It asks a property of the EVENT, exactly as the job's
+      # draft/fork exemption does, never whether a credential happens to be set — and the job still
+      # RUNS and still reports on a non-default base rather than vanishing, so "not armed" and
+      # "lane never ran" stay distinguishable. This lane publishes no required context.
+      - name: The base branch decides whether arming means "when green" or "now"
+        id: base
+        env:
+          BASE: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          # Assert the readings rather than defaulting them. An empty default branch would make
+          # every base look non-default and silently stop arming the entire fleet — the mirror
+          # image of the failure above — so it gets a red that names itself instead.
+          if [ -z "$DEFAULT_BRANCH" ]; then
+            echo "::error::the pull-request payload carried no repository.default_branch, so this lane cannot tell a protected base from an unprotected one. Refusing to arm."
+            exit 1
+          fi
+          if [ -z "$BASE" ]; then
+            echo "::error::the pull-request payload carried no base.ref, so this lane cannot tell what this pull request would merge into. Refusing to arm."
+            exit 1
+          fi
+          if [ "$BASE" = "$DEFAULT_BRANCH" ]; then
+            echo "onto-default=true" >> "$GITHUB_OUTPUT"
+            echo "base '$BASE' is the default branch: arming means 'merge when the required contexts pass'."
+            exit 0
+          fi
+          echo "onto-default=false" >> "$GITHUB_OUTPUT"
+          echo "::warning::auto-merge was NOT armed on this pull request — it targets '$BASE', not the default branch '$DEFAULT_BRANCH'. A non-default base carries no branch protection and therefore no required contexts, so arming would merge this pull request immediately, before its own CI has run."
+          {
+            echo "### Auto-merge not armed — the base is not the default branch"
+            echo
+            echo "| | |"
+            echo "|---|---|"
+            echo "| base | \`$BASE\` |"
+            echo "| default branch | \`$DEFAULT_BRANCH\` |"
+            echo
+            echo "Auto-merge waits for the required contexts of the **base**. \`$BASE\` is not the"
+            echo "default branch, so branch protection does not cover it, the required set is empty,"
+            echo "and the condition is satisfied the moment GitHub reads it — the pull request would"
+            echo "merge before any check started (measured: MeshWeaver.Plugins#1685, merged 61"
+            echo "seconds after it was opened)."
+            echo
+            echo "Merge this pull request by hand once you are satisfied with it, or retarget it at"
+            echo "\`$DEFAULT_BRANCH\` and the next event on it will arm it normally."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # 🚨 `gh pr merge --auto` either enables ordinary auto-merge or enqueues the PR, depending on
       # the repository. Both mutations need `Pull requests: write`; the merge they later perform
@@ -200,11 +274,49 @@ jobs:
             echo "not granted. \`arm-credential.yml\` is the lane that stays red until that is done."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      # Conditioned on the MINT's outcome, never on whether a secret "looks set" — the shape
-      # AGENTS.md forbids. Without a token there is nothing to arm with; running gh anyway would
-      # fall back to the runner's default credential, which is the #2916 outage exactly.
+      # Silence is the thing to avoid. The warning above lands in a run log nobody opens for a
+      # lane whose entire normal output is the word "armed" — so an author whose stacked pull
+      # request is sitting there unarmed cannot tell this from a lane that is simply broken, and
+      # waits for an arm that is never coming. Say it once on the pull request itself, where the
+      # author already is.
+      #
+      # ONCE, not once per event: `synchronize` fires on every push, and a lane that repeats itself
+      # is a lane people mute. The marker is read back before anything is written.
+      - name: Say on the pull request that a non-default base was not armed
+        if: steps.base.outputs.onto-default == 'false' && steps.arm-token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.arm-token.outputs.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          BASE: ${{ github.event.pull_request.base.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          MARKER: '<!-- auto-arm:non-default-base -->'
+        run: |
+          set -euo pipefail
+          # Not swallowed: a read that fails says so and leaves the run-log warning standing. It
+          # must not fail the job — the honest per-PR outcome of a comment that could not be
+          # written is still "this pull request was not armed", which is already reported above.
+          if ! existing=$(gh api "repos/$REPO/issues/$PR/comments" --paginate --jq '.[].body'); then
+            echo "::warning::could not read the existing comments on #$PR, so nothing was posted; the run-log warning above stands."
+            exit 0
+          fi
+          if printf '%s' "$existing" | grep -qF -- "$MARKER"; then
+            echo "already said so on #$PR — nothing to do"
+            exit 0
+          fi
+          body=$(printf '%s\n%s\n' \
+            "$MARKER" \
+            "**Auto-merge was not armed.** This pull request targets \`$BASE\`, not the default branch \`$DEFAULT_BRANCH\` — a non-default base has no branch protection and therefore no required contexts, so arming it would merge it immediately, before its own CI runs. Merge it by hand when you are ready, or retarget it at \`$DEFAULT_BRANCH\` to have it armed normally.")
+          gh pr comment "$PR" --repo "$REPO" --body "$body"
+          echo "commented on #$PR"
+
+      # Conditioned on the MINT's outcome and on the BASE, never on whether a secret "looks set" —
+      # the shape AGENTS.md forbids. Without a token there is nothing to arm with; running gh
+      # anyway would fall back to the runner's default credential, which is the #2916 outage
+      # exactly. And without a default-branch base there is nothing to WAIT for, so an arm here is
+      # an immediate merge rather than a deferred one (see the base step above).
       - name: Arm it
-        if: steps.arm-token.outcome == 'success'
+        if: steps.arm-token.outcome == 'success' && steps.base.outputs.onto-default == 'true'
         env:
           GH_TOKEN: ${{ steps.arm-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
@@ -187,8 +187,16 @@ required set, and a condition that is met the instant GitHub first reads it.
 `auto-arm.yml` armed it and GitHub merged it at 21:03:23Z — **61 seconds after it was opened, before
 its own CI had started a single job**. Nothing failed and nothing was bypassed; the stack collapsed
 unreviewed, exactly as configured. `auto-arm.yml` is the fleet's only copy of the arm lane and every
-satellite reaches it through `workflow_call`, so the hole was open in all eight repositories at once
-and closing it in core closed it everywhere without a satellite-side change.
+satellite reaches it through `workflow_call`, so the hole was open in every repository at once.
+
+🚨 **But "the satellites get it for free" is true only where the caller pins `@main`, and one does
+not.** Measured 2026-09-11 over the contents API (never a local clone — satellite checkouts here run
+days stale): all seven callers exist, and six pin `auto-arm.yml@main` — MeshWeaver.Plugins,
+.Reinsurance, .SocialMedia, .Education, .Crm, .Manufacturing — so a core fix lands there on merge.
+**`Systemorph/Memex` pins a SHA** (`@c7fef7a2`, 971 commits behind core's `main` when measured), so
+it picks up nothing until that line moves. The lesson generalises past this fix: before claiming a
+reusable-lane change reaches the fleet, read every caller's `uses:` ref — a fleet-wide fix and a
+six-of-seven fix are indistinguishable from core, and the odd one out is silent, not red.
 
 The lane now reads `github.event.repository.default_branch` off the event — **never a literal
 `main`**, which would be a copy of a fact every repo happens to share today and the exact drift the

--- a/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
@@ -175,11 +175,50 @@ seeded on weaker evidence than that would be an automatic re-runner with a JSON 
 - `dotnet-test.yml`'s *CI's own shell* job runs the steward's `--self-test` on every pull request,
   so a classifier regression cannot merge on a branch that never dequeued anything.
 
+## 🚨 Auto-merge waits on the BASE's protection — so a stacked PR is armed to merge NOW
+
+`--auto` does not mean "merge when this pull request is green". It means "merge when the contexts
+**branch protection requires of the BASE** are satisfied" — and in this fleet protection is
+configured on the default branch and nowhere else. A **stacked** pull request, opened against
+another pull request's feature branch, therefore has a base that is protected by nothing, an EMPTY
+required set, and a condition that is met the instant GitHub first reads it.
+
+**Measured 2026-09-11.** `MeshWeaver.Plugins#1685` was opened against the feature branch of #1681.
+`auto-arm.yml` armed it and GitHub merged it at 21:03:23Z — **61 seconds after it was opened, before
+its own CI had started a single job**. Nothing failed and nothing was bypassed; the stack collapsed
+unreviewed, exactly as configured. `auto-arm.yml` is the fleet's only copy of the arm lane and every
+satellite reaches it through `workflow_call`, so the hole was open in all eight repositories at once
+and closing it in core closed it everywhere without a satellite-side change.
+
+The lane now reads `github.event.repository.default_branch` off the event — **never a literal
+`main`**, which would be a copy of a fact every repo happens to share today and the exact drift the
+single-copy design exists to end — compares it with `github.event.pull_request.base.ref`, and arms
+only on a match.
+
+🚨 **The decision is announced, and the JOB is never what skips.** Moving the base test onto the
+job's `if:` is the tidy-looking version of this fix and deletes the message with it: a skipped job
+renders like a passed one and carries no warning, no summary and no comment, so "the lane declined"
+and "the lane is broken" become the same page. Instead the job runs, a `::warning::` plus a step
+summary name the base, and one idempotent comment says so on the pull request itself. Draft and fork
+stay on the job condition, because for those there is genuinely nothing to say.
+
+**The other lanes were checked and are clean structurally, not by luck** — which is why none is
+exempted by name in the guard: `arm-credential.yml` mints and inspects a token and arms nothing;
+this steward acts only on a `dequeued` event, which cannot occur for a pull request never admitted
+to a queue, and a queue exists only on a branch configured to have one; `release.yml` and
+`node-repo-platform-ref-bump.yml` OPEN pull requests (`--base main`, explicitly) without arming them.
+
+`ArmedMergeMustTriggerMainsPushLanesGuard` holds all three properties: the arming step is governed
+by an `if:` consuming a step output whose producer reads `default_branch` (a condition moved into
+`env:`, or one that consults only the token mint, breaks the chain and fails); no workflow in the
+directory arms without that chain; and the non-default path still warns and still comments.
+
 ## Working with the queue
 
-- **`gh pr merge <n> --auto` enqueues.** With a queue enabled, "auto-merge" means *enqueue when the
-  PR's own required checks are green*. `auto-arm.yml` does this for every non-draft PR, so a green PR
-  lands without anyone pressing anything. Marking a PR **draft** is the opt-out.
+- **`gh pr merge <n> --auto` enqueues — but only onto the default branch.** With a queue enabled,
+  "auto-merge" means *enqueue when the PR's own required checks are green*. `auto-arm.yml` does this
+  for every non-draft PR **whose base is the default branch**; see the section above for why a
+  stacked PR is deliberately left unarmed. Marking a PR **draft** is the opt-out.
 - **A push to a queued branch ejects it.** GitHub removes the entry (reason `MANUAL`-shaped from the
   steward's point of view: it comments once and takes no action); auto-arm re-arms on the
   `synchronize` event, so the new head re-enters the queue once its own run is green. Do not push to

--- a/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MergeQueue.md
@@ -203,6 +203,15 @@ The lane now reads `github.event.repository.default_branch` off the event — **
 single-copy design exists to end — compares it with `github.event.pull_request.base.ref`, and arms
 only on a match.
 
+🚨 **One self-clearing window, named so it is not misread as the fix failing.** The lane runs on
+`pull_request_target`, and that event runs the workflow file **as it exists on the pull request's
+BASE branch** — not on `main`. So a stacked pull request opened onto a feature branch that was cut
+*before* this fix landed still runs the old, unguarded copy and is still armed immediately. Nothing
+in core can reach that: the branch carries its own copy by the event's definition. It clears as soon
+as the branch is cut from, or catches up with, a `main` that has the fix. If you see a stacked pull
+request merge instantly in the days after this lands, check the age of its base branch before
+concluding the guard is broken.
+
 🚨 **The decision is announced, and the JOB is never what skips.** Moving the base test onto the
 job's `if:` is the tidy-looking version of this fix and deletes the message with it: a skipped job
 renders like a passed one and carries no warning, no summary and no comment, so "the lane declined"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-stacked-pull-request-is-no-longer-merged-the-moment-it-is-opened.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-11-a-stacked-pull-request-is-no-longer-merged-the-moment-it-is-opened.md
@@ -1,0 +1,34 @@
+---
+Name: A stacked pull request is no longer merged the moment it is opened
+Category: Fix
+Description: A pull request opened onto another pull request's branch was auto-merged within a minute of being opened, before any of its own checks had started. Auto-merge is now only offered where the checks it waits for actually exist, and a pull request that does not qualify is told so on the pull request itself.
+Icon: ShieldCheckmark
+Order: -20260911
+---
+
+# A stacked pull request is no longer merged the moment it is opened
+
+Every pull request that is not a draft is armed to merge itself as soon as its checks pass. That is
+deliberate: it removes the wait between "everything is green" and "somebody pressed the button", and
+it weakens nothing, because the merge still waits for exactly the checks the target branch requires.
+
+The catch was in that last clause. What auto-merge waits for is whatever the **target** branch
+requires — and a project protects its main branch, not every working branch on it. So a pull request
+opened onto *another pull request's branch*, the ordinary way a larger change is split into
+reviewable pieces, was pointed at a target that required nothing at all. "Merge when the checks
+pass" then meant "merge now": there were no checks to wait for, and the condition was satisfied the
+first time it was looked at.
+
+It behaved exactly like that. One such pull request was merged 61 seconds after it was opened,
+before a single one of its own checks had started to run. Nothing failed and nothing was
+circumvented — the stack simply collapsed into its base while the author was still writing the
+description.
+
+Auto-merge is now offered only where the checks it waits for actually exist. A pull request aimed
+anywhere else is left for a person to merge, which was always the intent, and it is **told so**: a
+short comment on the pull request naming its target branch and why it was skipped. That matters as
+much as the fix. An unarmed pull request and a broken automation look identical from outside — both
+are a page where nothing happens — so the one case that is deliberate now says so out loud instead
+of leaving the author waiting for something that was never coming.
+
+Retargeting the pull request at the main branch arms it normally, with no further action.

--- a/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace MeshWeaver.Documentation.Test;
@@ -510,6 +511,228 @@ public class ArmedMergeMustTriggerMainsPushLanesGuard
             + "GitHub paints a skipped job the same colour as a passed one, so 'the lane never ran' and "
             + "'the lane had nothing to do' become indistinguishable — which is the exact state this "
             + "lane spent its whole existence in. Assert the input and fail RED naming it instead.");
+    }
+
+    /// <summary>
+    /// Every <c>steps.&lt;id&gt;.outputs.*</c> reference that appears inside a step's <c>if:</c> —
+    /// and nowhere else in the step. A reference sitting in <c>env:</c> says the step USES a value;
+    /// only one inside <c>if:</c> says the step is GOVERNED by it, and that difference is the whole
+    /// assertion below. Handles both the one-line form and a block scalar (<c>if: >-</c>), whose
+    /// continuation lines are the ones indented past the <c>if:</c> itself. Pure.
+    /// </summary>
+    private static string[] StepOutputsGoverningTheStep(string stepBlock)
+    {
+        var lines = stepBlock.Split('\n');
+        var governing = new List<string>();
+        for (var i = 0; i < lines.Length; i++)
+        {
+            var indent = lines[i].Length - lines[i].TrimStart().Length;
+            if (!lines[i].TrimStart().StartsWith("if:", StringComparison.Ordinal))
+                continue;
+            governing.Add(lines[i]);
+            for (var j = i + 1; j < lines.Length; j++)
+            {
+                if (lines[j].Trim().Length == 0)
+                    continue;
+                if (lines[j].Length - lines[j].TrimStart().Length <= indent)
+                    break;
+                governing.Add(lines[j]);
+            }
+        }
+
+        return [.. Regex
+            .Matches(string.Join('\n', governing), @"steps\.([A-Za-z0-9_.\-]+)\.outputs")
+            .Select(m => m.Groups[1].Value)
+            .Distinct(StringComparer.Ordinal)];
+    }
+
+    /// <summary>The <c>id:</c> a step declares, or <c>null</c>. Pure.</summary>
+    private static string? StepId(string stepBlock) =>
+        ExecutableLines(stepBlock)
+            .Select(l => Regex.Match(l, @"^id:\s*([A-Za-z0-9_.\-]+)\s*$"))
+            .Where(m => m.Success)
+            .Select(m => m.Groups[1].Value)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// A step block ARMS auto-merge when it runs the command that either enables auto-merge or
+    /// admits the pull request to a merge queue. Both are <c>gh pr merge --auto</c>; the GraphQL
+    /// mutation is the same act spelled differently, and a read-back that merely NAMES
+    /// <c>autoMergeRequest</c> is not one. Pure.
+    /// </summary>
+    private static bool ArmsAutoMerge(string stepBlock) =>
+        ExecutableLines(stepBlock).Any(l =>
+            (l.Contains("gh pr merge", StringComparison.Ordinal) && l.Contains("--auto", StringComparison.Ordinal))
+            || l.Contains("enablePullRequestAutoMerge", StringComparison.Ordinal));
+
+    /// <summary>
+    /// 🚨🚨 Arming a pull request whose BASE is not the default branch is not "merge when green" —
+    /// it is "merge NOW", and this guard is the thing that keeps it from being reintroduced.
+    ///
+    /// <para>GitHub's auto-merge waits for exactly the contexts BRANCH PROTECTION requires of the
+    /// pull request's BASE. Protection in this fleet is configured on the default branch and
+    /// nowhere else, so a STACKED pull request — one opened against another pull request's feature
+    /// branch — has an unprotected base, an EMPTY required set, and a condition that is satisfied
+    /// the instant it is first read.</para>
+    ///
+    /// <para><b>Measured, 2026-09-11.</b> MeshWeaver.Plugins#1685 was opened against the feature
+    /// branch of #1681. <c>auto-arm.yml</c> armed it and GitHub merged it at 21:03:23Z — 61 seconds
+    /// after it was opened, <i>before its own CI had started a single job</i>. Nothing failed and
+    /// nothing was bypassed: the stack collapsed unreviewed, exactly as configured. This file is
+    /// the fleet's only copy of the arm lane, reached by every satellite through
+    /// <c>workflow_call</c>, so the same hole was open in all eight repositories simultaneously.
+    /// </para>
+    ///
+    /// <para><b>What is asserted is the CHAIN, not a spelling.</b> The arming step must be governed
+    /// by an <c>if:</c>, that <c>if:</c> must consume a step output, and the step producing it must
+    /// read the repository's default branch from the event payload. A condition moved into
+    /// <c>env:</c>, or an <c>if:</c> that only consults the token mint, both break the chain and
+    /// fail here — which is the shape the regression would actually take.</para>
+    /// </summary>
+    [Fact]
+    public void TheArmLaneArmsOnlyOntoTheRepositoryDefaultBranch()
+    {
+        var path = Path.Combine(WorkflowsDir(), "auto-arm.yml");
+        Assert.True(File.Exists(path), $"{path} is missing — the arm lane is the subject of this guard.");
+
+        var blocks = StepBlocks(File.ReadAllText(path));
+        var armStep = Assert.Single(blocks.Where(ArmsAutoMerge));
+
+        var governing = StepOutputsGoverningTheStep(armStep);
+        Assert.True(
+            governing.Length > 0,
+            "auto-arm.yml's arming step is not governed by any step output — so it arms every pull "
+            + "request this lane sees, whatever its base.\n"
+            + "Auto-merge waits for the required contexts of the BASE. A base that is not the "
+            + "default branch has no branch protection and therefore no required contexts, so the "
+            + "condition is met the moment GitHub reads it and the pull request merges immediately "
+            + "(measured: MeshWeaver.Plugins#1685, merged 61 seconds after it was opened, before a "
+            + "single check had started).\n"
+            + "Read github.event.repository.default_branch in a step, compare it with "
+            + "github.event.pull_request.base.ref, and condition the arm on the result.");
+
+        var producers = blocks
+            .Where(b => StepId(b) is { } id && governing.Contains(id, StringComparer.Ordinal))
+            .ToArray();
+
+        Assert.True(
+            producers.Any(b => ExecutableLines(b).Any(l => l.Contains("default_branch", StringComparison.Ordinal))),
+            "auto-arm.yml's arming step is conditioned on step outputs "
+            + $"({string.Join(", ", governing)}), but none of the steps producing them reads the "
+            + "repository's default branch. The arm is therefore still unguarded against a "
+            + "non-default base — the #1685 failure, by omission rather than by choice.\n"
+            + "The step that decides must read github.event.repository.default_branch.");
+
+        // 🚨 And it must be READ, never assumed. Every repository in the fleet uses `main` today,
+        // which is exactly what makes a literal indistinguishable from a correct check while being
+        // a copy of a fact — the drift the header of this lane exists to end. One lane serves eight
+        // repositories; the day one of them renames its default branch, a literal arms nothing and
+        // says nothing.
+        var literalMain = ExecutableLines(File.ReadAllText(path))
+            .Where(l => Regex.IsMatch(l, @"(^|[^A-Za-z0-9_\-/.])main([^A-Za-z0-9_\-/.]|$)"))
+            .ToArray();
+
+        Assert.True(
+            literalMain.Length == 0,
+            "auto-arm.yml names the branch 'main' literally: "
+            + $"{string.Join(" | ", literalMain)}.\n"
+            + "This lane is called by every repository in the fleet through workflow_call, and the "
+            + "default branch is on the event payload in both modes. A literal is a copy of a fact "
+            + "that every repo happens to share today — precisely the drift that made the hand-copied "
+            + "versions of this file diverge into four variants. Read "
+            + "github.event.repository.default_branch instead.");
+    }
+
+    /// <summary>
+    /// The same rule, ratcheted across the whole directory: no workflow anywhere in this repository
+    /// may arm auto-merge without the base check. <c>auto-arm.yml</c> is the only lane that arms
+    /// today, and the point of a directory-wide sweep is that the SECOND one — a release lane, a
+    /// bump lane, a convenience added in a hurry — cannot ship without meeting the same bar.
+    ///
+    /// <para>The neighbours were checked when this was written and are clean for structural
+    /// reasons rather than by luck, which is why they are not exempted by name:
+    /// <c>arm-credential.yml</c> mints and inspects a token and arms nothing;
+    /// <c>merge-queue-steward.yml</c> acts only on a <c>dequeued</c> event, which cannot occur for
+    /// a pull request that was never admitted to a merge queue — and a queue exists only on a
+    /// branch that has one configured, i.e. a protected one; and <c>release.yml</c> /
+    /// <c>node-repo-platform-ref-bump.yml</c> OPEN pull requests (already covered above) without
+    /// arming them.</para>
+    /// </summary>
+    [Fact]
+    public void NoWorkflowArmsAutoMergeWithoutReadingTheDefaultBranch()
+    {
+        var offenders = Directory
+            .EnumerateFiles(WorkflowsDir(), "*.yml")
+            .Select(path => (path, blocks: StepBlocks(File.ReadAllText(path))))
+            .Where(w => w.blocks.Any(ArmsAutoMerge))
+            .Where(w =>
+            {
+                var governing = w.blocks.Where(ArmsAutoMerge).SelectMany(StepOutputsGoverningTheStep).ToArray();
+                return !w.blocks.Any(b =>
+                    StepId(b) is { } id
+                    && governing.Contains(id, StringComparer.Ordinal)
+                    && ExecutableLines(b).Any(l => l.Contains("default_branch", StringComparison.Ordinal)));
+            })
+            .Select(w => Path.GetFileName(w.path))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            $"These workflows arm auto-merge without checking the base branch: {string.Join(", ", offenders)}.\n"
+            + "Auto-merge waits for the required contexts of the pull request's BASE, and only the "
+            + "default branch carries branch protection in this fleet. On any other base the required "
+            + "set is EMPTY, so arming merges the pull request immediately — measured on "
+            + "MeshWeaver.Plugins#1685, which was opened against another pull request's feature branch "
+            + "and merged 61 seconds later, before its own CI had started.\n"
+            + "Read github.event.repository.default_branch, compare it with "
+            + "github.event.pull_request.base.ref, and condition the arm on the result.");
+    }
+
+    /// <summary>
+    /// 🚨 Not arming must be SAID, not merely done.
+    ///
+    /// <para>An author whose stacked pull request is sitting there unarmed cannot tell "the lane
+    /// decided not to arm this one" from "the lane is broken" — both look like nothing happening,
+    /// which is the same defect as a gate that skips silently, one level down. So the base decision
+    /// is reported twice: a <c>::warning::</c> in the run log, and one comment on the pull request
+    /// itself, where the author already is.</para>
+    ///
+    /// <para>And the JOB must not be what skips. Moving the base test onto the job's <c>if:</c>
+    /// would be the tidy-looking version of this fix and would delete the message with it — a
+    /// skipped job renders like a passed one and carries no warning, no summary and no comment.
+    /// This test pins the base out of the job condition for exactly that reason.</para>
+    /// </summary>
+    [Fact]
+    public void APullRequestOnANonDefaultBaseIsToldWhyItWasNotArmed()
+    {
+        var text = File.ReadAllText(Path.Combine(WorkflowsDir(), "auto-arm.yml"));
+        var blocks = StepBlocks(text);
+
+        var deciders = blocks
+            .Where(b => StepId(b) is not null)
+            .Where(b => ExecutableLines(b).Any(l => l.Contains("default_branch", StringComparison.Ordinal)))
+            .ToArray();
+
+        Assert.True(
+            deciders.Any(b => ExecutableLines(b).Any(l => l.Contains("::warning::", StringComparison.Ordinal))),
+            "auto-arm.yml decides not to arm a non-default base without emitting a ::warning::. "
+            + "Deciding silently is indistinguishable from being broken: the author waits for an arm "
+            + "that is never coming, with nothing anywhere saying why.");
+
+        Assert.True(
+            blocks.Any(b => ExecutableLines(b).Any(l => l.Contains("gh pr comment", StringComparison.Ordinal))),
+            "auto-arm.yml no longer comments on the pull request when it declines to arm. The run "
+            + "log of a lane whose entire normal output is the word 'armed' is not somewhere anyone "
+            + "looks; the one place the author already is, is the pull request.");
+
+        // The job-level `if:` may test draft and fork — both properties of the event that mean
+        // "there is nothing to do here at all". The base is different: there IS something to do,
+        // namely say why nothing was armed.
+        var jobCondition = Regex.Match(text, @"\n    if: >-\n((?:      .*\n)+)");
+        Assert.True(jobCondition.Success, "auto-arm.yml's job-level `if:` is no longer in the expected block form.");
+        Assert.DoesNotContain("base.ref", jobCondition.Groups[1].Value, StringComparison.Ordinal);
+        Assert.DoesNotContain("default_branch", jobCondition.Groups[1].Value, StringComparison.Ordinal);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## The defect

`auto-arm.yml` armed auto-merge on every non-draft, non-fork pull request, **whatever its base**.

`--auto` does not mean "merge when this pull request is green". It means "merge when the contexts
**branch protection requires of the BASE** are satisfied" — and protection in this fleet is
configured on the default branch and nowhere else. A **stacked** pull request, opened against
another pull request's feature branch, therefore had a base protected by nothing, an **empty**
required set, and a condition satisfied the instant GitHub first read it.

**Measured 2026-09-11.** `MeshWeaver.Plugins#1685` was opened against the feature branch of #1681.
This lane armed it and GitHub merged it at **21:03:23Z — 61 seconds after it was opened, before its
own CI had started a single job**. Nothing failed and nothing was bypassed; the stack collapsed
unreviewed, exactly as configured.

**This reaches six of the seven callers without a satellite-side change.** `auto-arm.yml` is the
fleet's only copy of the arm lane; every other repository reaches it through `workflow_call` with a
thin caller that forwards the App credential and nothing else. Measured today over the contents API,
all seven callers exist and six pin the lane at **`@main`** — MeshWeaver.Plugins, .Reinsurance,
.SocialMedia, .Education, .Crm and .Manufacturing — so the fix lands there the moment this merges.

🚨 **The exception is `Systemorph/Memex`, which pins a SHA**
(`auto-arm.yml@c7fef7a2d9cebce36889028c0b542acb05e77947`, **971 commits behind** core's `main`), so
it does **not** pick this up and needs a one-line pin bump. That follows this PR, in dependency
order.

## The fix

The lane reads `github.event.repository.default_branch` **off the event** — never a literal `main`,
which would be a copy of a fact every repo happens to share today and the exact drift the
single-copy design exists to end — compares it with `github.event.pull_request.base.ref`, and arms
only on a match.

🚨 **The decision is announced, and the JOB is never what skips.** Putting the base test on the
job's `if:` is the tidy-looking version of this fix and deletes the message with it: a skipped job
renders like a passed one and carries no warning, no summary and no comment, so "the lane declined"
and "the lane is broken" become the same page — an author waits for an arm that is never coming.
Instead the job runs, a `::warning::` plus a step summary name the base, and **one idempotent
comment** (marker read back before writing, so `synchronize` cannot repeat it) says so on the pull
request itself. Draft and fork stay on the job condition, because for those there is genuinely
nothing to say.

Everything else is unchanged: draft is still the opt-out, forks are still skipped, and the arm still
runs on the minted App installation token (#2916).

**No gate can skip silently here.** The new condition asks a property of the **event**, never
whether a secret is set; the credential assert, the base read and the mint all still run
unconditionally; and **this lane publishes no required context** — measured today, core requires
`Consolidate test results` only, and MeshWeaver.Plugins / .Reinsurance / .SocialMedia / .Education
require none of this lane's jobs. The job also never becomes `skipped` on any base, so the property
holds even if a repo were to start requiring it.

## The other arming lanes, checked

Clean structurally rather than by luck — which is why none is exempted by name in the guard:

| lane | why it is not affected |
|---|---|
| `arm-credential.yml` | mints and inspects a token; **arms nothing** |
| `merge-queue-steward.yml` | acts only on a `dequeued` event, which cannot occur for a PR never admitted to a queue — and a queue exists only on a branch configured to have one, i.e. a protected one |
| `release.yml`, `node-repo-platform-ref-bump.yml` | **open** pull requests (`--base main`, explicitly) without arming them |

## The guard

Three cases added to `ArmedMergeMustTriggerMainsPushLanesGuard`, all three of which **fail on
current `main`** (verified by restoring `origin/main`'s `auto-arm.yml` in the worktree and re-running
— 3 failed, the 8 pre-existing cases still passed):

```
Failed NoWorkflowArmsAutoMergeWithoutReadingTheDefaultBranch
  These workflows arm auto-merge without checking the base branch: auto-arm.yml.

Failed TheArmLaneArmsOnlyOntoTheRepositoryDefaultBranch
  auto-arm.yml's arming step is not governed by any step output — so it arms every pull
  request this lane sees, whatever its base.

Failed APullRequestOnANonDefaultBaseIsToldWhyItWasNotArmed
  auto-arm.yml decides not to arm a non-default base without emitting a ::warning::.
```

**What is asserted is the CHAIN, not a spelling.** The arming step must be governed by an `if:` that
consumes a step output, and the step producing that output must read `default_branch` from the event
payload. A condition moved into `env:`, or an `if:` that consults only the token mint, breaks the
chain and fails — which is the shape the regression would actually take. A companion case refuses a
literal `main` anywhere in the file's executable lines, and the directory-wide sweep makes this a
ratchet the **second** arming lane must also meet.

## Verification

- `dotnet build -c Release -warnaserror` on `MeshWeaver.Documentation` and
  `MeshWeaver.Documentation.Test` — **0 Warning(s), 0 Error(s)**.
- `ArmedMergeMustTriggerMainsPushLanesGuard` + `MergeQueueStewardGuard` +
  `WhatsNewEntryIntegrityTest` + `DocumentationLinkIntegrityTest` + `DocumentationEmbedIntegrityTest`
  + `ArchitectureTopicMapTest`: **31 passed, 0 failed**.
- `check-workflow-timeouts.py` (84 jobs, 0 violations; the arm job keeps its literal
  `timeout-minutes: 10`), `check-workflow-yaml-keys.py` (34 files, 0 violations),
  `check-workflow-shell.py` (0 live findings), `check-workflow-permission-pairing.py` (0 violations).

## Work products conserved

`Doc/Architecture/MergeQueue` gains the section **"Auto-merge waits on the BASE's protection — so a
stacked PR is armed to merge NOW"**, and there is a What's New entry (`Category: Fix`) — an author
who stacks a pull request can notice both the old behaviour and the new comment.

Pairs-with: none — this removes no public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
