### PR TITLE
fix: bind the last-good build while a compile is in flight; a content hash is never a SemVer major (memex 2026-09-12 compile storm)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -392,6 +392,82 @@ public static class PrebuiltAssemblySeeder
                 sourceFingerprint, moduleVersion)
             .Select(outcome => outcome is SeedOutcome.Adopted or SeedOutcome.AdoptedStale);
 
+    /// <summary>What <see cref="DecideAfterStaleDecline"/> concluded for one declined entry.</summary>
+    public enum StaleDeclineAction
+    {
+        /// <summary>The build the record names loads on this process — it keeps serving and the
+        /// bundle is left aside (the pre-existing decline).</summary>
+        KeepLiveBuild = 1,
+
+        /// <summary>Adopt the version-compatible bundle as the last build this mesh holds
+        /// (<see cref="BuildProvenance.StaleAdopted"/>): a page now, on bytes for THIS framework
+        /// identity.</summary>
+        AdoptBundle = 2,
+
+        /// <summary>No bundle can serve and this mesh compiles module content: clear the
+        /// dangling coordinates and dispatch a compile of the live source
+        /// (<see cref="AfterStaleDecline"/>).</summary>
+        DispatchCompile = 3,
+
+        /// <summary>Leave the record exactly as it is — a compile is already in flight, or there
+        /// is nothing to clear.</summary>
+        LeaveRecord = 4,
+
+        /// <summary>Nothing this process can do will serve the type: no loadable build, no
+        /// compatible bundle, and this mesh does not compile. Said at Critical by the caller.</summary>
+        Unservable = 5,
+    }
+
+    /// <summary>
+    /// 🚨 THE RULE for a bundle DECLINED on its source fingerprint, as a checkable table — the
+    /// decision <c>AfterStaleDeclineObserved</c> acts on, pure so the ordering is pinned rather
+    /// than read out of an Rx pipeline (<c>StaleDeclinePrefersBundleTest</c>).
+    ///
+    /// <para><b>A compatible bundle beats a local compile</b> (the tolerance directive of
+    /// 2026-09-12, <i>"it should all be tolerant"</i>, plus two UNATTRIBUTED, unverified statements
+    /// received mid-session — <i>"compile must happen on CI — at runtime you must resolve a package
+    /// version, not try to compile"</i> — flagged in the PR, not claimed as the maintainer's; if
+    /// they are not endorsed, drop the AdoptBundle row for a compiling mesh and nothing else in
+    /// the rule changes). When the build the record names does not
+    /// load on this process and a bundle for THIS framework identity is in hand whose module
+    /// version is compatible (or unknown), that bundle is adopted as the last build the mesh holds
+    /// — a page renders on CI-built bytes immediately — instead of clearing the coordinates and
+    /// dispatching Roslyn, which is a wait every instance of the type sat out behind the
+    /// "did not settle" overlay on memex 2026-09-12. A mesh that compiles module content still
+    /// converges: the stale-adopted record reads dirty and the next release request rebuilds it
+    /// from source in the background, behind a page that is already up.</para>
+    ///
+    /// <para>Every other row is the pre-existing behaviour: a build that resolves here is kept; a
+    /// compile already in flight is never stamped over on a compiling mesh (its terminal write
+    /// would race the adoption's) — a non-compiling mesh still adopts, as it did; a compiling
+    /// mesh with no compatible bundle dispatches; a non-compiling mesh with none is unservable.</para>
+    /// </summary>
+    /// <param name="observed">The owner's current definition.</param>
+    /// <param name="liveBuildResolvesHere">The record's build loads on this process.</param>
+    /// <param name="canCompileLocally">This mesh compiles module content for this partition.</param>
+    /// <param name="bundleAdoptable">A bundle for this identity is in hand and its module version
+    /// is compatible or unknown — never a MAJOR-incompatible one.</param>
+    public static StaleDeclineAction DecideAfterStaleDecline(
+        NodeTypeDefinition observed, bool liveBuildResolvesHere, bool canCompileLocally, bool bundleAdoptable)
+    {
+        ArgumentNullException.ThrowIfNull(observed);
+        if (liveBuildResolvesHere)
+            return StaleDeclineAction.KeepLiveBuild;
+        var inFlight = observed.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling;
+        if (inFlight)
+            return !canCompileLocally && bundleAdoptable
+                ? StaleDeclineAction.AdoptBundle
+                : StaleDeclineAction.LeaveRecord;
+        if (bundleAdoptable)
+            return StaleDeclineAction.AdoptBundle;
+        if (!canCompileLocally)
+            return StaleDeclineAction.Unservable;
+        return string.IsNullOrEmpty(observed.LatestAssemblyPath)
+               && string.IsNullOrEmpty(observed.LatestAssemblyCollection)
+            ? StaleDeclineAction.LeaveRecord
+            : StaleDeclineAction.DispatchCompile;
+    }
+
     /// <summary>
     /// 🚨 <b>A stale-source decline must never leave a DANGLING record</b> (measured on
     /// memex.systemorph.com, 2026-09-08). The decline-before-writing branch below leaves "the live
@@ -409,6 +485,10 @@ public static class PrebuiltAssemblySeeder
     /// or this mesh may not compile (the caller then logs Critical, as the refusal path does).
     /// Once per decline, never per activation: the <c>Pending</c>/<c>Compiling</c> guard makes a
     /// second decline of the same record a no-op.</para>
+    ///
+    /// <para>Since 2026-09-12 the caller consults <see cref="DecideAfterStaleDecline"/> FIRST and
+    /// reaches this dispatch only for <see cref="StaleDeclineAction.DispatchCompile"/> — a
+    /// compatible bundle for the live identity is adopted instead of compiled.</para>
     /// </summary>
     /// <param name="observed">The owner's current definition.</param>
     /// <param name="liveBuildResolvesHere">Whether the assembly store answered a path for the
