### PR TITLE
#4040 The Create form asks ICreatableTypesProvider — CreatableTypes is read at last

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -234,6 +234,7 @@ Each theme starts with its introductory page, followed by related architecture t
 ### Node types
 
 - **Start here:** [Adding a New Node Type](AddingANewNodeType)
+- [Creatable Types](CreatableTypes) — what may be created under a node: the one provider the Create form asks, what a parent NodeType restricts, what it extends, and why a parent that declares nothing must never narrow the menu
 - [Retiring a NodeType](RetiringANodeType) — the prune keeps the definition and deletes its sources
 - [Dangling NodeTypes](DanglingNodeTypes) — a node whose type resolves to nothing, and the two write paths that allowed it
 - [Node Type Compilation](NodeTypeCompilation)

--- a/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
@@ -1,0 +1,117 @@
+---
+Name: Creatable Types
+Category: Architecture
+Description: What may be created under a node — the one resolution rule the Create form asks, what a parent NodeType can restrict, what it can extend, and what the default is.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14"/><path d="M5 12h14"/></svg>
+---
+
+# Creatable Types
+
+**What may be created under a node has exactly one answer, and it is
+`ICreatableTypesProvider.GetCreatableTypes(nodePath, parentNode)`.** The Create form
+(`CreateLayoutArea`) asks it and renders the result; nothing else computes a second answer.
+
+```csharp
+// MeshWeaver.Graph/CreateLayoutArea.cs — the type picker's only source
+var creatableTypes = host.Hub.ServiceProvider
+    .GetRequiredService<ICreatableTypesProvider>()
+    .GetCreatableTypes(parentPath, currentNode);
+```
+
+The picker therefore carries **items and no queries**. That is not a style choice: a
+`MeshNodePickerControl.Queries` leg runs on the client and merges its rows into the same candidate
+set, so a query alongside the provider would re-admit by discovery exactly what a restricting
+parent excluded.
+
+## The resolution rule
+
+Four sources are merged, deduplicated by NodeType path, and ordered by `Order` then name.
+
+| # | Source | Governed by |
+|---|---|---|
+| 1 | **Ancestor-scoped discovery** — `nodeType:NodeType scope:selfAndAncestors namespace:{nodePath} context:create` | the mesh |
+| 2 | **Child types of the parent's own type** — `namespace:{parentNode.NodeType} nodeType:NodeType context:create`, so an `ACME/Project` instance offers `ACME/Project/Todo` | the mesh |
+| 3 | **The parent type's `CreatableTypes`** — `NodeTypeDefinition.CreatableTypes` on the NodeType of `parentNode` | the type author |
+| 4 | **The global set** — `MeshConfiguration.GlobalCreatableTypes` (`Markdown`, `Thread`, `Agent`, `NodeType` by default) | the host, opt-out per type |
+
+Plus every **static registration** the host contributed through `AddMeshNodes` /
+`IStaticNodeProvider` that has not opted out of `context:create`. At the ROOT path (no parent) there
+is no namespace to scope to, so source 1 becomes the declared mesh-wide NodeType catalog
+(`MeshWideQuery`) — a catalog is mesh-wide by nature and says so (see
+[Cross-Schema Fan-Out Elimination](/Doc/Architecture/CrossSchemaFanOutElimination)).
+
+### What a parent can restrict
+
+**`CreatableTypes` is a WHITELIST, not merely an addition.** When the parent node's NodeType
+declares one, sources 1, 2 and the static bucket are filtered down to it. A type the
+ancestor-scoped query found and the parent did not declare is withheld.
+
+```json
+{ "creatableTypes": ["Crm/Question"] }
+```
+
+Under an instance of that type, `Crm/Question` is the only discovered type offered — the global set
+still rides along (below).
+
+### What a parent can extend
+
+The same list ADDS. A declared path that no query returned is offered anyway, resolved from the
+static registry when it is there and synthesised from the path when it is not. **This is the half
+that no namespace-scoped query can reach**: in `Systemorph/MeshWeaver.Crm`, `Crm/Offer` declares
+`Crm/Question` while the instances live in a different partition (`PearlTechnology/Commercials`), so
+`Crm/Question` is in no ancestor chain of the node being created under. The declaration is the only
+thing that puts it in the menu.
+
+### What the default is
+
+**A parent that declares nothing restricts nothing.** With `CreatableTypes` absent, every discovered
+type and every static registration is offered — exactly the set the Create form offered before it
+asked the provider. `CreateMenuHonoursTheParentTypeTest.AParentDeclaringNothingLosesNothing` pins
+that as a SUPERSET assertion against the two query literals the form used to run, because the
+failure it guards against is invisible: a narrower source would shrink every Create menu in the
+fleet with no error and no empty state.
+
+### `IncludeGlobalTypes`
+
+`NodeTypeDefinition.IncludeGlobalTypes` defaults to `true` and rides along with a whitelist — a type
+that restricts discovery to `["Crm/Question"]` still offers Markdown, Thread, Agent and NodeType.
+Set it to `false` to seal that off. The property carries
+`[JsonIgnore(Condition = JsonIgnoreCondition.Never)]` on purpose: the initializer defaults to `true`,
+so an explicit `false` equals `default(bool)` and the hub's `WhenWritingDefault` policy would
+otherwise omit it and silently round-trip the opt-out back to `true`.
+
+### Opting a type out of creation entirely
+
+`ExcludeFromContext: ["create"]` on the NodeType is how a type says it is not creatable —
+`Release`, `Build`, `ModuleBuild` and `Partition` all use it. Every query above names
+`context:create`, and the static bucket applies the same filter, so the opt-out is honoured on both
+legs. See [Query Syntax](/Doc/DataMesh/QuerySyntax) for the `context:` qualifier and the other contexts.
+
+## Two rules that look like details and are not
+
+🚨 **The static bucket is filtered by the create-context opt-out, NEVER by `NodeType == "NodeType"`.**
+A built-in type registration is `AddMeshNodes(new MeshNode("Group") { HubConfiguration = … })` — the
+PATH is the type name and there is no self-typing stamp at all. Measured on a running mesh (#4040),
+filtering the static bucket on that stamp kept **7 of 42** registrations and silently dropped
+`Markdown`, `Group`, `Role`, `Redirect`, `UiContribution`, `HomeTab`, `License` and `WhatsNew` —
+every one a type the Create form has always offered.
+
+🚨 **There is no root-namespace query leg, and adding one back would achieve nothing.**
+`namespace:` with an empty value leaves `ParsedQuery.Path` empty, which is precisely the shape the
+Postgres planner refuses as unanchored (see
+[Cross-Schema Fan-Out Elimination](/Doc/Architecture/CrossSchemaFanOutElimination)) — so on a partitioned portal that
+leg has never returned a row, whatever it looked like it was doing. Root-level built-ins reach the
+menu through the static bucket, which is where they actually live.
+
+## Where the code is
+
+| Concern | File |
+|---|---|
+| The contract | `src/MeshWeaver.Mesh.Contract/Services/ICreatableTypesProvider.cs` |
+| The resolution | `src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs` |
+| The declaration | `src/MeshWeaver.Graph.Contract/NodeTypeDefinition.cs` (`CreatableTypes`, `IncludeGlobalTypes`) |
+| The global set | `src/MeshWeaver.Mesh.Contract/MeshConfiguration.cs` (`GlobalCreatableTypes`) |
+| The form | `src/MeshWeaver.Graph/CreateLayoutArea.cs` |
+| The tests | `test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs` |
+
+Related: [Adding a New Node Type](/Doc/Architecture/AddingANewNodeType) · [CQRS and Content Access](/Doc/Architecture/CqrsAndContentAccess)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-type-can-say-what-may-be-created-under-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-type-can-say-what-may-be-created-under-it.md
@@ -1,0 +1,42 @@
+---
+Name: A type can say what may be created under it
+Category: Fix
+Description: A NodeType's creatableTypes setting is finally read. Declaring it now both adds a type to the Create menu under instances of that type and limits the menu to what was declared — until now it was documented, accepted and ignored.
+Icon: Add
+Order: -20260912
+---
+
+# A type can say what may be created under it
+
+A node type can declare what may be created under its instances:
+
+```json
+{ "creatableTypes": ["Crm/Question"] }
+```
+
+That setting has been documented and accepted for a long time, and until now nothing read it. The
+Create form worked out its own list instead, from where the node sits: a type was offered if it
+lived at the top level or somewhere on the path above the node you were creating under. Nothing a
+type declared could add to that list, and nothing could take anything off it.
+
+The effect was a feature that appeared to work and did nothing. A CRM module shipped exactly this
+declaration — offers may contain questions — and on the portal an offer's Create menu listed around
+ninety types, not one of them from the CRM module. There was no error and no empty state to notice:
+the entry simply was not there. Anything else relying on the setting failed the same silent way.
+
+The Create form now asks the platform the question rather than answering it itself, so the setting
+does what it says:
+
+- **It adds.** A declared type is offered even when it lives in a different part of the mesh
+  entirely — which is the case the old list could never reach, and the reason the CRM module's
+  declaration did nothing.
+- **It limits.** Where a type declares a list, that list is what instances of it offer. A type
+  discovered nearby but not declared is withheld.
+- **It leaves the common case alone.** A type that declares nothing restricts nothing: the menu
+  under it still contains everything it contained before. That is pinned by a test, because a menu
+  that quietly got shorter would have been the same invisible failure aimed the other way.
+
+Two smaller corrections travel with it. Types that had opted out of being created — releases,
+builds, partitions — are honoured everywhere the menu is assembled. And the `includeGlobalTypes`
+switch works, so a type that limits its menu can also decide whether the always-available basics
+(Markdown, Thread, Agent, Node type) still ride along.

--- a/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
+++ b/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
@@ -27,9 +27,9 @@ namespace MeshWeaver.Graph.Configuration;
 ///   <item>NodeType MeshNodes returned by the query (dynamic NodeTypes
 ///     persisted as <c>nodeType:NodeType</c> rows + static NodeTypes
 ///     surfaced by <see cref="IStaticNodeProvider"/>).</item>
-///   <item>Static <c>MeshConfiguration</c> node entries with
-///     <c>NodeType = "NodeType"</c> — for AddMeshNodes registrations
-///     that aren't persisted (built-in types like Markdown, Thread).</item>
+///   <item>Static <see cref="IStaticNodeProvider"/> entries that have not opted out of
+///     <see cref="MeshContexts.Create"/> — the AddMeshNodes registrations that are never
+///     persisted (Markdown, Group, Role, Redirect, UiContribution, HomeTab, …).</item>
 ///   <item>Explicit <c>CreatableTypes</c> JSON on the parent NodeType
 ///     definition (read from
 ///     <see cref="NodeTypeDefinition.CreatableTypes"/>).</item>
@@ -150,19 +150,33 @@ internal sealed class CreatableTypesProvider(
 
     private static string[] BuildQueries(string? nodePath, string? currentType)
     {
+        // 🚨 `context:create` on EVERY query, because this IS the create menu. A NodeType that
+        // opted out of creation (Release, Build, ModuleBuild, Partition — `ExcludeFromContext:
+        // ["create"]`) must not be offered, and the opt-out is only honoured when the query
+        // names the context it is for. Without it the provider offered four types the Create
+        // form has always withheld.
+        const string CreateContext = "context:" + MeshContexts.Create;
+
         if (string.IsNullOrEmpty(nodePath))
         {
             // Root listing: no namespace bound. Surface every NodeType
             // definition so the create UI can offer the full menu — a catalog, mesh-wide by
             // nature, and it says so (#3202 — fan-out is opt-in).
-            return [MeshWideQuery.OfType("NodeType")];
+            return [MeshWideQuery.Declare($"nodeType:NodeType {CreateContext}")];
         }
 
         // Q1: NodeTypes along the ancestor chain of <myself> — picks up
         // types defined under any namespace in the path's hierarchy.
+        //
+        // 🚨 There is deliberately NO root-namespace leg (`namespace: nodeType:NodeType`)
+        // here, even though the Create form used to run one: `namespace:` with an empty value
+        // leaves ParsedQuery.Path empty, which is exactly the shape the Postgres planner
+        // REFUSES as unanchored (#3202) — so on a partitioned portal that leg has never
+        // returned a row. Root-level built-ins reach the menu through the static bucket in
+        // BuildInfos, which is where they actually live.
         var list = new List<string>(2)
         {
-            $"nodeType:NodeType scope:selfAndAncestors namespace:{nodePath}",
+            $"nodeType:NodeType scope:selfAndAncestors namespace:{nodePath} {CreateContext}",
         };
         // Q2 (when applicable): NodeTypes under the parent's NodeType so
         // an instance can offer the children its type defines (e.g. an
@@ -170,7 +184,7 @@ internal sealed class CreatableTypesProvider(
         if (!string.IsNullOrEmpty(currentType)
             && !string.Equals(currentType, MeshNode.NodeTypePath, StringComparison.Ordinal))
         {
-            list.Add($"namespace:{currentType} nodeType:NodeType");
+            list.Add($"namespace:{currentType} nodeType:NodeType {CreateContext}");
         }
         return list.ToArray();
     }
@@ -227,14 +241,22 @@ internal sealed class CreatableTypesProvider(
             result.Add(BuildInfoFromMeshNode(typeNode, options));
         }
 
-        // 2. Static IStaticNodeProvider-registered NodeType MeshNodes that aren't
-        //    persisted (don't show up in the query). Filter on
-        //    NodeType == MeshNode.NodeTypePath to grab only NodeType
-        //    definitions, not arbitrary static nodes.
+        // 2. Static IStaticNodeProvider-registered nodes that aren't persisted (so they never
+        //    show up in the query above).
+        //
+        //    🚨 THE FILTER IS THE CREATE-CONTEXT OPT-OUT, never `NodeType == "NodeType"`.
+        //    A built-in type registration is `AddMeshNodes(new MeshNode("Group") {
+        //    HubConfiguration = … })` — the PATH is the type name and there is no self-typing
+        //    stamp at all. Measured on a running mesh (#4040): filtering on
+        //    `NodeType == MeshNode.NodeTypePath` kept 7 of 42 and silently dropped Markdown,
+        //    Group, Role, Redirect, UiContribution, HomeTab, License and WhatsNew — every one
+        //    of them a type the Create form has always offered. Shrinking the create menu is
+        //    the same class of invisible failure as never reading CreatableTypes at all, so
+        //    this bucket applies exactly the rule the form applied: everything the host
+        //    registered, minus what opted out of `context:create`.
         foreach (var typeNode in serviceProvider.EnumerateStaticNodes())
         {
-            if (!string.Equals(typeNode.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
-                continue;
+            if (typeNode.IsExcludedFromContext(MeshContexts.Create)) continue;
             if (!Allowed(typeNode.Path)) continue;
             if (!added.Add(typeNode.Path)) continue;
             result.Add(BuildInfoFromMeshNode(typeNode, options));
@@ -269,10 +291,13 @@ internal sealed class CreatableTypesProvider(
             }
         }
 
-        // Order ascending — globals carry a high Order (e.g. 1000/1001) so they
-        // sort to the end of the create menu; OrderBy is stable so types with
-        // an equal Order keep their discovery sequence.
-        return result.OrderBy(x => x.Order).ToList();
+        // Order ascending — globals carry a high Order (e.g. 1000/1001) so they sort to the end
+        // of the create menu; within one Order the list is alphabetical, which is how the
+        // Create form has always presented its fixed items.
+        return result
+            .OrderBy(x => x.Order)
+            .ThenBy(x => x.DisplayName ?? x.NodeTypePath, StringComparer.OrdinalIgnoreCase)
+            .ToList();
     }
 
     private static CreatableTypeInfo BuildInfoFromMeshNode(MeshNode node, System.Text.Json.JsonSerializerOptions options)

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -264,6 +264,28 @@ public static class CreateLayoutArea
     }
 
     /// <summary>
+    /// The picker's item shape. <see cref="MeshNodePickerControl.Items"/> takes MeshNodes — it
+    /// stores the selected node's <c>Path</c> as the form value and renders Name/Icon/Description
+    /// — so a <see cref="CreatableTypeInfo"/> is projected onto one. Every entry IS a type
+    /// declaration, hence <see cref="MeshNode.NodeTypePath"/> as the NodeType.
+    /// </summary>
+    private static object ToPickerNode(CreatableTypeInfo info)
+    {
+        var lastSlash = info.NodeTypePath.LastIndexOf('/');
+        var node = lastSlash > 0
+            ? new MeshNode(info.NodeTypePath[(lastSlash + 1)..], info.NodeTypePath[..lastSlash])
+            : new MeshNode(info.NodeTypePath);
+        return node with
+        {
+            Name = info.DisplayName ?? node.Id,
+            Icon = info.Icon,
+            Description = info.Description,
+            Order = info.Order,
+            NodeType = MeshNode.NodeTypePath,
+        };
+    }
+
+    /// <summary>
     /// Builds the unified "Create New" form:
     /// Namespace (MeshNodePicker), Type (MeshNodePicker with Items), Name, Id, Create/Cancel.
     /// Synchronous — defaults are resolved from the already-available nodes array.
@@ -344,15 +366,9 @@ public static class CreateLayoutArea
         if (restrictedNamespaces is { Length: 1 })
             defaultNamespace = restrictedNamespaces[0];
 
-        // 2. Build fixed creatable type Items (alphabetical)
-        var creatableTypeNodes = host.Hub.ServiceProvider.EnumerateStaticNodes()
-            .Where(n => n.ExcludeFromContext?.Contains("create") != true)
-            .OrderBy(n => n.Name ?? n.Path)
-            .ToArray();
-
-        // Resolve the default icon from the selected type's registration so the preview
-        // can show something meaningful before the user clicks "Regenerate".
-        var defaultTypeIcon = creatableTypeNodes.FirstOrDefault(n => n.Path == defaultType)?.Icon;
+        // 2. Resolve the default icon from the selected type's registration so the preview
+        //    can show something meaningful before the user clicks "Regenerate".
+        var defaultTypeIcon = host.Hub.ServiceProvider.FindStaticNode(defaultType)?.Icon;
 
         // 3. Form data
         var formId = $"create_form_{Guid.NewGuid().AsString()}";
@@ -393,7 +409,7 @@ public static class CreateLayoutArea
         if (restrictedTypes is { Length: 1 })
         {
             // Single type restriction — show readonly info
-            var typeNode = creatableTypeNodes.FirstOrDefault(n => n.Path == restrictedTypes[0]);
+            var typeNode = host.Hub.ServiceProvider.FindStaticNode(restrictedTypes[0]);
             var typeLabel = typeNode?.Name ?? restrictedTypes[0];
             stack = stack.WithView(Controls.Stack
                 .WithWidth("100%")
@@ -401,42 +417,40 @@ public static class CreateLayoutArea
                 .WithView(Controls.Body(host.Localize("ui.type")).WithStyle("font-weight: 600; margin-bottom: 4px;"))
                 .WithView(Controls.Body(typeLabel).WithStyle("color: var(--neutral-foreground-rest);")));
         }
-        else if (restrictedTypes is { Length: > 1 })
-        {
-            // Multiple type restriction — filtered picker
-            var filteredTypeNodes = creatableTypeNodes
-                .Where(n => restrictedTypes.Contains(n.Path))
-                .ToArray();
-            stack = stack.WithView(new MeshNodePickerControl(new JsonPointerReference("type"))
-            {
-                Label = "Type *",
-                Required = true,
-                Placeholder = "Select a type...",
-                DataContext = dataContext
-            }.WithItems(filteredTypeNodes)
-             .WithMaxResults(15)
-             .WithStyle("width: 100%; margin-bottom: 16px;"));
-        }
         else
         {
-            // No restriction — full picker. Queries cover (a) root-level registered NodeTypes
-            // and (b) any NodeType defined within the current namespace or its ancestors.
-            // context:create excludes NodeTypes that opt out of creation (e.g. Release,
-            // Notification) — the WHERE on Items already filters those, but the QUERY path
-            // must too or the excluded types leak back in via query results.
-            var ancestorQuery = string.IsNullOrEmpty(parentPath)
-                ? "namespace: nodeType:NodeType context:create"
-                : $"namespace:{parentPath} nodeType:NodeType scope:selfAndAncestors context:create";
-            stack = stack.WithView(new MeshNodePickerControl(new JsonPointerReference("type"))
-            {
-                Label = "Type *",
-                Required = true,
-                Placeholder = "Select a type...",
-                DataContext = dataContext
-            }.WithItems(creatableTypeNodes)
-             .WithQueries("namespace: nodeType:NodeType context:create", ancestorQuery)
-             .WithMaxResults(15)
-             .WithStyle("width: 100%; margin-bottom: 16px;"));
+            // 🚨 WHAT MAY BE CREATED HERE IS ICreatableTypesProvider'S ANSWER — this form does
+            // not build a second one (#4040). It used to run two query literals of its own
+            // (`namespace: nodeType:NodeType context:create` plus the self-and-ancestors leg),
+            // which meant a type was offered only if it sat at the root namespace or in the
+            // target's own ancestor chain: no declaration on the parent NodeType could add one
+            // and none could take one away. NodeTypeDefinition.CreatableTypes,
+            // NodeTypeDefinition.IncludeGlobalTypes and MeshConfiguration.GlobalCreatableTypes
+            // were documented, populated by modules — MeshWeaver.Crm#82 declared
+            // `"creatableTypes": ["Crm/Question"]` on Crm/Offer — and read by nothing.
+            //
+            // The provider resolves all of it in one place: the namespace-scoped discovery
+            // queries, the parent type's own whitelist (which RESTRICTS discovery as well as
+            // EXTENDING it), and the global set. The picker therefore carries ITEMS and no
+            // queries — a query leg would re-admit exactly what a restricting parent excluded.
+            var creatableTypes = host.Hub.ServiceProvider
+                .GetRequiredService<ICreatableTypesProvider>()
+                .GetCreatableTypes(parentPath, currentNode);
+            stack = stack.WithView((_, _) => creatableTypes.Select(types =>
+                (UiControl)new MeshNodePickerControl(new JsonPointerReference("type"))
+                {
+                    Label = host.Localize("ui.typeRequired"),
+                    Required = true,
+                    Placeholder = host.Localize("create.selectType"),
+                    DataContext = dataContext
+                }
+                .WithItems(types
+                    .Where(t => restrictedTypes is null
+                        || restrictedTypes.Contains(t.NodeTypePath, StringComparer.OrdinalIgnoreCase))
+                    .Select(ToPickerNode)
+                    .ToArray<object>())
+                .WithMaxResults(15)
+                .WithStyle("width: 100%; margin-bottom: 16px;")));
         }
 
         // 7. Namespace — REACTIVE on the selected type. Partition objects (Space, User;

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -981,6 +981,7 @@
   "dialog.imageGenFailed": "Bilderzeugung fehlgeschlagen",
   "create.autoGenIdHint": "Leer lassen, um die ID automatisch aus dem Namen zu erzeugen (aus \"Mein Artikel\" wird \"MeinArtikel\")",
   "create.autoGenIdPlaceholder": "Leer lassen für automatische Erzeugung aus dem Namen",
+  "create.selectType": "Typ auswählen…",
   "apiTokens.intro": "Persönliche Zugriffstoken für API und MCP. Ein Token handelt in Ihrem Namen — behandeln Sie es wie ein Passwort.",
   "apiTokens.createHeading": "Token erstellen",
   "apiTokens.field.label": "Bezeichnung",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -981,6 +981,7 @@
   "dialog.imageGenFailed": "Image generation failed",
   "create.autoGenIdHint": "Leave empty to auto-generate from the name (e.g. \"My Article\" → \"MyArticle\")",
   "create.autoGenIdPlaceholder": "Leave empty to auto-generate from name",
+  "create.selectType": "Select a type...",
   "apiTokens.intro": "Personal access tokens for the API and MCP. A token acts as you — treat it like a password.",
   "apiTokens.createHeading": "Create a token",
   "apiTokens.field.label": "Label",

--- a/test/Memex.Portal.Shared.Test/UnanchoredQueryCensusTest.cs
+++ b/test/Memex.Portal.Shared.Test/UnanchoredQueryCensusTest.cs
@@ -78,6 +78,11 @@ public class UnanchoredQueryCensusTest(ITestOutputHelper output) : MonolithMeshT
         yield return ("CompletionUsageIndex", MeshWideQuery.Declare("nodeType:Code limit:2000"));
         yield return ("UiContributionCatalog", MeshWideQuery.OfType("UiContribution"));
         yield return ("CreateLayoutArea namespace picker", MeshWideQuery.OfType("Space"));
+        // The Create menu at the ROOT path has no namespace to scope to, so its NodeType leg is
+        // the declared catalog fan-out (CreatableTypesProvider.BuildQueries). Every other leg it
+        // issues carries a concrete namespace and is anchored by construction.
+        yield return ("CreatableTypesProvider root create menu",
+            MeshWideQuery.Declare("nodeType:NodeType context:create"));
         yield return ("EventSubscriptionRunner", MeshWideQuery.OfType("Invitation") + " content.email:a@b.c");
         yield return ("GitHubWebhookProcessor / ModuleDiscovery / InstanceComboReader", MeshWideQuery.OfType("GitHubSync"));
         yield return ("NodeTypeInstanceProbe", MeshWideQuery.OfType("Acme/Story"));

--- a/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
@@ -1,0 +1,385 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Layout.DataBinding;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>WHAT MAY BE CREATED UNDER A NODE IS <see cref="ICreatableTypesProvider"/>'S ANSWER, AND
+/// THE CREATE FORM ASKS IT</b> (issue #4040).
+///
+/// <para><b>The defect.</b> <c>CreateLayoutArea</c> built the type picker from two query literals
+/// of its own — <c>namespace: nodeType:NodeType context:create</c> and the
+/// <c>scope:selfAndAncestors</c> leg — so a type was offered iff it sat at the root namespace or in
+/// the target's own ancestor chain. <see cref="ICreatableTypesProvider.GetCreatableTypes"/> was
+/// registered as a singleton and called by NOTHING, which made
+/// <see cref="NodeTypeDefinition.CreatableTypes"/>, <see cref="NodeTypeDefinition.IncludeGlobalTypes"/>
+/// and <c>MeshConfiguration.GlobalCreatableTypes</c> documented, populated and never read. Measured
+/// on memex.systemorph.com on 2026-09-11: <c>Crm/Offer</c> declares
+/// <c>"creatableTypes": ["Crm/Question"]</c>, <c>PearlTechnology/Commercials</c> is a
+/// <c>Crm/Offer</c>, and its Create area offered ~90 types, none of them <c>Crm/*</c>
+/// (<c>Systemorph/MeshWeaver.Crm#82</c> shipped green through every gate on that basis).</para>
+///
+/// <para><b>The shape reconstructed here</b> is exactly that one: the declaring type and the
+/// declared type live in partition <c>Ct…</c>, the INSTANCE lives in partition <c>Ho…</c>, so the
+/// declared type is outside the instance's ancestor chain and no namespace-scoped query can reach
+/// it. <see cref="TheOldQueryLiteralsCannotReachADeclaredType"/> is the negative control that keeps
+/// this honest — it runs the two literals the form used to run and asserts they return nothing of
+/// the sort.</para>
+///
+/// <para>🚨 <b>And the opposite risk, which is the one that would ship silently.</b> Pointing the
+/// form at a NARROWER source would shrink every Create menu in the fleet with no error and no empty
+/// state — the same invisible failure, aimed the other way.
+/// <see cref="AParentDeclaringNothingLosesNothing"/> pins that: for a parent type that declares no
+/// <c>CreatableTypes</c>, the offered set must still CONTAIN everything the two literals returned
+/// AND every static registration the form used to hand the picker as fixed items. A parent that
+/// DOES declare restricts; a parent that declares nothing does not.</para>
+/// </summary>
+public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <inheritdoc />
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddLayoutClient()
+            .WithTypes(typeof(MeshNodePickerControl), typeof(MeshNode));
+
+    /// <summary>
+    /// The two query literals <c>CreateLayoutArea</c> ran before this change, verbatim. They are
+    /// the BASELINE the new source may never fall below, and the negative control that the
+    /// cross-partition declaration was genuinely unreachable through them.
+    /// </summary>
+    private static string[] RetiredQueryLiterals(string parentPath) =>
+    [
+        "namespace: nodeType:NodeType context:create",
+        $"namespace:{parentPath} nodeType:NodeType scope:selfAndAncestors context:create",
+    ];
+
+    /// <summary>
+    /// 🚨 THE NO-SHRINK PIN. A parent type declaring no <c>CreatableTypes</c> restricts nothing, so
+    /// the provider-fed menu must be a SUPERSET of what the retired literals returned and of the
+    /// static items the form used to pass as <c>WithItems</c>.
+    ///
+    /// <para>Asserted non-vacuously: the baseline itself must be non-empty and must contain the
+    /// RUNTIME NodeType sitting in the instance's own partition, so "both sets are empty" cannot
+    /// pass. Measured here: baseline 4 + 42 static items, all present in the provider's 45.</para>
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant (TestTimeouts.TestMilliseconds is not).
+    public async Task AParentDeclaringNothingLosesNothing()
+    {
+        var (types, host) = await Fixture();
+        var parentPath = $"{host}/Thing";
+
+        var baseline = await LiteralQueryResults(parentPath);
+        Output.WriteLine($"retired literals returned {baseline.Count}: {string.Join(", ", baseline.OrderBy(x => x))}");
+        baseline.Should().NotBeEmpty("a baseline of nothing cannot detect a shrink");
+        baseline.Should().Contain($"{host}/Local",
+            "the runtime NodeType in the instance's own partition is what the ancestor-scoped leg is FOR — "
+            + "without it in the baseline this comparison is not measuring the query legs at all");
+
+        var staticItems = Mesh.ServiceProvider.EnumerateStaticNodes()
+            .Where(n => !n.IsExcludedFromContext(MeshContexts.Create))
+            .Select(n => n.Path)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+        staticItems.Should().NotBeEmpty("the form passed these as the picker's fixed Items");
+
+        var offered = await Offered(parentPath);
+        Output.WriteLine($"provider offered {offered.Count}: {string.Join(", ", offered.OrderBy(x => x))}");
+
+        baseline.Except(offered).OrderBy(x => x).Should().BeEmpty(
+            "a parent type that declares no CreatableTypes restricts NOTHING — a type the retired "
+            + "query literals offered and the provider does not is a Create menu entry that "
+            + "silently disappeared, which is #4040 pointed the other way");
+        staticItems.Except(offered).OrderBy(x => x).Should().BeEmpty(
+            "the static registrations the form handed the picker as fixed Items are the bulk of the "
+            + "menu (Markdown, Group, Role, Redirect, UiContribution, HomeTab, License, WhatsNew — "
+            + "none of which carries NodeType=\"NodeType\", which is why filtering on that stamp "
+            + "kept 7 of 42)");
+        offered.Should().Contain($"{types}/Widget/Part",
+            "the second discovery leg — the child NodeTypes the PARENT'S TYPE defines, so a "
+            + "{0}/Widget instance offers {0}/Widget/Part. The retired literals could not reach it "
+            + "either: it is in the type's partition, not the instance's ancestor chain", types);
+    }
+
+    /// <summary>
+    /// 🚨 THE NEGATIVE CONTROL. The retired literals cannot reach a type declared outside the
+    /// instance's ancestor chain — which is precisely why <c>MeshWeaver.Crm#82</c> was inert. If
+    /// the literals ever DID reach it, the acceptance test below would be passing for a reason that
+    /// has nothing to do with the declaration, and would keep passing after a revert.
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task TheOldQueryLiteralsCannotReachADeclaredType()
+    {
+        var (types, host) = await Fixture();
+
+        var baseline = await LiteralQueryResults($"{host}/Deal");
+        Output.WriteLine($"retired literals for {host}/Deal returned {baseline.Count}: "
+            + string.Join(", ", baseline.OrderBy(x => x)));
+
+        baseline.Should().NotBeEmpty("a control that measured nothing controls nothing");
+        baseline.Should().NotContain($"{types}/Question",
+            "the declared type lives in ANOTHER partition, so no namespace-scoped query from the "
+            + "instance reaches it — this is the Crm#82 measurement, reconstructed");
+    }
+
+    /// <summary>
+    /// 🚨 THE ACCEPTANCE CRITERION, asserted on the RENDERED Create area rather than on the
+    /// provider: the type picker a person is actually shown offers <c>{types}/Question</c> because
+    /// the parent's NodeType declares it — and the same form rendered on a sibling instance whose
+    /// type declares nothing does NOT, so the declaration is demonstrably what put it there.
+    ///
+    /// <para>The picker also carries NO <see cref="MeshNodePickerControl.Queries"/>: a query leg
+    /// would re-admit by discovery exactly what a restricting parent excluded.</para>
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task TheRenderedCreateFormOffersATypeTheParentDeclaresInAnotherPartition()
+    {
+        var (types, host) = await Fixture();
+
+        var declaring = await RenderedTypePicker($"{host}/Deal");
+        var offered = PickerPaths(declaring);
+        Output.WriteLine($"rendered picker on {host}/Deal offers {offered.Count}: "
+            + string.Join(", ", offered.OrderBy(x => x)));
+
+        declaring.Queries.Should().BeNull(
+            "the picker is fed by ICreatableTypesProvider alone; a query leg alongside it would "
+            + "re-admit every discovered type and defeat the parent's restriction");
+        offered.Should().Contain($"{types}/Question",
+            "the parent's NodeType declares CreatableTypes: [\"{0}/Question\"] — that is the whole "
+            + "point of the setting, and it is what MeshWeaver.Crm#82 asked for", types);
+
+        var control = PickerPaths(await RenderedTypePicker($"{host}/Thing"));
+        control.Should().NotContain($"{types}/Question",
+            "the sibling instance's type declares nothing, so nothing ambient offers the type — "
+            + "the declaration is what put it in the other menu, not discovery");
+    }
+
+    /// <summary>
+    /// The RESTRICTING half of the same setting, and the two knobs that ride with it: an explicit
+    /// <c>CreatableTypes</c> filters auto-discovery down to the declared set, while
+    /// <see cref="NodeTypeDefinition.IncludeGlobalTypes"/> decides whether the global set still
+    /// rides along. A type that opted out of <c>context:create</c> is offered by neither.
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task ADeclarationRestrictsDiscovery_AndIncludeGlobalTypesDecidesTheGlobals()
+    {
+        var (types, host) = await Fixture();
+        var globals = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>().GlobalCreatableTypes;
+        globals.Should().NotBeEmpty("the global set is the thing IncludeGlobalTypes switches off");
+
+        var declaring = await Offered($"{host}/Deal");
+        Output.WriteLine($"declaring parent offers {declaring.Count}: {string.Join(", ", declaring.OrderBy(x => x))}");
+        declaring.Should().NotContain($"{host}/Local",
+            "a declared CreatableTypes list is a WHITELIST: discovery is filtered down to it, so a "
+            + "type the ancestor-scoped query found but the parent did not declare is withheld");
+        globals.Except(declaring).OrderBy(x => x).Should().BeEmpty(
+            "IncludeGlobalTypes defaults to true, so the global set rides along with the whitelist");
+
+        var sealedOff = await Offered($"{host}/Sealed");
+        Output.WriteLine($"IncludeGlobalTypes=false offers {sealedOff.Count}: {string.Join(", ", sealedOff.OrderBy(x => x))}");
+        sealedOff.Should().Contain($"{types}/Question", "the declared type is still offered");
+        sealedOff.Intersect(globals).OrderBy(x => x).Should().BeEmpty(
+            "IncludeGlobalTypes=false is the opt-out, and it is the reason the property carries "
+            + "JsonIgnoreCondition.Never — an explicit false must survive the round trip");
+    }
+
+    /// <summary>
+    /// A NodeType that opted out of the create context (<c>ExcludeFromContext: ["create"]</c> —
+    /// Release, Build, ModuleBuild, Partition) is never offered. The retired form filtered these
+    /// out of both its Items and its queries; the provider did not, and would have started offering
+    /// four uncreatable types the moment it was wired up.
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task ATypeThatOptedOutOfTheCreateContextIsNeverOffered()
+    {
+        var (_, host) = await Fixture();
+
+        var optedOut = Mesh.ServiceProvider.EnumerateStaticNodes()
+            .Where(n => n.IsExcludedFromContext(MeshContexts.Create))
+            .Select(n => n.Path)
+            .ToArray();
+        Output.WriteLine($"opted out of create: {string.Join(", ", optedOut.OrderBy(x => x))}");
+        optedOut.Should().NotBeEmpty("a platform with no opt-out cannot show that the opt-out is honoured");
+
+        var offered = await Offered($"{host}/Thing");
+        offered.Intersect(optedOut).OrderBy(x => x).Should().BeEmpty(
+            "ExcludeFromContext: [\"create\"] is how a type says it is not creatable — the Create "
+            + "menu is the one surface that must honour it");
+    }
+
+    // ── fixture ────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Two partitions, mirroring <c>Crm</c> + <c>PearlTechnology</c>: the TYPES live in one and the
+    /// INSTANCES in the other, so a declared type is provably outside the instance's ancestor chain.
+    /// </summary>
+    private async Task<(string Types, string Host)> Fixture()
+    {
+        var types = "Ct" + Guid.NewGuid().ToString("N")[..8];
+        var host = "Ho" + Guid.NewGuid().ToString("N")[..8];
+
+        await Import(new FakeRepoSource(types)
+        {
+            Root = Space(types),
+            Nodes =
+            [
+                // Declares nothing — the no-shrink case.
+                TypeNode(types, "Widget", new NodeTypeDefinition { Configuration = "config => config" }),
+                // A child type of Widget: what an instance of Widget may create by hierarchy.
+                TypeNode($"{types}/Widget", "Part", new NodeTypeDefinition { Configuration = "config => config" }),
+                // The Crm/Offer shape: declares a type in its own partition, which is NOT in the
+                // ancestor chain of the instances that carry this type.
+                TypeNode(types, "Offer", new NodeTypeDefinition
+                {
+                    Configuration = "config => config",
+                    CreatableTypes = [$"{types}/Question"],
+                }),
+                // Same, with the globals switched off.
+                TypeNode(types, "SealedOffer", new NodeTypeDefinition
+                {
+                    Configuration = "config => config",
+                    CreatableTypes = [$"{types}/Question"],
+                    IncludeGlobalTypes = false,
+                }),
+                TypeNode(types, "Question", new NodeTypeDefinition { Configuration = "config => config" }),
+            ],
+        });
+
+        await Import(new FakeRepoSource(host)
+        {
+            Root = Space(host),
+            Nodes =
+            [
+                // A runtime NodeType in the INSTANCE's partition — what the ancestor-scoped query
+                // leg is for, and what makes the baseline non-vacuous.
+                TypeNode(host, "Local", new NodeTypeDefinition { Configuration = "config => config" }),
+                Instance(host, "Thing", $"{types}/Widget"),
+                Instance(host, "Deal", $"{types}/Offer"),
+                Instance(host, "Sealed", $"{types}/SealedOffer"),
+            ],
+        });
+
+        return (types, host);
+    }
+
+    private async Task Import(FakeRepoSource source)
+    {
+        // 🚨 .Await(), never a bare `await source`: Rx's own awaiter resumes the continuation
+        // INLINE on the signalling thread, and every later await in the method inherits that
+        // scheduler.
+        var result = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Output.WriteLine($"{source.Partition} import: {result.Outcome} count={result.Count} "
+            + $"failed={result.Failed} blocked=[{string.Join(", ", result.BlockedCreatePaths)}]");
+        result.Failed.Should().Be(0, "a fixture that did not land cannot measure anything");
+    }
+
+    /// <summary>What <see cref="ICreatableTypesProvider"/> offers at <paramref name="parentPath"/>.</summary>
+    private async Task<HashSet<string>> Offered(string parentPath)
+    {
+        var parent = await Mesh.GetWorkspace().GetMeshNodeStream(parentPath)
+            .Where(n => n is not null).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        var types = await Mesh.ServiceProvider.GetRequiredService<ICreatableTypesProvider>()
+            .GetCreatableTypes(parentPath, parent)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        return types.Select(t => t.NodeTypePath).ToHashSet(StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>What the two retired query literals return — run against the same query core.</summary>
+    private async Task<HashSet<string>> LiteralQueryResults(string parentPath)
+    {
+        var core = Mesh.ServiceProvider.GetRequiredService<IMeshQueryCore>();
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var query in RetiredQueryLiterals(parentPath))
+        {
+            var change = await core
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(query), Mesh.JsonSerializerOptions)
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+            foreach (var item in change.Items)
+                result.Add(item.Path);
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// The type picker of the RENDERED Create area, read through the layout client exactly as the
+    /// portal reads it — the assertion is on what a person is offered, not on what a service
+    /// returned. Every child area is subscribed at once so a sibling that has not rendered yet
+    /// cannot hold the read.
+    /// </summary>
+    private async Task<MeshNodePickerControl> RenderedTypePicker(string nodePath)
+    {
+        var reference = new LayoutAreaReference(MeshNodeLayoutAreas.CreateNodeArea);
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(nodePath), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Where(c => c is StackControl { Areas.Count: > 0 })
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        var areas = ((StackControl)root!).Areas
+            .Select(a => a.Area?.ToString())
+            .Where(a => !string.IsNullOrEmpty(a))
+            .Select(a => stream.GetControlStream(a!))
+            .ToArray();
+
+        return await Observable.Merge(areas)
+            .OfType<MeshNodePickerControl>()
+            .Where(IsTypePicker)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+    }
+
+    private static bool IsTypePicker(MeshNodePickerControl picker) =>
+        picker.Data is JsonPointerReference { Pointer: var p }
+        && p.TrimStart('/').Equals("type", StringComparison.OrdinalIgnoreCase);
+
+    private static HashSet<string> PickerPaths(MeshNodePickerControl picker) =>
+        (picker.Items ?? [])
+        .OfType<MeshNode>()
+        .Select(n => n.Path)
+        .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+    private static MeshNode Space(string partition) => new(partition)
+    {
+        Name = partition, NodeType = "Space", State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = $"# {partition}" }
+    };
+
+    private static MeshNode Instance(string partition, string id, string typePath) => new(id, partition)
+    {
+        NodeType = typePath, Name = id, State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = $"# {id}" }
+    };
+
+    private static MeshNode TypeNode(string nameSpace, string id, NodeTypeDefinition definition) =>
+        new(id, nameSpace)
+        {
+            NodeType = MeshNode.NodeTypePath, Name = id, State = MeshNodeState.Active,
+            Content = definition
+        };
+
+    private sealed class FakeRepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; set; } = [];
+        public MeshNode? Root { get; set; }
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+    }
+}


