### PR TITLE
A green-build seal hold is recorded on the sync config, not only in a log (#4063)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -161,6 +161,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Declarative export and import](DeclarativeImportExport)
 - [Syncing a Space with GitHub](GitHubSync)
 - [What a Green Build Costs a Synced Space](GitSyncTriggerCost) — one field decided whether a delivery was free or a full clone, and it is deliberately frozen while an import does not converge; the second, weaker pointer that makes a settled source free again, and why the skip needs the verdict to be FINAL and not merely recorded
+- [When a Publication Seal Stops Advancing](PublicationSealStarvation) — a Space converges on a green build only while the publication sealed for THIS instance's framework identity keeps reaching the built commit; when the instance's identity and the lane that publishes for it drift apart that condition stops being satisfiable, and until the hold was recorded on the node a held source was byte-identical to a settled one
 - [The Import Marker Records Convergence](ImportMarkerRecordsConvergence)
 - [Instance Sync — bi-directional space replication between MeshWeaver instances](InstanceSync)
 - [Managing Partition Sync (Admin Guide)](PartitionSyncGuide)

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitHubSync.md
@@ -489,5 +489,6 @@ All GitHub HTTP and serialization run through the controlled I/O pool — see
 - [DataSyncSetup.md](/Doc/Architecture/DataSyncSetup) — the import-source model (platform content synced from a repo at a release tag).
 - [StaticRepoImport.md](/Doc/Architecture/StaticRepoImport) — the import mechanism reused here (fingerprint, activity lock, upsert, prune).
 - [What a Green Build Costs a Synced Space](/Doc/Architecture/GitSyncTriggerCost) — what one webhook delivery costs, the single field that makes it free, and why a source that never converges re-clones its repository on every green build.
+- [When a Publication Seal Stops Advancing](/Doc/Architecture/PublicationSealStarvation) — why a green build can authorize an import that never happens, how to tell a HELD source from a settled one, and what a portal whose framework identity has stopped being published for looks like.
 - [ControlledIoPooling.md](/Doc/Architecture/ControlledIoPooling) — why every GitHub HTTP call runs in the I/O pool.
 - [AccessControl.md](/Doc/Architecture/AccessControl) — credential encryption + the master key.

--- a/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/GitSyncTriggerCost.md
@@ -429,3 +429,4 @@ its path, and the shared node-repo validation lane fails red if a satellite move
 - [The Import Marker Records Convergence](/Doc/Architecture/ImportMarkerRecordsConvergence) — the content-addressed short-circuit and what may write it.
 - [Static Repo Import](/Doc/Architecture/StaticRepoImport) — fingerprint, activity lock, upsert, prune.
 - [Sync Ref Contract](/Doc/Architecture/SyncRefContract) — what a build completion records and who consumes it.
+- [When a Publication Seal Stops Advancing](/Doc/Architecture/PublicationSealStarvation) — the OTHER reason a delivery costs nothing: the publication seal held it. Why that hold can become permanent, and how it is recorded now that a held source is no longer byte-identical to a settled one.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PublicationSealStarvation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PublicationSealStarvation.md
@@ -1,0 +1,163 @@
+---
+Name: When a Publication Seal Stops Advancing
+Category: Architecture
+Description: A GitSynced Space converges on a green build only while the publication sealed for THIS instance's framework identity keeps reaching the built commit. When the instance's identity and the lane that publishes for it drift apart, that condition stops being satisfiable — every green build is held, forever, and until now the held source was byte-identical to a settled one. The measurement from both production portals, the branch-by-branch elimination that located it, what the node says now, and what is still missing for "published" to imply "live".
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="11" width="16" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0"/><path d="M12 15v2"/></svg>
+---
+
+# When a Publication Seal Stops Advancing
+
+[GitHub Sync](/Doc/Architecture/GitHubSync) keeps a Space current without polling, and
+[The Sync-Ref Contract](/Doc/Architecture/SyncRefContract) says which commit an unattended import may
+read. This page is about the gate that sits between them, and about the state it can enter from
+which nothing ever releases it.
+
+The short version:
+
+> A green build authorizes an import. For a **module-bearing** repository it does not perform one:
+> the source advances only to a commit the registry has **sealed for this instance's own framework
+> identity**. That identity is a property of the image the instance is RUNNING; the seal is written
+> by a lane that bakes against the image its pin RESOLVES. While those are the same image the gate
+> is invisible. When they diverge, the gate's release condition becomes **permanently unsatisfiable**
+> — and the only thing that then converges a Space is a pod restart, which re-reads the same stale
+> seal and imports nothing new.
+
+## 1. The gate, and why it exists
+
+`SealedSyncGate.Decide` (`src/MeshWeaver.GitSync/SealedSyncGate.cs`) answers one question per sync
+source: *may this source import the green build at `headSha`?*
+
+- No sealed publication is attributable to the repository → **Go**. The instance runs no publication
+  of it (a course repo, a content repo), so the gate does not apply.
+- Some publication of that repository, sealed under **this instance's framework identity**, is at
+  `headSha` → **Go**. The seal and the build agree on the tree.
+- Otherwise → **Hold**, with the reason stated.
+
+It exists because the alternative was measured. On 2026-09-06 a MeshWeaver.Plugins `main` run
+finished after `main` had moved past the Payments split, both production portals imported the new
+`Store/*` sources against a platform carrying neither `IPaymentProvider` nor the Payments module,
+and four `Store` NodeTypes sat in compile `Error` for about five hours. A green build proves a tree
+compiles *somewhere*; the seal proves it compiles **here**.
+
+The gate is right. What follows is about what happens when its release condition can no longer
+occur.
+
+## 2. The identity the gate keys on is the instance's, and it drifts
+
+`SealedPublicationIndex.ReadFor(publishedRoot, identity)` reads
+`<PreWarm:PrebuiltBundleRoot>/<identity>/<source>/` and nothing else. `identity` is
+`PrebuiltAssemblySeeder.LiveFrameworkMvid` — the API-surface identity of the assemblies **this
+process is running**, the same value `/health`'s bake report prints as `framework=…`.
+
+The seal on the other side of that path is written by `publish-bake-bundles.sh` under the identity
+of the platform image the publishing lane resolved. Two different clocks:
+
+| | what fixes it | when it moves |
+|---|---|---|
+| the instance's identity | the image the portal was last **rolled** to | on a deploy |
+| the seal's identity | the platform image the repo's bake **resolves** | when the platform release it tracks moves |
+
+The identity is breaking-change-keyed, so an ordinary core merge re-resolves the **same** hash and
+the two stay equal without anyone arranging it. That is why this is invisible almost all the time.
+The moment core's public surface changes and the portal has not been rolled onto the new image, they
+separate — and from then on every publication of every module-bearing repository lands in a
+directory the portal never reads.
+
+`mine` is then non-empty (the portal's own identity still holds the *last* publication made for it)
+and nothing in it is ever at `headSha` again. **Hold, on every green build, for ever.**
+
+## 3. Measured — both production portals, 2026-09-11/12
+
+- Last automatic convergence: `24c2d024` (MeshWeaver.Plugins #1663), imported 18:53:55Z on
+  memex.systemorph.com and 18:55:16Z on memex.meshweaver.cloud.
+- Green MeshWeaver.Plugins `main` builds after it: 20:17, 21:55, 23:58, 23:59, 00:53, 02:29, 03:39,
+  03:44Z. **None** produced an import on either portal. `Hosting/v1.17.1` and `v1.18.0` were tagged
+  by the 23:59Z run; `DeepSign/v1.1.0` by the 03:44Z run. Neither reached a mesh until a person ran
+  `git_hub_sync update` by hand at 03:47Z.
+- Both portals: `/api/version` = core `74d4c852`, `/health` = `framework=s6649734…`.
+- `Hosting/PlatformBuilds/plugins`, written by the publishing lane at 03:44:43Z:
+  `identity: s8e1f76cc22bcd7051a7ad998debbfeb3`, `version: 3.0.0-ci.8392`.
+
+Two identities, one letter apart in nothing. The portals had not been rolled onto the image the
+bake resolves, so their `plugins` seal froze at `24c2d024` and the gate held every commit after it.
+
+### The branch-by-branch elimination
+
+`MatchingBuildTargets` can drop a candidate for four reasons, and only one of them leaves no trace.
+Each of the others had a **positive control** on the live meshes:
+
+| branch | control | reading |
+|---|---|---|
+| the webhook never arrived / was refused | `Admin/_Build/Systemorph.MeshWeaver.Plugins` rewritten at 03:44:49Z on BOTH portals, 0.5 ms apart | it arrived and was accepted |
+| the config query or repo match returned nothing | the issue fan-out wrote `*/_Issue/1678` across 34 Plugins-sourced spaces at 02:07:07Z — the same `ConfigsTargeting` seam | it matches |
+| `SkipReason` | the node's own fields: `lastSyncCommitSha` = `lastAttemptedCommitSha` = `24c2d024` ≠ any later `headSha`; branch `main` = `main`; direction not `ExportOnly` | no arm fires |
+| `SealedSyncGate` | — | **the only branch left** |
+
+That table is the method, not just the answer: three of the four branches are indistinguishable from
+the fourth in the node's recorded state, and each needed an artefact somewhere else to rule it out.
+
+## 4. The defect that made it cost nine hours: a hold looked exactly like "settled"
+
+`GitHubSyncConfig` has fields for all of this, and the boot-time reconciler already used them:
+`GitHubSyncService.RecordHold` writes `lastSyncOutcome: "Held"` plus the reason in `lastSyncNote`,
+and clears the attempt pair so a hold never leaves a
+[#3945 "already attempted, final"](/Doc/Architecture/GitSyncTriggerCost) licence standing.
+
+The green-build path — the one that actually runs, on every delivery — recorded **nothing**. Its
+whole trace was one `Warning` per delivery in a log an operator must already suspect a hold to go
+looking in. So the node read:
+
+```json
+"lastSyncOutcome": "Imported",
+"lastSyncCommitSha": "24c2d024…",
+"lastAttemptedCommitSha": "24c2d024…",
+"lastAttemptWasFinal": true
+```
+
+which is, field for field, what a genuinely settled source looks like. `lastAttemptWasFinal` is
+documented as the field that separates settled from stuck, and here it said *settled* about a source
+that had not been attempted since the previous evening. Two sessions read it that way before the
+Space's `_Activity` list — which had no `Update Hosting to the built commit …` entry after
+18:55:17Z — gave the hold away.
+
+`GitHubWebhookProcessor.RecordSealHold` now writes the hold where the outcome is, through the same
+`RecordHold` the reconciler uses: once per **reason** rather than per delivery (the reason names the
+built sha, so a re-run or a `schedule` probe of the same commit writes nothing), best-effort, and
+cleared by the next attempt that actually runs.
+
+## 5. How to read a source's state
+
+1. `get @<Space>/_GitSync`. `lastSyncOutcome: "Held"` with a `lastSyncNote` naming a sealed commit is
+   the state this page is about — the note says which commit the instance IS sealed at.
+2. Compare `/health`'s `framework=…` with the `identity` on `Hosting/PlatformBuilds/<source>`. If they
+   differ, the instance is not being published for, and no publication will release the hold.
+3. `search 'namespace:<Space>/_Activity scope:descendants sort:lastModified-desc'`. A green-build
+   import appears as `Update <Space> to the built commit <sha>`; the boot reconciler's appears as
+   `Reconcile <Space> with the sealed commit <sha>`. An empty tail is a Space nothing has touched,
+   whatever the config says.
+4. `Admin/_Build/<owner>.<repo>` says whether the webhook itself is alive. It is written by the
+   delivery, not by CI, so a fresh `lastModified` proves the chain up to the import decision.
+
+**Do not read `lastSyncOutcome: Imported` + `lastAttemptWasFinal: true` as settled without step 3**
+on any instance that has not been rolled recently. That pair is what nine hours of undelivered
+releases looked like.
+
+## 6. What is still missing
+
+Recording the hold makes the freeze **findable**. It does not make it **converge**, and nothing in
+the platform today does:
+
+- The seal-triggered reconciler (`SealedPublicationSyncReconciler`) is the designed answer to "the
+  seal landed after the webhook" — but it is wired only into `ShippedPrebuiltBundles.SeedPublishedRoot`,
+  which `DynamicTypePreWarmerHostedService` calls **once, at `ApplicationStarted`**. The release
+  valve is a process boot.
+- A boot re-reads the same identity, so when the identity itself is the stale thing, the boot
+  converges nothing either. The only true release is a **roll onto the image the bake resolves**.
+- Nothing measures or reports the divergence. Neither portal's health, nor any gate, states "this
+  instance's identity has no publication of repository X at or after its last green build".
+
+Tracked as [Systemorph/MeshWeaver#4063](https://github.com/Systemorph/MeshWeaver/issues/4063).
+Related: [Module Publication Gate](/Doc/Architecture/ModulePublicationGate),
+[Sealed Publication Reads](/Doc/Architecture/SealedPublicationReads),
+[Bake Identity Mismatch](/Doc/Architecture/BakeIdentityMismatch),
+[What a Green Build Costs a Synced Space](/Doc/Architecture/GitSyncTriggerCost).

--- a/src/MeshWeaver.Documentation/Data/Architecture/PublicationSealStarvation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PublicationSealStarvation.md
@@ -81,6 +81,25 @@ and nothing in it is ever at `headSha` again. **Hold, on every green build, for 
 Two identities, one letter apart in nothing. The portals had not been rolled onto the image the
 bake resolves, so their `plugins` seal froze at `24c2d024` and the gate held every commit after it.
 
+### The roll is both the last convergence and the start of the freeze
+
+Core `74d4c852` is *"Merge pull request #4044 from Systemorph/feat/per-module-deploy"*, committed
+17:05:45Z on 2026-09-11 — and it is the image both portals are running, 50 core commits behind
+`main` by the next morning. The 18:53:55Z / 18:55:16Z imports were that roll's own boot sweep:
+`SeedPublishedRoot` → `SealedPublicationSyncReconciler` → every source brought onto the commit
+sealed for the freshly-booted identity, `24c2d024`, which the 18:27:53Z green build had just sealed.
+
+That is the whole shape in one sentence: **the roll converged every Space, and then core's surface
+moved while the portals did not.** The next Plugins bake resolved a newer platform image, sealed
+under `s8e1f76cc…`, and the first green build the gate held was `7660ca73` at 21:55:18Z. Everything
+after it — `222853d4` (which tagged `Hosting/v1.17.1` and `v1.18.0`), `4b97be19` (which tagged
+`DeepSign/v1.1.0`) — was held the same way.
+
+So the break is dated **between 18:27Z and 21:55Z on 2026-09-11**, which is *after* core's
+per-module deploy (the portals RUN it) and *before* the Plugins half of it (`MeshWeaver.Plugins#1676`,
+merged 02:37Z on 09-12). The per-module publish path is not the cause; the missed 23:59Z `Hosting`
+publication already said so, four hours before #1676 existed.
+
 ### The branch-by-branch elimination
 
 `MatchingBuildTargets` can drop a candidate for four reasons, and only one of them leaves no trace.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-held-sync-source-no-longer-looks-settled.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-held-sync-source-no-longer-looks-settled.md
@@ -1,0 +1,40 @@
+---
+Name: A held sync source no longer looks settled
+Category: Fix
+Description: When the publication seal holds a GitSynced Space back from a green build, the Space's sync record now says so — outcome Held, with the reason and the commit the instance is sealed at. Until now a held source was field-for-field identical to one that was simply up to date, and two tagged releases sat undelivered on both portals for nine hours behind that reading.
+Icon: Checkmark
+Order: -20260912
+---
+
+# A held sync source no longer looks settled
+
+A Space that syncs a module-bearing repository does not import every green build of it. It advances
+only to a commit the registry has **sealed for the instance you are looking at** — the rule that
+stops a portal receiving sources its running modules cannot serve. That is deliberate, and it is
+usually invisible because the seal and the build agree.
+
+When they do not, the Space is **held**. Until now that held Space was indistinguishable from one
+that was simply current: the sync record read `Imported`, the attempted commit equalled the synced
+commit, and `lastAttemptWasFinal` — the field that is supposed to separate *settled* from *stuck* —
+said `true`. All three were about the previous evening's delivery.
+
+On 2026-09-12 that reading cost nine hours: `Hosting/v1.17.1`, `Hosting/v1.18.0` and
+`DeepSign/v1.1.0` were tagged by green builds, held on both production portals, and the records said
+nothing was outstanding.
+
+Now a hold is written where the outcome is:
+
+```json
+"lastSyncOutcome": "Held",
+"lastSyncNote": "built at 222853d4, not sealed for this instance (identity s6649734…: 'plugins' is sealed at 24c2d024)"
+```
+
+The note names the commit the instance **is** sealed at, which is what tells you whether to wait for
+the next publication or to roll the instance. The attempt pair is cleared with it, so a hold can
+never leave a "we already looked at these exact bytes" licence standing for the delivery that
+follows. The next import that actually runs replaces both.
+
+Nothing about when a Space imports has changed — only what its record says when it does not. Why a
+seal can stop advancing altogether, how to read a Space's real state, and what is still missing for
+"published" to imply "live" are written up under
+[When a Publication Seal Stops Advancing](/Doc/Architecture/PublicationSealStarvation).

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -67,6 +67,12 @@ public sealed class GitHubWebhookProcessor
     private readonly ILogger? logger;
     private readonly IReadOnlyList<GitHubContentWorkflow> contentWorkflows;
 
+    /// <summary>The seal-hold reason last WRITTEN onto each sync config, so a hold that persists
+    /// across deliveries of the same commit is recorded once and a hold at a NEW commit is recorded
+    /// again. Instance state on a mesh-scoped singleton — never static (AGENTS.md).</summary>
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<string, string> recordedSealHolds =
+        new(StringComparer.Ordinal);
+
     /// <summary>Initializes a new instance of the <see cref="GitHubWebhookProcessor"/> class.</summary>
     /// <param name="hub">The hub this processor issues its reads and writes from.</param>
     /// <param name="meshService">Mesh query surface for the sync-config fan-out.</param>
@@ -367,6 +373,7 @@ public sealed class GitHubWebhookProcessor
                     {
                         held++;
                         skipped.Add($"{node.Path} ({hold.HoldReason})");
+                        RecordSealHold(node, cfg, hold.HoldReason);
                         continue;
                     }
                     if (ToPushTarget(node) is not { } pushTarget)
@@ -398,6 +405,70 @@ public sealed class GitHubWebhookProcessor
 
                 return targets;
             });
+
+    /// <summary>
+    /// 🚨 <b>A source the seal HELD must say so ON ITS OWN NODE — a hold that exists only as a log
+    /// line is indistinguishable from a source that is simply up to date</b>
+    /// (Systemorph/MeshWeaver#4063).
+    ///
+    /// <para><b>Measured, 2026-09-12 04:0xZ, on BOTH production portals.</b>
+    /// <c>Hosting/_GitSync</c> read <c>lastSyncOutcome: Imported</c>, <c>lastSyncCommitSha ==
+    /// lastAttemptedCommitSha == 24c2d024</c>, <c>lastAttemptWasFinal: true</c> — the exact
+    /// signature of a SETTLED source — while <c>Hosting/v1.17.1</c> and <c>v1.18.0</c> had been
+    /// tagged by a green <c>main</c> run nine hours earlier and the space had never seen them. Every
+    /// green build in between reached <see cref="MatchingBuildTargets"/>, was held by
+    /// <see cref="SealedSyncGate"/>, and left NOTHING behind: the record said "final", the note was
+    /// empty, and the only trace was a Warning in a log an operator must already suspect something
+    /// to go looking in. Two sessions read "settled" off that node before the activity list gave the
+    /// hold away.</para>
+    ///
+    /// <para>So the hold is written where the outcome is, through the same
+    /// <see cref="GitHubSyncService.RecordHold"/> the boot-time reconciler already uses — which also
+    /// CLEARS the attempt pair, so a hold never leaves a #3945 "already attempted, final at this
+    /// commit" licence standing for the delivery that follows it. Nothing else moves: not the
+    /// baseline commit, not the sync horizon.</para>
+    ///
+    /// <para><b>Said once per REASON, not once per delivery.</b> A repository's green builds arrive
+    /// at its CI cadence — a re-run, a <c>schedule</c> probe and a <c>repository_dispatch</c>
+    /// re-verification all carry the same head sha — and the reason string names that sha, so an
+    /// unchanged hold writes nothing and a hold at a NEW commit writes once. Same rule, same
+    /// instance-state shape as <c>SealedPublicationSyncReconciler.RecordHold</c>; the dictionary is
+    /// an instance field on a mesh-scoped singleton, never static.</para>
+    ///
+    /// <para>Best-effort by construction: a failed record is logged and swallowed. The delivery has
+    /// already decided not to import, GitHub is answered 200 either way, and turning a missing note
+    /// into a non-2xx would trade an invisible hold for a redelivery storm.</para>
+    /// </summary>
+    /// <param name="node">The sync-config node the gate held.</param>
+    /// <param name="config">Its content, or null when it could not be read.</param>
+    /// <param name="reason">The gate's hold reason — the exact string the log line carries.</param>
+    private void RecordSealHold(MeshNode node, GitHubSyncConfig? config, string? reason)
+    {
+        if (reason is not { Length: > 0 } || ToPushTarget(node) is not { } target)
+            return;
+        // Already said, and unchanged: neither the node nor the operator learns anything from a
+        // second write of the same sentence.
+        if (recordedSealHolds.TryGetValue(node.Path, out var previous)
+            && string.Equals(previous, reason, StringComparison.Ordinal))
+            return;
+        recordedSealHolds[node.Path] = reason;
+        if (config is not null
+            && string.Equals(config.LastSyncNote, reason, StringComparison.Ordinal)
+            && string.Equals(config.LastSyncOutcome, GitHubSyncService.HeldOutcome, StringComparison.Ordinal))
+            return;
+        if (hub.ServiceProvider.GetService<GitHubSyncService>() is not { } sync)
+            return;
+        // RunAsSystem, never Observable.Using(ImpersonateAsSystem) — #1790; and the webhook request
+        // is anonymous, so there is no ambient identity that could write {space}/_GitSync.
+        hub.ServiceProvider.GetService<AccessService>()
+            .RunAsSystem(() => sync.RecordHold(target.SpacePath, target.SourceId, reason))
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex,
+                    "Green build: {Space} was held by the publication seal, and recording that hold "
+                    + "on its sync config failed — the node still reads as settled.",
+                    target.SpacePath));
+    }
 
     /// <summary>
     /// Why a config that DOES target this repo is not being updated, or <c>null</c> when it is.

--- a/test/MeshWeaver.Hosting.Test/HeldSourceSaysItIsHeldTest.cs
+++ b/test/MeshWeaver.Hosting.Test/HeldSourceSaysItIsHeldTest.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reactive.Assertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A sync source the publication seal HELD must say so on its own node.</b> Until it did, a
+/// held source and a settled one were BYTE-IDENTICAL on the one artefact an operator reads, and the
+/// difference lived only in a log line (Systemorph/MeshWeaver#4063).
+///
+/// <para><b>Measured on both production portals, 2026-09-12 ~04:00Z.</b>
+/// <c>Hosting/_GitSync</c> read <c>lastSyncOutcome: Imported</c>, <c>lastSyncCommitSha ==
+/// lastAttemptedCommitSha == 24c2d024</c> and <c>lastAttemptWasFinal: true</c> — the exact
+/// signature of "settled, nothing to do" — while <c>Hosting/v1.17.1</c> and <c>v1.18.0</c> had been
+/// tagged by a green <c>main</c> run nine hours earlier and the Space had never seen either. Seven
+/// green builds of MeshWeaver.Plugins arrived in between; every one reached
+/// <c>GitHubWebhookProcessor.MatchingBuildTargets</c>, was held by <see cref="SealedSyncGate"/>
+/// because the publication sealed for this instance's framework identity had stopped advancing, and
+/// left NOTHING on the node. The positive controls that the rest of the chain was alive —
+/// <c>Admin/_Build</c> rewritten at 03:44:49Z on both portals, an issue fan-out across 34 spaces at
+/// 02:07:07Z — were what finally located the hold, one branch at a time.</para>
+///
+/// <para><b>What is measured here, and what could falsify it.</b> The first fact drives a real
+/// <c>workflow_run</c> delivery at a commit the seal does not cover and reads the config node back:
+/// against the pre-fix code the node still reads <c>Imported</c> with an empty note, which is the
+/// defect stated in the words the incident used. The second fact is the control that keeps the
+/// first honest — a delivery at the SEALED commit must import and CLEAR the note, so the hold
+/// record can never be mistaken for a permanent stamp, and "held" stays a statement about one
+/// delivery rather than a property of the source.</para>
+///
+/// <para>One seam is substituted, the GitHub transport (<see cref="IGitHubRepoClient"/>), exactly as
+/// in <c>BuildTriggeredSyncPinsTheBuiltCommitTest</c>. The published bundle root is a REAL directory
+/// on disk carrying the markers <c>publish-bake-bundles.sh</c> writes, because
+/// <see cref="SealedPublicationIndex"/> is pure over the file system and staging it is cheaper and
+/// truer than substituting it. Everything between is the real mesh: the real webhook processor, the
+/// real gate, the real sync service, the real node streams.</para>
+/// </summary>
+public class HeldSourceSaysItIsHeldTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string RepoFullName = "test/held-source";
+    private const string RepoUrl = $"https://github.com/{RepoFullName}";
+
+    /// <summary>The bake source directory the seal lives under — the name the Plugins lane uses.</summary>
+    private const string SealedSourceName = "plugins";
+
+    /// <summary>Real-shaped 40-hex shas, so nothing downstream can mistake one for a branch name.</summary>
+    private const string SealedSha = "24c2d024b1f25e84a9c98525cfb543d3cbb79fda";
+
+    /// <summary>A later green build of the same branch — the commit the seal does NOT cover.</summary>
+    private const string UnsealedSha = "222853d4aabbccddeeff00112233445566778899";
+
+    private readonly RecordingRepoClient repoClient = new();
+
+    /// <summary>The published bundle root this test stages; removed on dispose.</summary>
+    private readonly string publishedRoot = Path.Combine(
+        Path.GetTempPath(), "mw-held-source-" + Guid.NewGuid().ToString("N")[..12]);
+
+    /// <summary>The DevLogin user the test base logs in — read directly, since
+    /// <c>AccessService.Context</c> is circuit-scoped and null on the test-method thread.</summary>
+    private static string UserId => TestUsers.Admin.ObjectId!;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        StageSealedPublication();
+        return base.ConfigureMesh(builder)
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                // Last registration wins: the recording client replaces the git/Octokit transport,
+                // so the whole loop runs offline and the FETCH is directly observable.
+                services.AddSingleton<IGitHubRepoClient>(repoClient);
+
+                // 🚨 LAYER the published-bundle root ONTO the host's configuration, never replace
+                // it. A bare AddSingleton<IConfiguration> wins the resolve and takes every other key
+                // with it — measured here: the credential save then refused with "no master key is
+                // configured (Ai:KeyProtection:MasterKey)", a failure about a key this test never
+                // mentions.
+                var configured = services.LastOrDefault(d => d.ServiceType == typeof(IConfiguration));
+                if (configured is not null)
+                    services.Remove(configured);
+                return services.AddSingleton<IConfiguration>(sp =>
+                {
+                    var builder = new ConfigurationBuilder();
+                    if (Materialise(configured, sp) is { } host)
+                        builder.AddConfiguration(host);
+                    return builder.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [ShippedPrebuiltBundles.PublishedRootConfigKey] = publishedRoot,
+                    }).Build();
+                });
+            });
+    }
+
+    /// <summary>The host's own <c>IConfiguration</c>, from whichever registration shape it used, or
+    /// null when the host registered none. Never silently empty on an unrecognised shape: a test
+    /// whose mesh lost every configuration key fails somewhere else entirely.</summary>
+    private static IConfiguration? Materialise(ServiceDescriptor? descriptor, IServiceProvider sp)
+        => descriptor is null ? null
+            : descriptor.ImplementationFactory is { } factory ? (IConfiguration)factory(sp)
+            : descriptor.ImplementationInstance is IConfiguration instance ? instance
+            : throw new InvalidOperationException(
+                "The IConfiguration registration is neither a factory nor an instance, so this test "
+                + "cannot layer onto it. If the host's configuration lane changed, update this hook — "
+                + "replacing it outright drops every key the mesh needs to boot.");
+
+    /// <summary>
+    /// <c>&lt;root&gt;/&lt;this process's identity&gt;/plugins/</c> with the three markers a sealed
+    /// publication carries: the producing repository, the commit it was baked from, and the
+    /// completion sentinel. The sentinel lists no bundles, which
+    /// <see cref="SealedPublicationIndex"/> reads as sealed-and-complete — the seal is what this
+    /// test needs, not the bytes.
+    /// </summary>
+    private void StageSealedPublication()
+    {
+        var sourceDirectory = Path.Combine(
+            publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid, SealedSourceName);
+        Directory.CreateDirectory(sourceDirectory);
+        File.WriteAllText(
+            Path.Combine(sourceDirectory, SealedPublicationIndex.RepositoryMarkerFileName), RepoFullName);
+        File.WriteAllText(
+            Path.Combine(sourceDirectory, SealedPublicationIndex.SourceCommitMarkerFileName), SealedSha);
+        File.WriteAllText(
+            Path.Combine(sourceDirectory, ShippedPrebuiltBundles.CompletionSentinelFileName), string.Empty);
+    }
+
+    private GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    private GitHubCredentialService Credentials =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubCredentialService>();
+
+    private GitHubWebhookProcessor Webhooks =>
+        Mesh.ServiceProvider.GetRequiredService<GitHubWebhookProcessor>();
+
+    // 120_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a
+    // constant, and the inner waits below already carry the adaptive bound. This outer one
+    // only has to stop a WEDGE.
+    [Fact(Timeout = 120_000)]
+    public async Task SealHeldSource_RecordsTheHoldOnItsConfig_SoItCannotReadAsSettled()
+    {
+        var space = await ArmedSpace("Held");
+
+        // ── the delivery the seal does not cover ─────────────────────────────
+        var neverFetched = repoClient.FetchedRefs.Where(r => r == UnsealedSha)
+            .Should().NotEmit(within: TestTimeouts.Quick);
+
+        await Deliver(UnsealedSha);
+        await neverFetched;
+
+        // 🚨 Read the node back with a FALLBACK to whatever it currently says, never a bare wait:
+        // against the pre-fix code the predicate is never satisfied, and a TimeoutException names no
+        // field and reads as a hang. The assertions below must be able to state what the node
+        // actually said instead.
+        var afterHold = await ConfigWhenOrCurrent(space, c =>
+            string.Equals(c.LastSyncOutcome, GitHubSyncService.HeldOutcome, StringComparison.Ordinal));
+
+        Output.WriteLine(
+            $"after the held delivery: outcome={afterHold.LastSyncOutcome} "
+            + $"note={afterHold.LastSyncNote} attempted={afterHold.LastAttemptedCommitSha ?? "(cleared)"}");
+
+        afterHold.LastSyncOutcome.Should().Be(GitHubSyncService.HeldOutcome,
+            "a source the publication seal held is not a source that is up to date, and the node is "
+            + "the one artefact an operator reads — on both production portals a held Hosting source "
+            + "read 'Imported … final: true' for nine hours while two tagged releases never arrived");
+        afterHold.LastSyncNote.Should().NotBeNullOrEmpty(
+            "the hold must carry its REASON where the outcome is; a hold whose reason lives only in "
+            + "a log line asks the reader to already suspect a hold before they can find one");
+        afterHold.LastSyncNote.Should().Contain(SealedSha[..8],
+            "the reason names the commit this instance's identity IS sealed at, which is what tells "
+            + "an operator whether to wait for a publication or to roll the instance");
+        afterHold.LastAttemptedCommitSha.Should().BeNull(
+            "a hold means no import ran, so it must never leave a #3945 'already attempted at this "
+            + "commit, final' licence standing for the delivery that follows it");
+        afterHold.LastAttemptWasFinal.Should().BeFalse(
+            "the finality flag is only ever read beside the attempted sha it qualifies");
+
+        // ── the control: the seal DOES cover this one, so it imports and the note clears ──
+        var fetched = repoClient.FetchedRefs.Where(r => r == SealedSha)
+            .Should().Within(TestTimeouts.Convergence * 2)
+            .Emit("a green build AT the sealed commit is exactly what the gate waits for");
+
+        await Deliver(SealedSha);
+        (await fetched).Should().Be(SealedSha);
+
+        var afterImport = await ConfigWhen(space, c =>
+            string.Equals(c.LastSyncCommitSha, SealedSha, StringComparison.OrdinalIgnoreCase));
+
+        Output.WriteLine(
+            $"after the sealed delivery: outcome={afterImport.LastSyncOutcome} "
+            + $"note={afterImport.LastSyncNote ?? "(cleared)"} sha={afterImport.LastSyncCommitSha}");
+
+        afterImport.LastSyncOutcome.Should().NotBe(GitHubSyncService.HeldOutcome,
+            "the hold describes ONE delivery; an import that ran must replace it, or the record "
+            + "would turn a transient condition into a permanent label");
+        afterImport.LastSyncNote.Should().BeNullOrEmpty(
+            "the note describes the LAST attempt only — a stale hold reason surviving a successful "
+            + "import is the same false reading in the opposite direction");
+    }
+
+    /// <summary>A Space with a sync config for this repository and a credential for whoever the
+    /// config write attributed itself to, so the import path can authenticate.</summary>
+    private async Task<string> ArmedSpace(string prefix)
+    {
+        var space = prefix + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space",
+            Name = "Seal-held space",
+            State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Timeout(TestTimeouts.Convergence).Await();
+
+        var configNode = await Sync
+            .SaveConfig(space, RepoUrl, "main", null,
+                createBranchIfMissing: false, createRepoIfMissing: false)
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        // The import authenticates as the sync config's CREATOR — read it off the node rather than
+        // assuming which identity the write landed under.
+        var syncOwner = configNode.CreatedBy is { Length: > 0 } creator ? creator : UserId;
+        await Credentials
+            .Save(syncOwner, new GitHubToken("ghp_test_token", null, "bearer", "repo", null), "octocat")
+            .Timeout(TestTimeouts.Convergence).Await();
+        return space;
+    }
+
+    /// <summary>One verified green-build delivery, with every ambient identity dropped: the webhook
+    /// request is ANONYMOUS — its authorization is the HMAC signature — so the processor's own
+    /// System impersonation must be what carries the lookups and the writes.</summary>
+    private async Task Deliver(string headSha)
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.ClearHostIdentity();
+        accessService.SetHostIdentity(null);
+        accessService.SetContext(null);
+        try
+        {
+            await Webhooks.Process("workflow_run", GreenBuildPayload(headSha))
+                .Timeout(TestTimeouts.Convergence).Await();
+        }
+        finally
+        {
+            accessService.SetHostIdentity(
+                new AccessContext { ObjectId = UserId, Name = TestUsers.Admin.Name });
+        }
+    }
+
+    /// <summary>The sync config once it satisfies <paramref name="predicate"/>, or — when it never
+    /// does within the bound — whatever the node says RIGHT NOW, so the caller's assertion is what
+    /// fails and names the field. A bare timeout would report a hang for a value that is simply
+    /// wrong.</summary>
+    private async Task<GitHubSyncConfig> ConfigWhenOrCurrent(
+        string space, Func<GitHubSyncConfig, bool> predicate)
+    {
+        var configs = Mesh.GetWorkspace().GetMeshNodeStream(GitHubSyncService.ConfigPath(space))
+            .Where(n => n is not null
+                        && n.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions) is not null)
+            .Select(n => n!.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)!);
+        return await configs.Where(predicate).FirstAsync()
+            .Timeout(TestTimeouts.Convergence, configs.FirstAsync())
+            .Timeout(TestTimeouts.CrossSilo)
+            .Await();
+    }
+
+    /// <summary>The sync config as the authoritative node stream reports it, once it satisfies
+    /// <paramref name="predicate"/> — never a query (eventually consistent, and this reads right
+    /// after a write), and never a bare first emission (the cache can replay the pre-write value).
+    /// </summary>
+    private async Task<GitHubSyncConfig> ConfigWhen(string space, Func<GitHubSyncConfig, bool> predicate)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(GitHubSyncService.ConfigPath(space))
+            .Where(n => n is not null
+                        && n.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions) is { } c
+                        && predicate(c))
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await();
+        return node.ContentAs<GitHubSyncConfig>(Mesh.JsonSerializerOptions)!;
+    }
+
+    private static JsonElement GreenBuildPayload(string headSha) => JsonDocument.Parse($$"""
+        {
+          "action": "completed",
+          "repository": { "full_name": "{{RepoFullName}}", "default_branch": "main" },
+          "workflow_run": {
+            "conclusion": "success", "head_branch": "main", "head_sha": "{{headSha}}",
+            "id": 34668111508, "run_number": 5957, "name": "Content CI", "event": "push",
+            "path": ".github/workflows/ci.yml",
+            "updated_at": "2026-09-12T03:44:46Z"
+          }
+        }
+        """).RootElement;
+
+    /// <inheritdoc />
+    public override void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(publishedRoot))
+                Directory.Delete(publishedRoot, recursive: true);
+        }
+        catch (IOException)
+        {
+            // A temp directory that outlives the run costs nothing and must never fail a test.
+        }
+        base.Dispose();
+    }
+
+    /// <summary>
+    /// The GitHub transport, reduced to the one question this test asks: which ref did the import
+    /// request? Everything else throws, so a future caller that starts depending on another
+    /// operation is told rather than silently served a fake answer.
+    /// </summary>
+    private sealed class RecordingRepoClient : IGitHubRepoClient
+    {
+        private readonly ReplaySubject<string> fetched = new();
+
+        /// <summary>Every commitish a fetch has asked for, replayed to a late subscriber.</summary>
+        public IObservable<string> FetchedRefs => fetched;
+
+        public IObservable<RepoSnapshot> Fetch(
+            string repositoryUrl, string commitish, string? subdirectory, string accessToken)
+        {
+            fetched.OnNext(commitish);
+            // An empty snapshot at the requested sha: the import then has nothing to write, which is
+            // exactly what this test wants — the RECORD is the measurement, the content is not.
+            return Observable.Return(new RepoSnapshot(commitish, Array.Empty<RepoFile>()));
+        }
+
+        public IObservable<GitHubPushResult> Push(GitHubPushRequest request) => NotUsed<GitHubPushResult>();
+
+        public IObservable<GitHubBranchResult> CreateBranch(GitHubCreateBranchRequest request)
+            => NotUsed<GitHubBranchResult>();
+
+        public IObservable<GitHubPullRequestInfo> OpenPullRequest(GitHubOpenPullRequestRequest request)
+            => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<GitHubPullRequestInfo> GetPullRequestStatus(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestInfo>();
+
+        public IObservable<IReadOnlyList<GitHubIssue>> ListIssues(
+            string repositoryUrl, GitHubIssueState? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubIssue>>();
+
+        public IObservable<GitHubIssue> GetIssue(string repositoryUrl, int number, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssue> CreateIssue(GitHubCreateIssueRequest request) => NotUsed<GitHubIssue>();
+
+        public IObservable<GitHubIssueComment> CommentIssue(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubIssue> SetIssueState(
+            string repositoryUrl, int number, GitHubIssueState state, string accessToken)
+            => NotUsed<GitHubIssue>();
+
+        public IObservable<IReadOnlyList<GitHubPullRequestSummary>> ListPullRequests(
+            string repositoryUrl, PullRequestStatus? state, string accessToken)
+            => NotUsed<IReadOnlyList<GitHubPullRequestSummary>>();
+
+        public IObservable<GitHubPullRequestDetail> GetPullRequestDetail(
+            string repositoryUrl, int number, string accessToken) => NotUsed<GitHubPullRequestDetail>();
+
+        public IObservable<GitHubIssueComment> CommentPullRequest(
+            string repositoryUrl, int number, string body, string accessToken)
+            => NotUsed<GitHubIssueComment>();
+
+        public IObservable<GitHubMergeResult> MergePullRequest(GitHubMergePullRequestRequest request)
+            => NotUsed<GitHubMergeResult>();
+
+        private static IObservable<T> NotUsed<T>() => Observable.Throw<T>(
+            new NotSupportedException("HeldSourceSaysItIsHeldTest's repo client answers only Fetch."));
+    }
+}


### PR DESCRIPTION
## The defect, measured on both production portals

**A green `main` build publishes and GitSynced Spaces do not converge to it** — and the Space's own
sync record says nothing is outstanding.

On 2026-09-12 at 04:0xZ, `Hosting/_GitSync` on memex.meshweaver.cloud AND memex.systemorph.com read:

```json
"lastSyncOutcome": "Imported",
"lastSyncCommitSha":      "24c2d024…",
"lastAttemptedCommitSha": "24c2d024…",
"lastAttemptWasFinal": true
```

which is, field for field, a **settled** source. It was not. `Hosting/v1.17.1` and `v1.18.0` had been
tagged by the green run at 23:59Z, `DeepSign/v1.1.0` by the one at 03:44Z, and eight green
MeshWeaver.Plugins `main` builds had arrived since 18:55Z without producing a single import. Every one
of them was refused by `SealedSyncGate` — correctly — and the refusal was recorded **nowhere**: its
whole trace was one `Warning` per delivery, in a log a reader must already suspect a hold to go
looking in. Two sessions read that node as settled before `Hosting/_Activity` (no
`Update Hosting to the built commit …` entry after 18:55:17Z) gave the hold away.

## What this changes

`GitHubWebhookProcessor.RecordSealHold` writes the hold where the outcome is, through the
`GitHubSyncService.RecordHold` the boot-time reconciler (`SealedPublicationSyncReconciler`) **already
uses** for its own holds — so the two paths stop disagreeing about what a hold looks like:

```json
"lastSyncOutcome": "Held",
"lastSyncNote": "built at 222853d4, not sealed for this instance (identity s6649734…: 'plugins' is sealed at 24c2d024)"
```

The attempt pair is cleared with it, so a hold can never leave a #3945 *"already attempted at this
commit, final"* licence standing for the delivery that follows. Said **once per reason**, not per
delivery: the reason names the built sha, so a re-run, a `schedule` probe or a
`repository_dispatch` re-verification of the same commit writes nothing, and a hold at a new commit
writes once. Best-effort — the delivery has already decided not to import and GitHub is answered 200
either way. An import that actually runs replaces the outcome and clears the note.

No retry, no timer, no poller, no widened bound: a silent refusal becomes a recorded one.

## The test, and what falsifies it

`HeldSourceSaysItIsHeldTest` stages a real published-bundle root with the markers
`publish-bake-bundles.sh` writes (`repository.txt`, `source-commit.txt`, `_complete`) under **this
process's own** framework identity, then drives a real `workflow_run` delivery through the real
webhook processor, the real gate, the real sync service and the real node streams. One seam is
substituted, the GitHub transport, as in `BuildTriggeredSyncPinsTheBuiltCommitTest`.

- **Against this fix:** passes in 12 s.
- **Against `main` (the `RecordSealHold` call commented out):** fails in 48 s with
  `Expected value to be "Held" … but found <null>` — the node read back carries no outcome and no
  note, which is the defect in the words the incident used. The read falls back to the node's
  CURRENT value rather than timing out, so the failure names the field instead of reading as a hang.
- **The control that keeps it honest:** a second delivery **at the sealed commit** must import and
  **clear** the note — so "held" can never become a permanent stamp, and a stale hold reason
  surviving a successful import is caught as the same false reading in the other direction.

## What this does NOT fix — filed as #4063

Recording the hold makes the freeze **findable**; it does not make it **converge**. Root cause:
`SealedSyncGate` proceeds only when a publication sealed under *this instance's own framework
identity* is at the built commit. That identity follows the image the portal was **rolled** to; the
seal's follows the image the repo's bake **resolves**. Measured here: both portals on
`framework=s6649734…` (core `74d4c852`), while `Hosting/PlatformBuilds/plugins` was registered at
03:44:43Z under `s8e1f76cc22bcd7051a7ad998debbfeb3` (3.0.0-ci.8392). The portals' own identity still
holds the *last* publication made for it (`24c2d024`), so the release condition is now permanently
unsatisfiable and the only true release is a roll. #4063 carries the mechanism, the branch-by-branch
elimination with its positive controls, and a proposed shape (a `census` health entry; re-evaluation
driven by the `Hosting/PlatformBuilds/<source>` fact rather than a timer; and the roll-policy half,
which is a maintainer call).

## Conserved

- `Doc/Architecture/PublicationSealStarvation` — the gate, the identity drift, the measurement, the
  elimination table, how to read a source's state, and what is still missing.
- Cross-linked from `GitHubSync` and `GitSyncTriggerCost`.
- What's New entry (`Category: Fix` — a user can notice a Space that stopped receiving releases).

## Local evidence (this worktree, CI's flags)

- `dotnet build -c Release -warnaserror` on `MeshWeaver.GitSync`, `MeshWeaver.PluginCatalog`,
  `MeshWeaver.Hosting.Test`, `MeshWeaver.Documentation.Test`: **0 Warning(s), 0 Error(s)** each.
- `HeldSourceSaysItIsHeldTest`: 1 passed (12 s); 1 failed with the fix disabled (48 s, assertion above).
- Siblings on the same seam — `GreenBuildSkipsASettledSource`, `BuildTriggeredSyncPinsTheBuiltCommit`,
  `SealedSyncReconcile`, `SyncNodeSaysWhenItLastSynced`, `ReturningSourceConverges`,
  `SealedPublicationIndex`: **29 passed, 0 failed**.
- `DocumentationLinkIntegrityTest` + What's New + `SealedSyncGate` guards: **17 passed, 0 failed**.

Pairs-with: none — no public type or member is removed; the change adds one private method and one
private instance field to `GitHubWebhookProcessor` and touches no public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