@@ -859,16 +939,20 @@ public static class PrebuiltAssemblySeeder
             .SelectMany(probe =>
         {
             var (liveBuildResolvesHere, canCompileLocally) = probe;
-            var dispatch = AfterStaleDecline(
+            var action = DecideAfterStaleDecline(
                 observed, liveBuildResolvesHere, canCompileLocally,
-                NodeTypeCompilationHelpers.ModulesHashOf(hub));
-            if (liveBuildResolvesHere)
-                return Observable.Return(SeedOutcome.DeclinedStaleSources);
-            if (dispatch is null)
+                bundleAdoptable: adoptAnyway is not null);
+            switch (action)
             {
-                if (!canCompileLocally && adoptAnyway is not null)
-                    return adoptAnyway();
-                if (!canCompileLocally)
+                case StaleDeclineAction.KeepLiveBuild:
+                case StaleDeclineAction.LeaveRecord:
+                    return Observable.Return(SeedOutcome.DeclinedStaleSources);
+                case StaleDeclineAction.AdoptBundle:
+                    // A compatible bundle for THIS framework identity is in hand and the build the
+                    // record names cannot be loaded here. Serving the bundle is a page; a Roslyn
+                    // compile is a wait — see DecideAfterStaleDecline for the rule.
+                    return adoptAnyway!();
+                case StaleDeclineAction.Unservable:
                     logger?.LogCritical(
                         "Prebuilt assembly for {NodeTypePath} DECLINED on stale sources AND the live "
                         + "build it left in place does not resolve on this process ({Collection}/{Path}) "
@@ -880,9 +964,11 @@ public static class PrebuiltAssemblySeeder
                         nodeTypePath, observed.LatestAssemblyCollection ?? "(null)",
                         observed.LatestAssemblyPath ?? "(null)", RequirePrebuiltConfigKey,
                         NodeTypeCompilationHelpers.FrameworkVersion);
-                return Observable.Return(canCompileLocally
-                    ? SeedOutcome.DeclinedStaleSources
-                    : SeedOutcome.DeclinedStaleSourcesUnservable);
+                    return Observable.Return(SeedOutcome.DeclinedStaleSourcesUnservable);
+                case StaleDeclineAction.DispatchCompile:
+                    break;
+                default:
+                    return Observable.Return(SeedOutcome.DeclinedStaleSources);
             }
 
             logger?.LogWarning(

--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -287,6 +287,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [The Module Identity Anchor](ModuleIdentityAnchor)
 - [Module-Owned Siblings Ride](ModuleOwnedSiblingsRide)
 - [The Module Platform Link Gate](ModulePlatformLinkGate)
+- [Rolling-Update Build Tolerance](RollingUpdateBuildTolerance) — why a rolling platform update recompiled Store/Plugin ten times in four minutes and blanked every instance behind "build did not settle within 30s" (two generations, one record, one framework identity per record), and the rules that let an instance render on the last build its process can load instead
 - [The Module Publication Gate](ModulePublicationGate) — a bundle used to reach the live registry from inside its own pack leg, before the sibling suites, the portal-host shards, the compile-check and the Tests-area gate had reported; the hand-over moved downstream of the full source verdict, and what it refuses (failed, skipped, cancelled, missing, foreign-lane, substituted)
 - [Module Generation Substitution](ModuleGenerationSubstitution) — `Assembly.LoadFrom` does not promise to load the path it is handed: a byte-identical copy the load context already holds is returned instead, silently, so the loader recorded the generation it ASKED for while the process ran another; the three answers that replace two
 - [Module Set Convergence](ModuleSetConvergence)

--- a/src/MeshWeaver.Documentation/Data/Architecture/RollingUpdateBuildTolerance.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RollingUpdateBuildTolerance.md
@@ -1,0 +1,87 @@
+---
+Name: Rolling-Update Build Tolerance
+Category: Architecture
+Description: Why a rolling platform update recompiled Store/Plugin ten times in four minutes and blanked every instance of the type behind "build did not settle within 30s" — two platform generations, one NodeType record, one framework identity per record — and the tolerance rules that now let an instance render on the last build its process can load instead of waiting for a settle that another generation cannot deliver.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.2-8.6"/><path d="M21 3v6h-6"/><path d="M12 7v5l3 3"/></svg>
+---
+
+# Rolling-Update Build Tolerance
+
+> **Maintainer directive, 2026-09-12 (relayed by the coordinating session):** *"it should all be tolerant"* — a page of an instance whose type has a last-good compiled assembly must render on that assembly while a recompile is in flight; the 30-second *"did not settle"* fallback is itself the defect when a loadable build exists. That directive is what this page implements.
+>
+> Two further statements reached the investigating session mid-task from an **unattributed, unverified** source (not the maintainer's verbatim words, not a doc): *"compile must happen on CI — at runtime you must resolve a package version, not try to compile"* and *"dynamic compilation should be disabled for CI-built plugins."* They agree with the existing [#3583](https://github.com/Systemorph/MeshWeaver/issues/3583) rule (a stale-but-compatible page beats a refusal), and rule 3 below leans on them; the structural remainder in the issue at the end is conditional on the maintainer confirming them.
+
+## The incident, measured
+
+On 2026-09-12 at 06:25Z `https://memex.meshweaver.cloud/DeepSign` — an instance of the `Store/Plugin` NodeType — rendered:
+
+> This item's type has not finished compilation yet, so its page couldn't be built. **NodeType 'Store/Plugin' build did not settle within 30s.** Instance 'DeepSign' is rendering this fallback until the type's build settles.
+
+`get @Store/Plugin` at the same moment said `compilationStatus: Ok`. Every other instance of the type on the new pods (Edu, RolePlay, Chess, ClaudeCode, Voice, WebSearch, DataModelling, LearningRoadmap, Hosting, Approvals, DoublePendulum, AgenticEngineering, …) logged the same `TimeoutException: NodeType 'Store/Plugin' recompile did not settle and no compile is in flight (within 30s)`, and the `content-types` health check reported *Degraded: Store/Plugin ×116 … this replica cannot type*.
+
+What the mesh recorded:
+
+| Time (UTC) | Fact | Where |
+|---|---|---|
+| 06:10:48 → 06:14:48 | Rolling update `ci.8372` → `ci.8399` on `memex-cloud/memex-portal-deployment` (`maxSurge 1, maxUnavailable 0`); the three old pods get `Killing` at 06:12:22, 06:13:35, 06:14:48 | `kubectl get events` |
+| — | `terminationGracePeriodSeconds: 1800` with a `preStop` that waits on `/drain` for up to 1680 s — **the old generation keeps serving hubs for up to 30 minutes after `Killing`** | Deployment spec |
+| — | `ci.8399` announces framework identity **`sa74cfbd…`** (`DynamicTypePreWarmer: … framework identity sa74cfbdd57e3a4f4440792fd1800aa3d, build g4c99ec26…`); `ci.8372` (still running as memex.systemorph.com) announces **`s6649734…`** | pod logs |
+| 06:17:48 / 06:17:50 / 06:18:02 | Three concurrent `Update Store to the built commit 38ebf08e` activities (one per new pod) | `Store/_Activity` |
+| 06:18:38 | Release `X3ICiS9-`: an **adoption** under `sa74cfbd` (`v13825-sa74cfbd-…dll`, no compile activity) — the CI bundle for the live identity was on `/data/prebuilt-bundles/sa74cfbd…` | `Store/Plugin/Release` |
+| 06:18:58 … 06:23:08 | **Eight compiles, all producing `s6649734`-tagged assemblies** (`v13834`, `v13839`, `v13843`, `v13847`, `v13855`, `v13859`, `v13863`) — the per-NodeType hub's owner grain was on a *draining old-generation pod*, and every activation on a new pod read the record as ABI-stale, flipped it Pending, and the old owner rebuilt it under its own identity | `Store/Plugin/_Activity/compile-*`, Release artifacts |
+| 06:23:12 | One compile producing **`sa74cfbd`** (`v13872-sa74cfbd-…dll`) — the owner grain had moved to a new pod | same |
+| 06:24:53 | The record settles for the new generation: `compiledFrameworkVersion sa74cfbd`, `adoptedSourceFingerprint == currentSourceFingerprint == c4730d4bf8f180fb`, `buildProvenance AdoptedVerified`, version 13874 | `get @Store/Plugin` |
+| 06:25 → 06:44 | Activations on the new pods **still** time out — the instance page stays on the fallback; `get @DeepSign/layoutAreas/` times out | pod logs, MCP |
+| ≈ 06:45 | The last old pod's grace expires; `DeepSign` resolves again (its page still shows the overlay it bound earlier until the instance is recycled) | MCP |
+
+The same shape on 2026-09-11 18:47–18:55Z (`ci.8323` → `ci.8372`) and on 2026-09-10 14:40–14:47Z. `Store/Plugin` on memex is at node version 13 870; on systemorph, which rolls less often, 2 895.
+
+The seeder's line names the second defect. On every new pod:
+
+```
+Prebuilt assembly for Store/Plugin DECLINED before writing (#2813): the bundle records source
+fingerprint c4730d4bf8f180fb but the live sources are bf501962b9ea4c2a (bundle module version
+221c6c286785ddf2, current 1.10: Incompatible) — the owner would not verify the adoption …
+ShippedPrebuiltBundles: adopted no prebuilt assembly for 1 of 2 requested NodeType(s) — Store/Plugin.
+A bundle entry under /data/prebuilt-bundles/sa74cfbd… DID name 1 of them … so those bytes were
+present and did not land.
+```
+
+`221c6c286785ddf2` is `manifest.lock`'s content hash (the bake wrote `ReleasedVersion ?? ModuleVersion ?? Version`, i.e. the hash whenever no released version was recorded); `ModuleVersionCompatibility.MajorOf` read its leading digits as *major 221* against the root's `1.10` and classified the pair **Incompatible** — the one verdict that refuses. The bundle's fingerprint (`c473…`) was the fingerprint the new generation itself computed; the "live" `bf50…` it was compared against had been stamped by the *old* generation's toolchain.
+
+## The mechanism
+
+Three things compose:
+
+1. **A rolling update runs two platform generations against one mesh for the whole termination grace.** With a 30-minute drain, that is not a race window; it is the normal operating state of every roll.
+2. **A NodeType record holds ONE `compiledFrameworkVersion`.** Each generation reads the other's build as ABI-stale (`HasUsableBuild` is an equality on the live identity). The record cannot be "usable" for both.
+3. **The activation path was intolerant.** On a foreign stamp it flipped the type Pending and *waited* for a usable build (`TriggerRecompileAndRetry … requireUsableBuild: true`); on an in-flight status it *waited* for settle (`IsCompileSettled` rejects Pending/Compiling) and then painted the progress overlay; when the compile ran on the other generation the wait never satisfied and the 30-second no-progress budget produced the fallback. Every activation is a fresh attempt, so the "bounded" retry (`MaxRecompileAttempts = 1`) bounded nothing across a fleet of instances — that is the storm.
+
+After the record settled for the new generation (06:24:53) the activations still failed. Storage was usable; the node the activation decided on came off the mesh-hub **mirror** — the workspace's per-path replay subject — which had replayed the old owner's snapshot after that owner drained and its sync stream went silent. This is the shape [#2409](https://github.com/Systemorph/MeshWeaver/issues/2409) fixed on the *in-flight* branch (`ConfirmInFlightAgainstStorage`); the framework-stale branch had no such confirmation. (The mirror latch is the inference that fits every measurement; the ENRICH-DIAG lines that would show the mirror's value are logged at Information and were not retained at production level. The fix below does not depend on the inference: it consults storage on that branch regardless.)
+
+## The tolerance rules (implemented)
+
+**1. An in-flight type that still names a loadable last-good build is BOUND, not awaited.** `NodeTypeEnrichmentHelpers.IsBindableWhileCompiling` — Pending/Compiling *and* `HasUsableBuild` for this process — is admitted by the slow path's settle predicate (`IsBindableOrSettled`) and routed to `ApplyStreamResult`, whose `HasUsableBuild` branch precedes every status branch and arms `WithStaleAssemblySelfHeal`. The instance renders on the previous bytes now; when the rebuild publishes a different usable path, the watcher offers (or, on a converging portal, takes) the new build. An in-flight type with *nothing* loadable keeps the grace-then-progress-overlay behaviour: there is nothing to render on.
+
+**2. The framework-stale branch confirms against STORAGE before it asks for a rebuild.** One `AuthoritativeTypeRead` (the same read the in-flight branch already makes); when storage holds a build for the live identity, the activation binds it and writes nothing. Only when storage agrees the build is foreign does the Pending flip happen — and on a mesh where module content resolves from bundles that flip is the next thing to remove (see the issue).
+
+**3. A compatible CI bundle beats a local compile** (motivated by the unverified statements above; also the tolerant reading of #3583 — clearing a record and compiling leaves no page in between). `PrebuiltAssemblySeeder.DecideAfterStaleDecline` is the rule as a table: when the record's build does not load on this process, no compile is in flight, and a bundle for the live identity is in hand whose module version is compatible or unknown, it is adopted as the last build the mesh holds (`StaleAdopted`) — a page on CI-built bytes immediately — instead of clearing the record and dispatching Roslyn. A compiling mesh still converges (the stale-adopted record reads dirty and the next release request rebuilds it behind a page that is already up).
+
+**4. A content hash is never a SemVer major.** `ModuleVersionCompatibility.MajorOf` yields a major only for a version-shaped value (digits followed by `.`, `-`, `+` or the end); a hash reads Unknown, which never refuses. And the bake now records `ReleasedVersion ?? Version ?? ModuleVersion`, so new bundles carry the SemVer the rule was written for.
+
+Tests: `InFlightLastGoodBuildBindsTest` (predicates, virtual-time wait), `ForeignFrameworkStampOnTheMirrorTest` (real mesh: foreign stamp on the mirror, usable build in storage ⇒ bound, version unchanged, no Pending flip), `StaleDeclinePrefersBundleTest` (the decision table), `ModuleVersionCompatibilityTest` (the hash pair that refused Store/Plugin).
+
+## What this does not fix (tracked)
+
+- **One identity per record.** Two generations will still alternately stamp the record for the whole drain; with the rules above nobody *waits* on the foreign stamp and nobody compiles when a bundle exists, but the record still flips. The structural fix is a build record **per framework identity** (the store already keys bytes by identity tag) or, equivalently, the unverified statement's rule: a CI-built type's record names a *package version*, and each process resolves `(package version, own identity)` from the bundle store — never a compile.
+- **Runtime compile for module content.** The release-request watcher still compiles a dirty module type on a mesh that may compile. If that statement is confirmed it should resolve the sealed bundle for the synced commit and hold (`BuildDeliveryHold`) until one exists.
+- **The source fingerprint depends on the toolchain.** The two generations computed different fingerprints for the same sources (`bf50…` vs `c473…`), so a cross-generation record always reads "source moved". The seeder should compare a bundle against the fingerprint *this* process computes from the live snapshot, not against the stored one.
+- **The drain.** A 30-minute grace with two generations serving is a policy the platform tolerates now; it is still the window in which every cross-generation mismatch happens.
+
+Tracking issue: [#4071 — Rolling-update compile storm: per-identity build records and no runtime compile for CI-built plugins](https://github.com/Systemorph/MeshWeaver/issues/4071).
+
+## Operator notes
+
+- A type that compiles every 15–30 s with alternating `-s…-` tags in its `Release/` artifacts is a **generation overlap**, not a source problem. Read `kubectl get rs` and the pods' `framework identity` log line before touching the type.
+- An instance already on the *"did not settle"* fallback stays there until it is recycled (its self-heal is version-gated on the type record). **Recycle the instance**; do not recompile the type.
+- `Prebuilt assembly … DECLINED … Incompatible` with a 16-hex "module version" was the classifier defect above; after this change the same bundle reads Unknown and is adopted.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -545,6 +545,12 @@ internal static class NodeTypeEnrichmentHelpers
                     "EnrichWithNodeType: self-heal Pending flip for {NodeType} faulted",
                     nodeType));
 
+        // 🚨 An in-flight type that still names a build this process can load is BINDABLE, not a
+        // wait: the instance renders on the last-good build now and the stale-assembly watcher
+        // picks up the rebuild when it lands (IsBindableWhileCompiling). The guards are the same
+        // live environment ApplyStreamResult judges HasUsableBuild with, so the wait and the bind
+        // cannot disagree about what "loadable here" means.
+        var guards = NodeTypeCompilationHelpers.GuardsOf(meshHub);
         var settled = typeStream
             .Do(typeNode => logger?.LogInformation(
                 "[COMPILE-TRACE] Slow-path typeStream emission for {NodeType} (instance={InstancePath}): HubConfig={HasHub} Status={Status} Coll={Coll} Path={Path}",
@@ -553,7 +559,7 @@ internal static class NodeTypeEnrichmentHelpers
                 typeNode.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions)?.CompilationStatus,
                 typeNode.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions)?.LatestAssemblyCollection ?? "(null)",
                 typeNode.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions)?.LatestAssemblyPath ?? "(null)"))
-            .Where(typeNode => IsCompileSettled(typeNode, meshHub.JsonSerializerOptions))
+            .Where(typeNode => IsBindableOrSettled(typeNode, meshHub.JsonSerializerOptions, guards))
             .Take(1);
 
         // 🚨 Fresh-pod wedge fix: DON'T cut short an in-flight compile with a fixed
@@ -574,12 +580,14 @@ internal static class NodeTypeEnrichmentHelpers
                 inFlightGrace: InFlightOverlayGrace,
                 parkedFault: ParkedFaultProbe(meshHub, nodeType))
             .Finally(healSub.Dispose)
-            // An in-flight emission is the grace path, never a settle (every settle
-            // predicate rejects Pending/Compiling): activate the progress overlay now
-            // and let its self-heal recycle the instance when the compile lands.
-            .SelectMany(typeNode => IsCompileInFlight(typeNode, meshHub.JsonSerializerOptions)
+            // An in-flight emission with nothing loadable behind it is the grace path (the
+            // settle predicate rejects it): activate the progress overlay now and let its
+            // self-heal recycle the instance when the compile lands. An in-flight emission that
+            // still names a loadable last-good build is BOUND, exactly like a settled one — see
+            // IsBindableWhileCompiling.
+            .SelectMany(typeNode => RoutesToInFlightOverlay(typeNode, meshHub.JsonSerializerOptions, guards)
                 ? ConfirmInFlightAgainstStorage(meshHub, nodeType, typeNode, node.Path, logger)
-                    .SelectMany(confirmed => IsCompileInFlight(confirmed, meshHub.JsonSerializerOptions)
+                    .SelectMany(confirmed => RoutesToInFlightOverlay(confirmed, meshHub.JsonSerializerOptions, guards)
                         ? WithCompilationInProgressOverlay(node, nodeType, confirmed, meshHub, logger)
                         : ApplyStreamResult(
                             confirmed, node, nodeType, meshConfiguration, compilationService, meshHub, logger))
@@ -922,6 +930,60 @@ internal static class NodeTypeEnrichmentHelpers
     internal static bool IsCompileInFlight(MeshNode? typeNode, System.Text.Json.JsonSerializerOptions options)
         => typeNode?.ContentAs<NodeTypeDefinition>(options) is { } d
             && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling;
+
+    /// <summary>
+    /// 🚨 TOLERANCE WHILE A COMPILE IS IN FLIGHT (maintainer directive, 2026-09-12: <i>"it should
+    /// all be tolerant"</i> — a page that rendered a minute ago must not go blank because its type
+    /// is being rebuilt). True when the NodeType is Pending/Compiling AND its record still names a
+    /// build THIS process can load (<see cref="NodeTypeCompilationHelpers.HasUsableBuild(MeshNode, NodeTypeDefinition, NodeTypeCompilationHelpers.BuildGuards?)"/>:
+    /// coordinates present, compiled for the live framework identity, dependency record valid).
+    ///
+    /// <para>An activation that observes this state binds the LAST-GOOD build now — the
+    /// <c>HasUsableBuild</c> branch of <see cref="ApplyStreamResult"/> is evaluated before any
+    /// status branch, and it arms <see cref="WithStaleAssemblySelfHeal"/>, whose watcher fires when
+    /// the rebuild publishes a different usable assembly path. Nothing is frozen: the instance
+    /// serves the previous bytes until the new ones land, then offers (or, on a converging portal,
+    /// takes) the newer build. What used to happen instead — waiting the in-flight grace, then
+    /// painting the compile-progress overlay, then (when the compile ran on another process
+    /// generation and never satisfied this one) the 30 s "did not settle" fallback — is the
+    /// intolerant path, and it blanked every Store/Plugin instance on memex 2026-09-12 while a
+    /// loadable build sat in the store the whole time.</para>
+    ///
+    /// <para>Deliberately NOT true for an in-flight type whose record names no loadable build
+    /// (first compile, framework-stale coordinates, bytes for another identity): there is nothing
+    /// to render on, and the progress overlay stays the honest answer.</para>
+    /// </summary>
+    internal static bool IsBindableWhileCompiling(
+        MeshNode? typeNode,
+        System.Text.Json.JsonSerializerOptions options,
+        NodeTypeCompilationHelpers.BuildGuards? guards)
+        => typeNode?.ContentAs<NodeTypeDefinition>(options) is { } d
+            && d.CompilationStatus is CompilationStatus.Pending or CompilationStatus.Compiling
+            && NodeTypeCompilationHelpers.HasUsableBuild(typeNode, d, guards);
+
+    /// <summary>
+    /// The FIRST-wait settle predicate of <see cref="BuildSlowPath"/>: a settled terminal state
+    /// (<see cref="IsCompileSettled"/>), OR an in-flight state that still carries a loadable
+    /// last-good build (<see cref="IsBindableWhileCompiling"/>). Exposed so the composition is
+    /// pinned by a test on the production function rather than on a copy of it.
+    /// </summary>
+    internal static bool IsBindableOrSettled(
+        MeshNode typeNode,
+        System.Text.Json.JsonSerializerOptions options,
+        NodeTypeCompilationHelpers.BuildGuards? guards)
+        => IsCompileSettled(typeNode, options) || IsBindableWhileCompiling(typeNode, options, guards);
+
+    /// <summary>
+    /// Whether an emission the first wait handed back must be routed to the compile-progress
+    /// overlay (after the storage confirmation) rather than bound: in flight AND nothing loadable
+    /// to bind. The bindable in-flight case goes to <see cref="ApplyStreamResult"/> like a settled
+    /// one — see <see cref="IsBindableWhileCompiling"/>.
+    /// </summary>
+    internal static bool RoutesToInFlightOverlay(
+        MeshNode typeNode,
+        System.Text.Json.JsonSerializerOptions options,
+        NodeTypeCompilationHelpers.BuildGuards? guards)
+        => IsCompileInFlight(typeNode, options) && !IsBindableWhileCompiling(typeNode, options, guards);
 
     /// <summary>
     /// Bounded recursion on the per-NodeType compile self-heal loop. The hot
@@ -1433,31 +1495,87 @@ internal static class NodeTypeEnrichmentHelpers
             && !string.IsNullOrEmpty(def.LatestAssemblyPath)
             && compilationService is not null)
         {
-            if (recompileAttempts >= MaxRecompileAttempts)
+            // 🚨 CONFIRM AGAINST STORAGE BEFORE ASKING FOR A REBUILD (2026-09-12). The node in hand
+            // came off the mesh hub's MIRROR, and the mirror is exactly the reader that goes stale
+            // when the WRITER is another process: during a rolling update two platform generations
+            // serve one mesh for the whole termination grace (30 minutes on memex), each with its
+            // own framework identity, and the per-NodeType hub's owner grain moves between them.
+            // The old generation's compile stamps ITS identity on the record; this generation's
+            // mirror replays that snapshot after the old owner drains and its sync stream goes
+            // silent (#2409's shape, on the bind path) — while STORAGE already holds the build this
+            // generation adopted or compiled. Every activation then took this branch, flipped the
+            // type Pending, waited for a "usable" build the other generation could never produce,
+            // and timed out onto the "did not settle" overlay: every Store/Plugin instance on memex,
+            // for as long as the drain lasted. One authoritative read — the same read
+            // ConfirmInFlightAgainstStorage makes one branch up — is what turns a wait into a bind.
+            // Attempt 0 only: the retry already re-enters with the node the recompile wait handed
+            // back, and asking storage again there would only delay the overlay it has earned.
+            var staleGuards = NodeTypeCompilationHelpers.GuardsOf(meshHub);
+            if (recompileAttempts == 0 && AuthoritativeTypeRead(meshHub, nodeType) is { } reReadStale)
             {
-                logger?.LogWarning(
-                    "EnrichWithNodeType: {NodeType} assembly is compiled against framework {Compiled} but the live framework is {Live}; still ABI-stale after {Attempts} recompile attempt(s) — overlaying recompile prompt",
-                    nodeType, def.CompiledFrameworkVersion ?? "(null)",
-                    NodeTypeCompilationHelpers.FrameworkVersion, recompileAttempts);
-                // Version-gated self-heal: when the operator's recompile lands
-                // (a Version-advancing write with a framework-matching build),
-                // every instance stuck on this prompt recycles itself.
-                var (staleIntro, staleCta, staleGuidance) = OverlayCopy(OverlayCause.FrameworkStale);
-                return Observable.Return(
-                    WithOverlaySelfHeal(
-                        WithCompilationErrorOverlay(node, nodeType,
-                            "Built against a previous framework version",
-                            guidance: staleGuidance,
-                            intro: staleIntro,
-                            callToAction: staleCta,
-                            activityPath: def.LastCompilationActivityPath),
-                        meshHub, nodeType, typeNode.Version, logger));
+                return reReadStale()
+                    .Take(1)
+                    .Timeout(NodeTypeProbeTimeout)
+                    .Catch((Exception ex) =>
+                    {
+                        logger?.LogWarning(ex,
+                            "EnrichWithNodeType: could not confirm '{NodeType}' against storage before the "
+                            + "framework-stale recompile for '{InstancePath}' — proceeding on the mirror's state",
+                            nodeType, node.Path);
+                        return Observable.Return<MeshNode?>(null);
+                    })
+                    .SelectMany(authoritative =>
+                    {
+                        var chosen = PreferAuthoritative(typeNode, authoritative);
+                        if (!ReferenceEquals(chosen, typeNode)
+                            && chosen.ContentAs<NodeTypeDefinition>(meshHub.JsonSerializerOptions) is { } fresh
+                            && NodeTypeCompilationHelpers.HasUsableBuild(chosen, fresh, staleGuards))
+                        {
+                            logger?.LogInformation(
+                                "EnrichWithNodeType: the mesh-hub mirror reported '{NodeType}' compiled for "
+                                + "framework {Compiled} (live {Live}), but storage holds a build for the live "
+                                + "framework (version {Version}, {Path}) — binding it for '{InstancePath}' "
+                                + "instead of requesting a recompile",
+                                nodeType, def.CompiledFrameworkVersion ?? "(null)",
+                                NodeTypeCompilationHelpers.FrameworkVersion, chosen.Version,
+                                fresh.LatestAssemblyPath, node.Path);
+                            return ApplyStreamResult(
+                                chosen, node, nodeType, meshConfiguration, compilationService, meshHub,
+                                logger, recompileAttempts);
+                        }
+                        return RecompileForLiveFramework();
+                    });
             }
-            return TriggerRecompileAndRetry(
-                node, nodeType, meshConfiguration, compilationService, meshHub,
-                logger, recompileAttempts,
-                reason: $"'{nodeType}' assembly compiled against framework '{def.CompiledFrameworkVersion}' but live framework is '{NodeTypeCompilationHelpers.FrameworkVersion}' — ABI-stale, recompiling",
-                requireUsableBuild: true);
+            return RecompileForLiveFramework();
+
+            IObservable<MeshNode> RecompileForLiveFramework()
+            {
+                if (recompileAttempts >= MaxRecompileAttempts)
+                {
+                    logger?.LogWarning(
+                        "EnrichWithNodeType: {NodeType} assembly is compiled against framework {Compiled} but the live framework is {Live}; still ABI-stale after {Attempts} recompile attempt(s) — overlaying recompile prompt",
+                        nodeType, def.CompiledFrameworkVersion ?? "(null)",
+                        NodeTypeCompilationHelpers.FrameworkVersion, recompileAttempts);
+                    // Version-gated self-heal: when the operator's recompile lands
+                    // (a Version-advancing write with a framework-matching build),
+                    // every instance stuck on this prompt recycles itself.
+                    var (staleIntro, staleCta, staleGuidance) = OverlayCopy(OverlayCause.FrameworkStale);
+                    return Observable.Return(
+                        WithOverlaySelfHeal(
+                            WithCompilationErrorOverlay(node, nodeType,
+                                "Built against a previous framework version",
+                                guidance: staleGuidance,
+                                intro: staleIntro,
+                                callToAction: staleCta,
+                                activityPath: def.LastCompilationActivityPath),
+                            meshHub, nodeType, typeNode.Version, logger));
+                }
+                return TriggerRecompileAndRetry(
+                    node, nodeType, meshConfiguration, compilationService, meshHub,
+                    logger, recompileAttempts,
+                    reason: $"'{nodeType}' assembly compiled against framework '{def.CompiledFrameworkVersion}' but live framework is '{NodeTypeCompilationHelpers.FrameworkVersion}' — ABI-stale, recompiling",
+                    requireUsableBuild: true);
+            }
         }
 
         // 🚨 The compile state could not be DETERMINED (a settle wait or an assembly

--- a/src/MeshWeaver.Mesh.Contract/Services/ModuleVersionCompatibility.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/ModuleVersionCompatibility.cs
@@ -72,7 +72,21 @@ public static class ModuleVersionCompatibility
     public static bool Refuses(string? adoptedVersion, string? currentVersion)
         => Classify(adoptedVersion, currentVersion) is ModuleVersionVerdict.Incompatible;
 
-    /// <summary>The MAJOR component of a SemVer-ish string, or null when none can be read.</summary>
+    /// <summary>
+    /// The MAJOR component of a SemVer-ish string, or null when none can be read.
+    ///
+    /// <para>🚨 A value is a VERSION only when its leading integer is followed by a version
+    /// separator (<c>.</c>, <c>-</c>, <c>+</c>) or by the end of the string. A content HASH such as
+    /// <c>221c6c286785ddf2</c> — which is what a bundle baked without a released version carried
+    /// as its module version — starts with digits too, and reading those digits as "major 221"
+    /// against a root at <c>1.10</c> classified every such bundle INCOMPATIBLE and refused it.
+    /// Measured on memex 2026-09-12: the CI bundle for the running framework identity sat on the
+    /// prebuilt volume, its source fingerprint matched the live sources, and
+    /// <c>Prebuilt assembly for Store/Plugin DECLINED … (bundle module version 221c6c286785ddf2,
+    /// current 1.10: Incompatible)</c> sent every instance of the type through a Roslyn compile
+    /// instead. Ten of sixteen hex hashes start with a digit, so the refusal was the common case,
+    /// not a corner. A hash is UNKNOWN — nothing was compared — never a declared MAJOR bump.</para>
+    /// </summary>
     public static int? MajorOf(string? version)
     {
         if (string.IsNullOrWhiteSpace(version))
@@ -84,6 +98,10 @@ public static class ModuleVersionCompatibility
         while (end < span.Length && char.IsAsciiDigit(span[end]))
             end++;
         if (end == 0)
+            return null;
+        // The digits must END the version core: a following letter (a hash, a word) means the
+        // value is not a version at all, and its digits are not a major.
+        if (end < span.Length && span[end] is not ('.' or '-' or '+'))
             return null;
         return int.TryParse(span[..end], NumberStyles.None, CultureInfo.InvariantCulture, out var major)
             ? major

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ModuleVersionCompatibilityTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ModuleVersionCompatibilityTest.cs
@@ -1,0 +1,82 @@
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🚨 The module-version compatibility rule must never read a CONTENT HASH as a SemVer major.
+///
+/// <para>Measured on memex 2026-09-12: a bundle baked without a released version carried
+/// <c>manifest.lock</c>'s content hash (<c>221c6c286785ddf2</c>) as its module version; the root's
+/// <c>CurrentModuleVersion</c> was <c>1.10</c>. <see cref="ModuleVersionCompatibility.MajorOf"/>
+/// read the hash's leading digits as major 221, classified the pair INCOMPATIBLE, and the seeder
+/// refused the CI bundle for the running framework identity — whose source fingerprint matched the
+/// live sources — so every instance of <c>Store/Plugin</c> went through a Roslyn compile it did
+/// not need. Ten of sixteen hex hashes start with a digit: the refusal was the common case.</para>
+///
+/// <para>A hash is UNKNOWN: nothing was compared, nothing is refused. Only a version-shaped value
+/// yields a major, and only two version-shaped values whose majors differ refuse.</para>
+/// </summary>
+public class ModuleVersionCompatibilityTest
+{
+    [Theory]
+    [InlineData("221c6c286785ddf2")]   // the memex bundle: digits, then hex letters
+    [InlineData("73eff86754a63ac9")]   // the previous bundle on both portals
+    [InlineData("3fa590ff0719c04f")]   // this repo's Store/manifest.lock moduleVersion
+    [InlineData("deadbeef")]
+    [InlineData("12abc")]
+    [InlineData("v9x")]
+    public void AContentHash_HasNoMajor(string hash)
+        => Assert.Null(ModuleVersionCompatibility.MajorOf(hash));
+
+    [Theory]
+    [InlineData("1.10", 1)]
+    [InlineData("1.9.10", 1)]
+    [InlineData("2", 2)]
+    [InlineData("v3.0.0", 3)]
+    [InlineData("3.0.0-ci.8399", 3)]
+    [InlineData("4.1.0+sha", 4)]
+    [InlineData(" 12.0 ", 12)]
+    public void AVersionShapedValue_YieldsItsMajor(string version, int major)
+        => Assert.Equal(major, ModuleVersionCompatibility.MajorOf(version));
+
+    /// <summary>THE regression: the pair that refused Store/Plugin's CI bundle must be UNKNOWN.</summary>
+    [Fact]
+    public void AHashAgainstASemVer_IsUnknown_NeverIncompatible()
+    {
+        Assert.Equal(ModuleVersionVerdict.Unknown,
+            ModuleVersionCompatibility.Classify("221c6c286785ddf2", "1.10"));
+        Assert.False(ModuleVersionCompatibility.Refuses("221c6c286785ddf2", "1.10"),
+            "a bundle whose module version is a content hash was never compared to anything, "
+            + "so it cannot have declared a MAJOR bump — refusing it is what sent a whole type "
+            + "through Roslyn on memex 2026-09-12");
+    }
+
+    [Fact]
+    public void ASemVerAgainstAHash_IsUnknownToo()
+        => Assert.Equal(ModuleVersionVerdict.Unknown,
+            ModuleVersionCompatibility.Classify("1.10", "221c6c286785ddf2"));
+
+    [Fact]
+    public void SameMajor_IsCompatible()
+        => Assert.Equal(ModuleVersionVerdict.Compatible,
+            ModuleVersionCompatibility.Classify("1.9.10", "1.10"));
+
+    [Fact]
+    public void ADeclaredMajorBump_StillRefuses()
+    {
+        Assert.Equal(ModuleVersionVerdict.Incompatible,
+            ModuleVersionCompatibility.Classify("2.0.0", "1.10"));
+        Assert.True(ModuleVersionCompatibility.Refuses("2.0.0", "1.10"),
+            "the ONE refusal — a real MAJOR bump between two real versions — is unchanged");
+    }
+
+    [Theory]
+    [InlineData(null, "1.10")]
+    [InlineData("1.10", null)]
+    [InlineData("", "1.10")]
+    [InlineData("   ", "1.10")]
+    public void AMissingSide_IsUnknown(string? adopted, string? current)
+        => Assert.Equal(ModuleVersionVerdict.Unknown,
+            ModuleVersionCompatibility.Classify(adopted, current));
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/StaleDeclineNeverDanglesTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/StaleDeclineNeverDanglesTest.cs
@@ -109,16 +109,19 @@ public class StaleDeclineNeverDanglesTest(ITestOutputHelper output) : MonolithMe
     private static byte[] BundleBytes() =>
         File.ReadAllBytes(typeof(StaleDeclineNeverDanglesTest).Assembly.Location);
 
-    [Fact]
-    public async Task ADeclinedBundle_OverARecordWhoseBuildTheStoreDoesNotHold_ClearsItAndDispatchesACompile()
+    /// <summary>
+    /// Persists a record that claims a build this mesh's store has never held — the restarted-pod
+    /// shape — and returns its path once the mirror shows it.
+    /// </summary>
+    private async Task<string> PersistDanglingRecord(string typeName, string? currentModuleVersion = null)
     {
-        const string typePath = "type/DanglingStaleType";
+        var typePath = $"type/{typeName}";
         var typeNode = MeshNode.FromPath(typePath) with
         {
-            Name = "DanglingStaleType",
+            Name = typeName,
             NodeType = MeshNode.NodeTypePath,
             State = MeshNodeState.Active,
-            Content = ClaimingABuild(),
+            Content = ClaimingABuild() with { CurrentModuleVersion = currentModuleVersion },
         };
         await MeshService.CreateNode(typeNode).Should().Within(20.Seconds()).Emit();
         await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
@@ -131,14 +134,60 @@ public class StaleDeclineNeverDanglesTest(ITestOutputHelper output) : MonolithMe
         var store = Mesh.ServiceProvider.GetRequiredService<IAssemblyStore>();
         var path = await store.TryGetAssemblyPath(typePath, 5).Should().Within(10.Seconds()).Emit();
         path.Should().BeNull("the precondition: the claimed build does not resolve here");
+        return typePath;
+    }
+
+    /// <summary>
+    /// 🚨 Since 2026-09-12 (the tolerance directive, plus an UNATTRIBUTED, unverified statement —
+    /// <i>"at runtime you must resolve a package version, not try to compile"</i> — flagged in the
+    /// PR rather than claimed as the maintainer's): a bundle declined on its fingerprint whose module version is compatible or
+    /// unknown, over a record whose build the store does not hold, is ADOPTED as the last build
+    /// the mesh holds — a page on CI-built bytes now — rather than cleared and compiled. The
+    /// dangling record is still gone: it names the bundle's bytes instead of the dead build. See
+    /// <c>StaleDeclinePrefersBundleTest</c> for the table.
+    /// </summary>
+    [Fact]
+    public async Task ACompatibleDeclinedBundle_OverARecordWhoseBuildTheStoreDoesNotHold_IsAdoptedNotCompiled()
+    {
+        var typePath = await PersistDanglingRecord("DanglingStaleType");
 
         var outcome = await PrebuiltAssemblySeeder.SeedDetailed(
                 SweepHub("sweep"), typePath, BundleBytes(), pdbBytes: null,
                 frameworkMvid: PrebuiltAssemblySeeder.LiveFrameworkMvid, logger: null,
                 dependencies: null, sourceFingerprint: FixtureLiveFingerprint + "-stale")
             .Should().Within(20.Seconds()).Emit("a decline completes like any other");
+        outcome.Should().Be(PrebuiltAssemblySeeder.SeedOutcome.AdoptedStale,
+            "the bytes were declined on their fingerprint, the dead build does not resolve here, and "
+            + "the bundle's module version is unknown — so the bundle serves as the last build the "
+            + "mesh holds instead of a Roslyn compile being dispatched");
+
+        await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && !string.Equals(d.LatestAssemblyMvid, DeadMvid, StringComparison.Ordinal)
+                        && d.CompilationStatus == CompilationStatus.Ok
+                        && !string.IsNullOrEmpty(d.LatestAssemblyPath),
+                "the record no longer names the dead build — it names the adopted bundle, Ok and servable");
+    }
+
+    /// <summary>
+    /// The control arm, unchanged: a bundle that DECLARES incompatibility (a MAJOR bump against the
+    /// current source) is never adopted; the dead build is cleared and a compile is dispatched,
+    /// exactly as before.
+    /// </summary>
+    [Fact]
+    public async Task AnIncompatibleDeclinedBundle_OverARecordWhoseBuildTheStoreDoesNotHold_ClearsItAndDispatchesACompile()
+    {
+        var typePath = await PersistDanglingRecord("DanglingIncompatibleType", currentModuleVersion: "1.0");
+
+        var outcome = await PrebuiltAssemblySeeder.SeedDetailed(
+                SweepHub("sweep-incompatible"), typePath, BundleBytes(), pdbBytes: null,
+                frameworkMvid: PrebuiltAssemblySeeder.LiveFrameworkMvid, logger: null,
+                dependencies: null, sourceFingerprint: FixtureLiveFingerprint + "-stale",
+                moduleVersion: "2.0.0")
+            .Should().Within(20.Seconds()).Emit("a decline completes like any other");
         outcome.Should().Be(PrebuiltAssemblySeeder.SeedOutcome.DeclinedStaleSourcesCompileDispatched,
-            "the bytes were declined on their fingerprint AND the dead build was cleared with a compile dispatched");
+            "a MAJOR bump is the one declared incompatibility: the bytes are refused, the dead build "
+            + "is cleared and a compile of the live source is dispatched");
 
         await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
             .Match(n => n?.Content is NodeTypeDefinition d

--- a/test/MeshWeaver.Compiler.Pipeline.Test/StaleDeclinePrefersBundleTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/StaleDeclinePrefersBundleTest.cs
@@ -1,0 +1,99 @@
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+using static MeshWeaver.Graph.Configuration.PrebuiltAssemblySeeder;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// 🚨 The rule for a bundle DECLINED on its source fingerprint, as a table
+/// (<see cref="PrebuiltAssemblySeeder.DecideAfterStaleDecline"/>), pinned so the ordering cannot
+/// drift back to "compile first".
+///
+/// <para>Maintainer directive, 2026-09-12 (relayed): <i>"it should all be tolerant"</i>. The
+/// bundle-before-compile row ALSO leans on two UNATTRIBUTED, unverified statements received
+/// mid-session (<i>"compile must happen on CI — at runtime you must resolve a package version,
+/// not try to compile"</i>) — flagged in the PR, not claimed as the maintainer's. When the
+/// build the record names does not load on this process and a version-compatible bundle for THIS
+/// framework identity is in hand, the bundle is adopted — a page renders on CI-built bytes now —
+/// instead of clearing the record and dispatching Roslyn. On memex 2026-09-12 the compile path is
+/// what every instance of <c>Store/Plugin</c> sat behind, on the "did not settle" overlay, while
+/// the CI bundle for the running identity was on the prebuilt volume the whole time.</para>
+/// </summary>
+public class StaleDeclinePrefersBundleTest
+{
+    private static NodeTypeDefinition ClaimingABuild(CompilationStatus status = CompilationStatus.Ok) => new()
+    {
+        CompilationStatus = status,
+        LastCompiledVersion = 5,
+        LatestAssemblyCollection = FileSystemAssemblyStore.FileSystemCollectionName,
+        LatestAssemblyPath = "Type_Stale/v5-dead.dll",
+        CompiledFrameworkVersion = "s0000000000000000000000000000000f",
+    };
+
+    private static NodeTypeDefinition ClaimingNoBuild() => new()
+    {
+        CompilationStatus = CompilationStatus.Ok,
+    };
+
+    /// <summary>THE CHANGE: a compatible bundle beats a local compile.</summary>
+    [Fact]
+    public void ACompatibleBundle_IsAdopted_BeforeALocalCompileIsDispatched()
+        => Assert.Equal(StaleDeclineAction.AdoptBundle,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: false, canCompileLocally: true, bundleAdoptable: true));
+
+    [Fact]
+    public void ABuildThatResolvesHere_IsKept_WhateverTheBundleSays()
+    {
+        Assert.Equal(StaleDeclineAction.KeepLiveBuild,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: true, canCompileLocally: true, bundleAdoptable: true));
+        Assert.Equal(StaleDeclineAction.KeepLiveBuild,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: true, canCompileLocally: false, bundleAdoptable: false));
+    }
+
+    [Fact]
+    public void NoCompatibleBundle_OnACompilingMesh_DispatchesTheCompile()
+        => Assert.Equal(StaleDeclineAction.DispatchCompile,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: false, canCompileLocally: true, bundleAdoptable: false));
+
+    [Fact]
+    public void NoCompatibleBundle_OnANonCompilingMesh_IsUnservable()
+        => Assert.Equal(StaleDeclineAction.Unservable,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: false, canCompileLocally: false, bundleAdoptable: false));
+
+    [Fact]
+    public void ACompatibleBundle_OnANonCompilingMesh_IsAdopted_AsBefore()
+        => Assert.Equal(StaleDeclineAction.AdoptBundle,
+            DecideAfterStaleDecline(ClaimingABuild(),
+                liveBuildResolvesHere: false, canCompileLocally: false, bundleAdoptable: true));
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void ACompileInFlight_OnACompilingMesh_IsNeverStampedOver(CompilationStatus inFlight)
+        => Assert.Equal(StaleDeclineAction.LeaveRecord,
+            DecideAfterStaleDecline(ClaimingABuild(inFlight),
+                liveBuildResolvesHere: false, canCompileLocally: true, bundleAdoptable: true));
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void ACompileInFlight_OnANonCompilingMesh_StillAdopts_AsBefore(CompilationStatus inFlight)
+        => Assert.Equal(StaleDeclineAction.AdoptBundle,
+            DecideAfterStaleDecline(ClaimingABuild(inFlight),
+                liveBuildResolvesHere: false, canCompileLocally: false, bundleAdoptable: true));
+
+    [Fact]
+    public void ARecordClaimingNoBuild_HasNothingToClear()
+        => Assert.Equal(StaleDeclineAction.LeaveRecord,
+            DecideAfterStaleDecline(ClaimingNoBuild(),
+                liveBuildResolvesHere: false, canCompileLocally: true, bundleAdoptable: false));
+}