### PR DESCRIPTION
Fixes #4040. The issue's **option 1**: `CreateLayoutArea` builds its picker from
`ICreatableTypesProvider.GetCreatableTypes`, and the two query literals at `CreateLayoutArea.cs:423-437`
are retired.

## The defect

`ICreatableTypesProvider.GetCreatableTypes` was a singleton with no caller, so
`NodeTypeDefinition.CreatableTypes`, `NodeTypeDefinition.IncludeGlobalTypes` and
`MeshConfiguration.GlobalCreatableTypes` were documented, populated by modules, and read by nothing.
The form ran `namespace: nodeType:NodeType context:create` plus a `scope:selfAndAncestors` leg, so a
type was offered iff it sat at the root namespace or in the target's own ancestor chain. `MeshWeaver.Crm#82`
declared `"creatableTypes": ["Crm/Question"]` on `Crm/Offer` and was inert.

## What feeds the picker now

`GetCreatableTypes(parentPath, currentNode)` — ancestor-scoped discovery, the child types of the
parent's own type, the parent type's `CreatableTypes` whitelist, `GlobalCreatableTypes`, and every
static registration that has not opted out of `context:create`. The picker carries **items and no
queries**: a query leg would re-admit by discovery exactly what a restricting parent excluded.

## 🚨 The narrowing risk, measured

