### PR TITLE
roster: delete Plugins' supersede and publish-modules rows (#1676 merged)

### DIFF
--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -72,18 +72,6 @@ repos:
         job: publish-bake
         lane: node-repo-publish-bake.yml
         grants: {contents: read, id-token: write}
-      # The module registry hand-over, moved out of `modules-floor`'s matrix legs to after the whole
-      # validation verdict (MeshWeaver#3878). The lane's one job demands `contents: read`.
-      - workflow: ci.yml
-        job: publish-modules
-        lane: node-repo-module-publish.yml
-        grants: {contents: read}
-        pending: on main since Systemorph/MeshWeaver.Plugins#1663 and REMOVED again by Systemorph/MeshWeaver.Plugins#1676 (per-module deploy — ModuleBuildArchitecture → Per-module deploy, so modules publish on their own verdict, not the whole run's). Compared key for key while main still has it; the marker excuses the absence once #1676 merges — delete this row then.
-      - workflow: ci.yml
-        job: supersede
-        lane: node-repo-supersede.yml
-        grants: {actions: write, contents: read}
-        pending: REMOVED by Systemorph/MeshWeaver.Plugins#1676 — per-module deploy never cancels a main run, so Plugins no longer calls the supersede lane (ModuleBuildArchitecture → Per-module deploy). Compared key for key while main still has it; the marker excuses the absence once #1676 merges — delete this row then.
       - workflow: ci.yml
         job: test-repos
         lane: node-repo-gate.yml


### PR DESCRIPTION
Follow-up to #4047, as promised there. Systemorph/MeshWeaver.Plugins#1676 has merged, so the two rows marked `pending:` for the transition window describe callers that no longer exist: `ci.yml#supersede` (no push run on main is ever cancelled) and `ci.yml#publish-modules` (modules publish on their own verdict — per-module deploy).

Verified locally: `check-workflow-permission-pairing.py --assert-fleet-row Systemorph/MeshWeaver.Plugins` passes against the post-merge Plugins tree, and `--self-test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)