--- a/test/MeshWeaver.Graph.Test/InFlightLastGoodBuildBindsTest.cs
+++ b/test/MeshWeaver.Graph.Test/InFlightLastGoodBuildBindsTest.cs
@@ -1,0 +1,274 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 TOLERANCE: a page of an instance whose type has a LAST-GOOD compiled assembly must render on
+/// that assembly while a recompile is in flight (maintainer directive, 2026-09-12: <i>"it should all
+/// be tolerant"</i>). Waiting for the build to "settle" — and painting the compile-progress overlay
+/// after the grace, then the 30 s "did not settle" fallback — is the defect whenever the record
+/// still names bytes this process can load.
+///
+/// <para><b>Measured.</b> memex 2026-09-12, during a rolling update: two platform generations served
+/// one mesh for the 30-minute termination grace, each compiling <c>Store/Plugin</c> under its own
+/// framework identity (ten compiles in four minutes), and every instance of the type on the new
+/// generation — DeepSign, Edu, RolePlay, Chess, ClaudeCode, Voice, WebSearch, … — sat on
+/// <c>NodeType 'Store/Plugin' build did not settle within 30s</c> while the assembly store held a
+/// build for the running identity the whole time.</para>
+///
+/// <para>Asserted on the production predicates the slow path composes
+/// (<see cref="NodeTypeEnrichmentHelpers.IsBindableOrSettled"/>,
+/// <see cref="NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay"/>) and on
+/// <see cref="NodeTypeEnrichmentHelpers.WaitForCompileSettled"/> under virtual time — the same
+/// seams <c>CompileSettlePredicateTest</c> and <c>CompileWaitDoesNotTimeoutTest</c> pin — so the
+/// verdict is about the decision, not about a compiler's timing.</para>
+/// </summary>
+public class InFlightLastGoodBuildBindsTest
+{
+    private const string NodeTypePath = "type/LastGoodProbe";
+    private const string ForeignFramework = "s0000000000000000000000000000000f";
+
+    private static readonly JsonSerializerOptions Options = new(JsonSerializerOptions.Default);
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+    private static readonly TimeSpan Grace = TimeSpan.FromSeconds(5);
+
+    /// <summary>A dynamic type mid-rebuild (<paramref name="status"/>) that still names the build
+    /// it published before — for THIS framework identity unless <paramref name="framework"/> says
+    /// otherwise.</summary>
+    private static MeshNode Node(CompilationStatus? status, bool lastGood, string? framework = null) =>
+        new(NodeTypePath)
+        {
+            Version = 7,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                CompilationStatus = status,
+                LatestAssemblyCollection = lastGood ? "local" : null,
+                LatestAssemblyPath = lastGood ? "Type_LastGood/v7-live.dll" : null,
+                CompiledFrameworkVersion = lastGood
+                    ? framework ?? NodeTypeCompilationHelpers.FrameworkVersion
+                    : null,
+            },
+        };
+
+    // ── the predicates ────────────────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void AnInFlightTypeWithALastGoodBuild_IsBindable(CompilationStatus inFlight)
+        => Assert.True(NodeTypeEnrichmentHelpers.IsBindableWhileCompiling(
+            Node(inFlight, lastGood: true), Options, guards: null));
+
+    [Theory]
+    [InlineData(CompilationStatus.Pending)]
+    [InlineData(CompilationStatus.Compiling)]
+    public void AnInFlightTypeWithNoBuild_IsNotBindable(CompilationStatus inFlight)
+        => Assert.False(NodeTypeEnrichmentHelpers.IsBindableWhileCompiling(
+            Node(inFlight, lastGood: false), Options, guards: null));
+
+    [Fact]
+    public void AnInFlightTypeWhoseBuildIsForAnotherFramework_IsNotBindable()
+        => Assert.False(NodeTypeEnrichmentHelpers.IsBindableWhileCompiling(
+                Node(CompilationStatus.Pending, lastGood: true, ForeignFramework), Options, guards: null),
+            "bytes compiled for another framework identity are not loadable here — the progress "
+            + "overlay stays the honest answer for those");
+
+    [Fact]
+    public void ASettledType_IsNotBindableWhileCompiling_ItIsSimplySettled()
+    {
+        var ok = Node(CompilationStatus.Ok, lastGood: true);
+        Assert.False(NodeTypeEnrichmentHelpers.IsBindableWhileCompiling(ok, Options, guards: null));
+        Assert.True(NodeTypeEnrichmentHelpers.IsBindableOrSettled(ok, Options, guards: null));
+    }
+
+    [Fact]
+    public void RoutingToTheProgressOverlay_IsOnlyForAnInFlightTypeWithNothingToBind()
+    {
+        Assert.False(NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay(
+                Node(CompilationStatus.Pending, lastGood: true), Options, guards: null),
+            "a loadable last-good build is bound, never overlaid");
+        Assert.True(NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay(
+            Node(CompilationStatus.Compiling, lastGood: false), Options, guards: null));
+        Assert.False(NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay(
+            Node(CompilationStatus.Ok, lastGood: true), Options, guards: null));
+    }
+
+    // ── the wait, under virtual time ──────────────────────────────────────────────────────────
+
+    private static IObservable<MeshNode> Settled(IObservable<MeshNode> typeStream)
+        => typeStream
+            .Where(n => NodeTypeEnrichmentHelpers.IsBindableOrSettled(n, Options, guards: null))
+            .Take(1);
+
+    /// <summary>
+    /// THE CONTRACT: compile in flight + last-good assembly present ⇒ the activation binds NOW —
+    /// at virtual t = 0, before any grace elapses and without waiting for the terminal write.
+    /// </summary>
+    [Fact]
+    public void CompileInFlightWithALastGoodBuild_EmitsImmediately_NotAfterTheGrace()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler, Options,
+                inFlightGrace: Grace)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        var rebuilding = Node(CompilationStatus.Compiling, lastGood: true);
+        typeStream.OnNext(rebuilding);
+
+        Assert.Null(error);
+        Assert.Same(rebuilding, emitted);
+        Assert.False(NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay(emitted!, Options, guards: null),
+            "the slow path binds this emission through ApplyStreamResult's HasUsableBuild branch "
+            + "(which precedes every status branch) and arms the stale-assembly watcher for the "
+            + "rebuild — it does not route it to the compile-progress overlay");
+    }
+
+    /// <summary>
+    /// The control arm: an in-flight type with NOTHING loadable keeps today's contract exactly —
+    /// silence at t = 0, the grace emission after <see cref="Grace"/>, and that emission routes to
+    /// the overlay.
+    /// </summary>
+    [Fact]
+    public void CompileInFlightWithNoBuild_StillWaitsOutTheGrace_ThenOverlays()
+    {
+        var scheduler = new TestScheduler();
+        var typeStream = new Subject<MeshNode>();
+        MeshNode? emitted = null;
+        Exception? error = null;
+        NodeTypeEnrichmentHelpers
+            .WaitForCompileSettled(typeStream, Settled(typeStream), Budget,
+                () => new TimeoutException("no compile in flight"), scheduler, Options,
+                inFlightGrace: Grace)
+            .Subscribe(n => emitted = n, ex => error = ex);
+
+        var firstBuild = Node(CompilationStatus.Compiling, lastGood: false);
+        typeStream.OnNext(firstBuild);
+        Assert.Null(emitted);
+
+        scheduler.AdvanceBy(Grace.Ticks);
+        Assert.Null(error);
+        Assert.Same(firstBuild, emitted);
+        Assert.True(NodeTypeEnrichmentHelpers.RoutesToInFlightOverlay(emitted!, Options, guards: null));
+    }
+}
+
+/// <summary>
+/// 🚨 THE WEDGE ON THE ACTIVATION PATH, reproduced against a real mesh: the NodeType node an
+/// activation reads off the mesh-hub MIRROR says the build is for ANOTHER framework identity, while
+/// STORAGE holds a build for the live one. Before this fix the framework-stale branch trusted the
+/// mirror, flipped the type Pending and waited for a "usable" build; with the writer being another
+/// process generation that wait could not be satisfied and every activation timed out onto the
+/// "did not settle" overlay (memex 2026-09-12, every <c>Store/Plugin</c> instance). Now the branch
+/// confirms against storage first and binds the build that is actually there — no Pending flip, no
+/// recompile, no wait.
+///
+/// <para>Discriminating by construction: the pre-fix path WRITES (the Ok→Pending flip advances the
+/// persisted version and dispatches a compile); the fixed path reads once and binds. The persisted
+/// record's version and status are therefore the assertion, not the shape of the configuration.</para>
+/// </summary>
+public class ForeignFrameworkStampOnTheMirrorTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string TypeName = "ForeignStampProbe";
+    private const string ForeignFramework = "s0000000000000000000000000000000f";
+    private static readonly TimeSpan VerdictBudget = TimeSpan.FromSeconds(20);
+
+    private static MeshConfiguration EmptyMeshConfiguration() => new(Array.Empty<MeshNode>());
+
+    private IMeshNodeCompilationService Compiler =>
+        Mesh.ServiceProvider.GetRequiredService<IMeshNodeCompilationService>();
+
+    [Fact(Timeout = 90_000)]
+    public async Task AForeignStampOnTheMirror_BindsTheStorageBuild_WithoutARecompile()
+    {
+        var typePath = $"{TestPartition}/{TypeName}";
+        var store = Mesh.ServiceProvider.GetService<IAssemblyStore>();
+        Assert.NotNull(store);
+
+        // Real bytes under the live framework tag — the build THIS process can load.
+        const long storeVersion = 1;
+        var bytes = await File.ReadAllBytesAsync(typeof(ModuleVersionCompatibility).Assembly.Location);
+        var location = await store!.PutWithLocation(typePath, storeVersion, bytes, null)
+            .FirstAsync().Timeout(VerdictBudget).Await();
+
+        var usable = new NodeTypeDefinition
+        {
+            Configuration = "config => config",
+            CompilationStatus = CompilationStatus.Ok,
+            LastCompiledVersion = storeVersion,
+            LatestAssemblyCollection = location.Collection,
+            LatestAssemblyPath = location.ContentPath,
+            CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+        };
+        var persisted = await CreateAsSystem(new MeshNode(TypeName, TestPartition)
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Content = usable,
+        });
+
+        // What the mirror replays: the same record, stamped by another generation's compile.
+        var mirror = persisted with
+        {
+            Content = usable with { CompiledFrameworkVersion = ForeignFramework },
+        };
+        var instance = new MeshNode("foreign-stamp-instance", TestPartition) { NodeType = typePath };
+
+        var verdict = await NodeTypeEnrichmentHelpers
+            .ApplyStreamResult(
+                mirror, instance, typePath, EmptyMeshConfiguration(), Compiler, Mesh, logger: null)
+            .Take(1)
+            .Should().Within(VerdictBudget).Emit("the activation must reach a verdict");
+
+        // Not an overlay: every overlay installs an UnhandledMessageNack; a bound build does not.
+        if (verdict.HubConfiguration is not null)
+        {
+            var applied = verdict.HubConfiguration(
+                new MessageHubConfiguration(null, new Address("probe", TypeName)));
+            (applied.Get<UnhandledMessageNack>()).Should().BeNull(
+                "storage holds a build for the live framework, so the instance binds it — it is "
+                + "neither the compile-progress overlay nor the framework-stale prompt");
+        }
+
+        // No recompile was requested: the persisted record is exactly as written.
+        var after = await Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Where(n => n is not null)
+            .Take(1)
+            .Should().Within(VerdictBudget).Emit("the type node is readable after the verdict");
+        var afterDef = after!.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions);
+        afterDef.Should().NotBeNull();
+        afterDef!.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "the framework-stale branch must not flip a type Pending when storage already holds a "
+            + "loadable build — that flip is the wait every instance sat out on memex 2026-09-12");
+        after.Version.Should().Be(persisted.Version,
+            "a bind is a READ; the pre-fix path's Ok→Pending flip advanced the version");
+    }
+
+    private Task<MeshNode> CreateAsSystem(MeshNode node)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var access = Mesh.ServiceProvider.GetService<AccessService>();
+        return access.RunAsSystem(() => meshService.CreateNode(node))
+            .FirstAsync().Timeout(VerdictBudget).Await();
+    }
+}