Wiring the form to a narrower source would have shrunk every Create menu in the fleet with no error
and no empty state. Two provider defects had to be fixed first — both found by measuring the provider
against the retired literals on a running mesh, not by reading it:

| | before | after |
|---|---|---|
| static bucket filter | `NodeType == "NodeType"` → **7 of 42** registrations; dropped `Markdown`, `Group`, `Role`, `Redirect`, `UiContribution`, `HomeTab`, `License`, `WhatsNew` | the `context:create` opt-out — the rule the form itself applied |
| `context:create` on the queries | absent → offered `Release`, `Build`, `ModuleBuild`, `Partition` | on every leg |

Measured for a parent type declaring nothing: offered = **45**, a strict superset of the retired
literals (**4**, including the runtime NodeType in the instance's own partition) and of the static
items the form passed as `WithItems` (**42**). Nothing lost.

## Tests — `test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs`

The Crm#82 shape is reconstructed across two partitions (types in one, instances in the other, so the
declared type is outside the instance's ancestor chain) and asserted on the **rendered** Create area:

- `TheRenderedCreateFormOffersATypeTheParentDeclaresInAnotherPartition` — the picker a person is shown
  offers the declared type, carries no `Queries`, and the **sibling instance whose type declares
  nothing does not offer it**, so the declaration is demonstrably what put it there.
- `TheOldQueryLiteralsCannotReachADeclaredType` — the negative control: the retired literals return a
  non-empty set that does not contain it. This is the Crm#82 measurement, reconstructed.
- `AParentDeclaringNothingLosesNothing` — the no-shrink pin (superset against both baselines, asserted
  non-vacuously).
- `ADeclarationRestrictsDiscovery_AndIncludeGlobalTypesDecidesTheGlobals`, `ATypeThatOptedOutOfTheCreateContextIsNeverOffered`.

Local: `MeshWeaver.Graph.Test` 1557/1557, `MeshWeaver.Documentation.Test` 432/432 (link integrity +
What's New), `LocalizationTest` 58/58, `UnanchoredQueryCensusTest` green with the new root-leg row.
Release `-warnaserror` clean on every touched project.

## Work product

- Doc: `Doc/Architecture/CreatableTypes` — the resolution rule, what a parent restricts, what it
  extends, what the default is, `IncludeGlobalTypes`, the create opt-out, and why there is no
  root-namespace query leg (`namespace:` with an empty value is the shape the Postgres planner refuses
  as unanchored, so it has never returned a row on a partitioned portal). Linked from the Architecture index.
- What's New entry, `Category: Fix`.

Pairs-with: none — no public type or member leaves `src/`; the provider is `internal` and its
interface is unchanged.

Mirror-sync: MeshWeaver.Plugins runs `npm run sync:i18n -- --ref <this merge sha>` to pick up the one
new key (`create.selectType`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFBiMVHLTZM2axNgVvaZN2