--- a/test/MeshWeaver.Graph.Test/InFlightLastGoodBuildBindsTest.cs
+++ b/test/MeshWeaver.Graph.Test/InFlightLastGoodBuildBindsTest.cs
@@ -45,7 +45,9 @@ public class InFlightLastGoodBuildBindsTest
     private const string ForeignFramework = "s0000000000000000000000000000000f";
 
     private static readonly JsonSerializerOptions Options = new(JsonSerializerOptions.Default);
-    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+    // Virtual time (TestScheduler): the no-progress budget the wait is armed with. Any value works;
+    // it is deliberately NOT the copied 30 s convention the timeout-literal ratchet counts.
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(25);
     private static readonly TimeSpan Grace = TimeSpan.FromSeconds(5);
 
     /// <summary>A dynamic type mid-rebuild (<paramref name="status"/>) that still names the build

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -151,7 +151,14 @@ public static class BakeOutput
                             BundleWriter.Write(
                                 file,
                                 package.Id,
-                                manifest?.ReleasedVersion ?? manifest?.ModuleVersion ?? manifest?.Version,
+                                // 🚨 The SemVer, never the content hash. The bundle's version is
+                                // what ModuleVersionCompatibility reads against the root's
+                                // MAJOR.MINOR; a hash there (ModuleVersion is manifest.lock's
+                                // unordered content hash) is at best UNKNOWN and, when it starts
+                                // with digits, was read as a foreign MAJOR and refused (memex
+                                // 2026-09-12). ModuleVersion is the last resort, for a package
+                                // that records no SemVer at all.
+                                manifest?.ReleasedVersion ?? manifest?.Version ?? manifest?.ModuleVersion,
                                 frameworkMvid,
                                 entries.ToList(),
                                 sourceSha,

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -563,7 +563,8 @@ public static class TreeBake
                 BundleWriter.Write(
                     file,
                     packageId,
-                    manifest?.ReleasedVersion ?? manifest?.ModuleVersion ?? manifest?.Version,
+                    // The SemVer before the content hash — same rule and reason as BakeOutput.
+                    manifest?.ReleasedVersion ?? manifest?.Version ?? manifest?.ModuleVersion,
                     frameworkIdentity,
                     [.. entries.OrderBy(e => e.NodePath, StringComparer.Ordinal)],
                     sourceSha,


### PR DESCRIPTION
## What & why

Fixes the production defect Roland hit on https://memex.meshweaver.cloud/DeepSign at 06:25Z today — *"NodeType 'Store/Plugin' build did not settle within 30s"* on an instance whose type read `compilationStatus: Ok` — and the compile storm behind it (ten `Store/Plugin` compiles in four minutes; the type is at node version 13 870 on memex vs 2 895 on systemorph). Tracking issue for the structural remainder: #4071. Write-up (lands with this PR): `Doc/Architecture/RollingUpdateBuildTolerance`.

**Mechanism, measured.** The 06:10Z rolling update (`ci.8372` → `ci.8399`, `terminationGracePeriodSeconds: 1800`, `preStop` waits on `/drain`) ran two platform generations against one mesh for the whole drain, with different framework identities (`s6649734…` / `sa74cfbd…`). The `Store/Plugin` record holds ONE `compiledFrameworkVersion`, so each generation read the other's build as ABI-stale: activations on the new pods flipped the type Pending and *waited*, the owner grain (on a draining old pod) rebuilt it under the OLD identity — eight times — and the wait timed out onto the fallback for every instance of the type (DeepSign, Edu, RolePlay, Chess, ClaudeCode, Voice, WebSearch, …; health `content-types Degraded … Store/Plugin ×116`). It cleared only when the last old pod's grace expired (~06:45Z). Same shape on every recent roll (09-11 18:47Z, 09-10 14:40Z).

Compounding it: the CI bundle for the live identity was on `/data/prebuilt-bundles/sa74cfbd…` with a matching fingerprint and was **refused** — `Prebuilt assembly for Store/Plugin DECLINED … (bundle module version 221c6c286785ddf2, current 1.10: Incompatible)`. The bake records `manifest.lock`'s content HASH as the module version when no released version exists, and `ModuleVersionCompatibility.MajorOf` read its leading digits as major 221.

**Directive applied** (2026-09-12, relayed by the coordinating session): *"it should all be tolerant"*. Two further statements — *"compile must happen on CI — at runtime you must resolve a package version, not try to compile"* and *"dynamic compilation should be disabled for CI-built plugins"* — reached the investigating session from an **unattributed, unverified** source; they are NOT quoted as maintainer directives. Change (3) below leans on them and is flagged for the reviewer; (1), (2) and (4) stand on the relayed directive and on measurement alone.

## Changes

1. **Bind the last-good build while a compile is in flight** (`NodeTypeEnrichmentHelpers`): `IsBindableWhileCompiling` (Pending/Compiling + `HasUsableBuild` for this process) is admitted by the slow path's settle predicate (`IsBindableOrSettled`) and routed to `ApplyStreamResult`, which binds it and arms the stale-assembly watcher. An in-flight type with nothing loadable keeps the grace → progress-overlay behaviour.
2. **Confirm against storage before asking for a rebuild** on the framework-stale branch (one `AuthoritativeTypeRead`, the same read `ConfirmInFlightAgainstStorage` makes): when storage holds a build for the live identity, bind it; no Pending flip, no recompile.
3. **A compatible CI bundle beats a local compile** (`PrebuiltAssemblySeeder.DecideAfterStaleDecline`, pure table): a bundle declined on its fingerprint whose module version is compatible/unknown, over a record whose build the store does not hold, is adopted as `StaleAdopted` instead of clearing the record and dispatching Roslyn. Incompatible (MAJOR bump) still clears and dispatches; in-flight compiles on a compiling mesh are never stamped over.
4. **A content hash is never a SemVer major** (`ModuleVersionCompatibility.MajorOf`): only a version-shaped value yields a major; a hash reads Unknown. The bake now records `ReleasedVersion ?? Version ?? ModuleVersion` (`BakeOutput`, `TreeBake`).

## Tests

- `InFlightLastGoodBuildBindsTest` — predicates and the virtual-time wait: compile in flight + last-good build ⇒ emitted at t = 0 and routed to bind; control arm (nothing loadable) still waits the grace and overlays.
- `ForeignFrameworkStampOnTheMirrorTest` — real Monolith mesh: foreign stamp on the mirror, usable build in storage ⇒ bound, no `UnhandledMessageNack`, persisted record still Ok at the same version (the pre-fix path's Ok→Pending flip advances it, so this fails against the mutation).
- `StaleDeclinePrefersBundleTest` — the decision table; `StaleDeclineNeverDanglesTest` updated: compatible ⇒ `AdoptedStale`, plus the new incompatible control arm ⇒ `DeclinedStaleSourcesCompileDispatched`.
- `ModuleVersionCompatibilityTest` — the exact pair that refused Store/Plugin (`221c6c286785ddf2` vs `1.10`) is Unknown; a real MAJOR bump still refuses.

## Merge preconditions

- [ ] **(a) Build is green with warnings-as-errors**
- [ ] **(b) Tests are green**
- [ ] **(c) Reviewed**
- [ ] **(d) Review comments dealt with**

## Notes for reviewers

- The behaviour change with blast radius is (3): on a compiling mesh a stale-but-compatible bundle now serves first and the dirty record is rebuilt afterwards by the release-request watcher (unchanged), instead of the type being cleared and compiled with no page in between. Its motivation is the UNVERIFIED statement above plus the tolerant reading of #3583; if the maintainer does not endorse it, drop `DecideAfterStaleDecline`'s `AdoptBundle`-on-a-compiling-mesh row (and the two tests that pin it) and the rest of the PR stands unchanged. The structural remainder — one build record per framework identity, no runtime compile for module content — is #4071, conditional on the same confirmation.
- The mirror-latch reading on the framework-stale branch (why activations kept failing after the record had settled at 06:24:53Z) is the inference that fits every measurement; the fix (2) does not depend on it — it consults storage regardless.
- Verified read-only on memex; no live action was taken. An instance already on the fallback stays there until recycled (its self-heal is version-gated on the type record).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
