### PR TITLE
#4040 review: the restriction must hold on the path that WRITES (follow-up to #4070)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
@@ -23,6 +23,15 @@ The picker therefore carries **items and no queries**. That is not a style choic
 set, so a query alongside the provider would re-admit by discovery exactly what a restricting
 parent excluded.
 
+🚨 **The picker is not the enforcement point — the form's `type` VALUE is.** The Create button reads
+`form["type"]`, never the picker's item list, and that value is seeded before the provider has
+answered (it cannot be otherwise — the answer is reactive). So when the resolved offer does not
+contain the seed, the form replaces it with the first offered type, or with nothing when the parent
+offers none, so a Required field blocks the submit. Without that, a parent declaring
+`CreatableTypes` with `IncludeGlobalTypes: false` would render a picker holding only its declared
+types and still create `Markdown` for anyone who submitted without touching the field — the menu
+honouring the declaration and the write ignoring it.
+
 ## The resolution rule
 
 Four sources are merged, deduplicated by NodeType path, and ordered by `Order` then name.
@@ -85,7 +94,13 @@ otherwise omit it and silently round-trip the opt-out back to `true`.
 `ExcludeFromContext: ["create"]` on the NodeType is how a type says it is not creatable —
 `Release`, `Build`, `ModuleBuild` and `Partition` all use it. Every query above names
 `context:create`, and the static bucket applies the same filter, so the opt-out is honoured on both
-legs. See [Query Syntax](/Doc/DataMesh/QuerySyntax) for the `context:` qualifier and the other contexts.
+legs.
+
+🚨 **A type's own opt-out beats a list that names it.** Sources 3 and 4 resolve through the same
+exclusion-aware lookup, so a parent's `CreatableTypes` — or a host's `GlobalCreatableTypes` —
+naming `Partition` does not resurrect it. A whitelist ADDS types the queries could not reach; it
+does not overrule a type's own statement that instances of it are made by the platform rather than
+by a person. See [Query Syntax](/Doc/DataMesh/QuerySyntax) for the `context:` qualifier and the other contexts.
 
 ## Two rules that look like details and are not
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-type-can-say-what-may-be-created-under-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-type-can-say-what-may-be-created-under-it.md
@@ -36,7 +36,13 @@ does what it says:
   under it still contains everything it contained before. That is pinned by a test, because a menu
   that quietly got shorter would have been the same invisible failure aimed the other way.
 
+- **It holds on the button, not just the menu.** The type the form starts on is chosen before
+  anything knows what the parent permits, and that is the value Create reads. Where the parent does
+  not allow it, the form moves to one it does — so a limited menu cannot be submitted past by
+  leaving the field alone.
+
 Two smaller corrections travel with it. Types that had opted out of being created — releases,
-builds, partitions — are honoured everywhere the menu is assembled. And the `includeGlobalTypes`
-switch works, so a type that limits its menu can also decide whether the always-available basics
-(Markdown, Thread, Agent, Node type) still ride along.
+builds, partitions — are honoured everywhere the menu is assembled, including when a list names one
+of them directly: opting out is the type's own statement and a list cannot overrule it. And the
+`includeGlobalTypes` switch works, so a type that limits its menu can also decide whether the
+always-available basics (Markdown, Thread, Agent, Node type) still ride along.

--- a/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
+++ b/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
@@ -312,12 +312,27 @@ internal sealed class CreatableTypesProvider(
             Order: node.Order ?? 0);
     }
 
+    /// <summary>
+    /// A path named by <see cref="NodeTypeDefinition.CreatableTypes"/> or
+    /// <see cref="MeshConfiguration.GlobalCreatableTypes"/>, as a <see cref="CreatableTypeInfo"/> —
+    /// or <c>null</c> when the type it names has opted out of being created.
+    ///
+    /// <para>🚨 <b>A type's own opt-out beats a list that names it.</b>
+    /// <c>ExcludeFromContext: ["create"]</c> is the TYPE saying instances of it are made by the
+    /// platform and not by a person through this form (Release, Build, ModuleBuild, Partition all
+    /// say it). A whitelist or a host's global list naming one of those must not resurrect it —
+    /// the queries and the static bucket both honour the opt-out, and a config source that did not
+    /// would be a hole in the one rule this provider exists to apply. The opt-out is read from the
+    /// static registry, which is where every platform type that declares one lives.</para>
+    /// </summary>
     private static CreatableTypeInfo? BuildInfoFromConfig(
         string typePath, IServiceProvider serviceProvider, System.Text.Json.JsonSerializerOptions options)
     {
         var node = serviceProvider.FindStaticNode(typePath);
         if (node is not null)
-            return BuildInfoFromMeshNode(node, options);
+            return node.IsExcludedFromContext(MeshContexts.Create)
+                ? null
+                : BuildInfoFromMeshNode(node, options);
         return new CreatableTypeInfo(
             NodeTypePath: typePath,
             DisplayName: GetLastSegment(typePath),

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -264,6 +264,55 @@ public static class CreateLayoutArea
     }
 
     /// <summary>
+    /// Replaces the form's seeded <c>type</c> (and the icon that came with it) when the parent
+    /// does not allow it — with the first offered type, or with nothing when the parent offers
+    /// none, so the Required field blocks the submit rather than writing a type the parent
+    /// forbids.
+    ///
+    /// <para>🚨 <b>Why this is not cosmetic.</b> The Create button reads
+    /// <c>form["type"]</c>; the picker's item list is only what a person is shown. The seed is
+    /// computed before <see cref="ICreatableTypesProvider"/> has answered — it cannot be
+    /// otherwise, the answer is reactive — so without this a parent declaring
+    /// <c>CreatableTypes</c> with <c>IncludeGlobalTypes = false</c> renders a picker holding only
+    /// its declared types and still creates <c>Markdown</c> for anyone who submits without
+    /// touching the field. Same for a <c>?type=</c> URL naming a type the parent excluded.</para>
+    ///
+    /// <para>Idempotent: it rewrites only when the current value is not in the offered set, and
+    /// the provider's answer arrives once per render, before the user can type.</para>
+    /// </summary>
+    private static void AlignSeededTypeWithOffer(
+        LayoutAreaHost host, string formId, IReadOnlyList<CreatableTypeInfo> offered)
+    {
+        var logger = host.Hub.ServiceProvider.GetService<ILogger<LayoutAreaHost>>();
+        host.Stream.GetDataStream<Dictionary<string, object?>>(formId)
+            .Take(1)
+            .Subscribe(
+                form =>
+                {
+                    var current = form?.GetValueOrDefault("type")?.ToString() ?? "";
+                    if (offered.Any(t => string.Equals(t.NodeTypePath, current, StringComparison.OrdinalIgnoreCase)))
+                        return;
+
+                    var replacement = offered.Count > 0 ? offered[0] : null;
+                    var next = form is null
+                        ? new Dictionary<string, object?>()
+                        : new Dictionary<string, object?>(form);
+                    next["type"] = replacement?.NodeTypePath ?? "";
+                    // The icon preview was seeded from the type we are replacing, so it travels
+                    // with it — otherwise the new node is created carrying the withdrawn type's
+                    // icon.
+                    next["icon"] = replacement?.Icon ?? "";
+                    host.UpdateData(formId, next);
+                },
+                // 🚨 onError is not optional. Rx RETHROWS a fault out of an onNext delegate onto
+                // the scheduler's thread, where nothing is left to catch it — it becomes an
+                // unhandled exception that ends the process (#2666). A form that could not read
+                // its own seed keeps the picker it already has; it must not take the host down.
+                ex => logger?.LogWarning(
+                    ex, "Could not align the seeded type on form {FormId} with the offered set", formId));
+    }
+
+    /// <summary>
     /// The picker's item shape. <see cref="MeshNodePickerControl.Items"/> takes MeshNodes — it
     /// stores the selected node's <c>Path</c> as the form value and renders Name/Icon/Description
     /// — so a <see cref="CreatableTypeInfo"/> is projected onto one. Every entry IS a type
@@ -436,21 +485,30 @@ public static class CreateLayoutArea
             var creatableTypes = host.Hub.ServiceProvider
                 .GetRequiredService<ICreatableTypesProvider>()
                 .GetCreatableTypes(parentPath, currentNode);
-            stack = stack.WithView((_, _) => creatableTypes.Select(types =>
-                (UiControl)new MeshNodePickerControl(new JsonPointerReference("type"))
+            stack = stack.WithView((h, _) => creatableTypes.Select(types =>
+            {
+                var offered = types
+                    .Where(t => restrictedTypes is null
+                        || restrictedTypes.Contains(t.NodeTypePath, StringComparer.OrdinalIgnoreCase))
+                    .ToArray();
+                // 🚨 The SEEDED default has to become one the parent allows. `type` was seeded
+                // several sections above (from ?type=, the current node, or "Markdown") — before
+                // anything knew what this parent permits — and the SUBMIT reads that value, not
+                // the picker's contents. So a restricting parent would render a picker offering
+                // only its declared types while a user who never touched the field still created
+                // the stale default. The restriction has to hold on the path that WRITES.
+                AlignSeededTypeWithOffer(h, formId, offered);
+                return (UiControl)new MeshNodePickerControl(new JsonPointerReference("type"))
                 {
                     Label = host.Localize("ui.typeRequired"),
                     Required = true,
                     Placeholder = host.Localize("create.selectType"),
                     DataContext = dataContext
                 }
-                .WithItems(types
-                    .Where(t => restrictedTypes is null
-                        || restrictedTypes.Contains(t.NodeTypePath, StringComparer.OrdinalIgnoreCase))
-                    .Select(ToPickerNode)
-                    .ToArray<object>())
+                .WithItems(offered.Select(ToPickerNode).ToArray<object>())
                 .WithMaxResults(15)
-                .WithStyle("width: 100%; margin-bottom: 16px;")));
+                .WithStyle("width: 100%; margin-bottom: 16px;");
+            }));
         }
 
         // 7. Namespace — REACTIVE on the selected type. Partition objects (Space, User;

--- a/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -82,7 +83,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant (TestTimeouts.TestMilliseconds is not).
     public async Task AParentDeclaringNothingLosesNothing()
     {
-        var (types, host) = await Fixture();
+        var (types, host, _) = await Fixture();
         var parentPath = $"{host}/Thing";
 
         var baseline = await LiteralQueryResults(parentPath);
@@ -125,7 +126,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
     public async Task TheOldQueryLiteralsCannotReachADeclaredType()
     {
-        var (types, host) = await Fixture();
+        var (types, host, _) = await Fixture();
 
         var baseline = await LiteralQueryResults($"{host}/Deal");
         Output.WriteLine($"retired literals for {host}/Deal returned {baseline.Count}: "
@@ -149,7 +150,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
     public async Task TheRenderedCreateFormOffersATypeTheParentDeclaresInAnotherPartition()
     {
-        var (types, host) = await Fixture();
+        var (types, host, _) = await Fixture();
 
         var declaring = await RenderedTypePicker($"{host}/Deal");
         var offered = PickerPaths(declaring);
@@ -178,7 +179,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
     public async Task ADeclarationRestrictsDiscovery_AndIncludeGlobalTypesDecidesTheGlobals()
     {
-        var (types, host) = await Fixture();
+        var (types, host, _) = await Fixture();
         var globals = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>().GlobalCreatableTypes;
         globals.Should().NotBeEmpty("the global set is the thing IncludeGlobalTypes switches off");
 
@@ -200,14 +201,21 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
 
     /// <summary>
     /// A NodeType that opted out of the create context (<c>ExcludeFromContext: ["create"]</c> —
-    /// Release, Build, ModuleBuild, Partition) is never offered. The retired form filtered these
-    /// out of both its Items and its queries; the provider did not, and would have started offering
-    /// four uncreatable types the moment it was wired up.
+    /// Release, Build, ModuleBuild, Partition) is never offered — not by discovery, and not when a
+    /// parent's <c>CreatableTypes</c> NAMES it. The retired form filtered these out of both its
+    /// Items and its queries; the provider did not, and would have started offering four
+    /// uncreatable types the moment it was wired up.
+    ///
+    /// <para>🚨 The whitelist half is the one that reads as a judgement call and is not: the type's
+    /// own opt-out is the platform saying instances of it are made by the platform, so a module
+    /// author naming it cannot resurrect it. Both config sources — the parent's
+    /// <c>CreatableTypes</c> and the host's <c>GlobalCreatableTypes</c> — resolve through the same
+    /// exclusion-aware lookup.</para>
     /// </summary>
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
     public async Task ATypeThatOptedOutOfTheCreateContextIsNeverOffered()
     {
-        var (_, host) = await Fixture();
+        var (_, host, declaredButOptedOut) = await Fixture();
 
         var optedOut = Mesh.ServiceProvider.EnumerateStaticNodes()
             .Where(n => n.IsExcludedFromContext(MeshContexts.Create))
@@ -220,6 +228,49 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
         offered.Intersect(optedOut).OrderBy(x => x).Should().BeEmpty(
             "ExcludeFromContext: [\"create\"] is how a type says it is not creatable — the Create "
             + "menu is the one surface that must honour it");
+
+        // The declaring parent NAMES it in CreatableTypes, and it is still withheld.
+        var declaring = await Offered($"{host}/Deal");
+        declaring.Should().NotContain(declaredButOptedOut,
+            "the parent's CreatableTypes names {0}, which opted out of context:create — a "
+            + "whitelist ADDS types the queries could not reach, it does not overrule a type's own "
+            + "statement that it is not created by hand", declaredButOptedOut);
+    }
+
+    /// <summary>
+    /// 🚨 THE PICKER IS NOT THE ENFORCEMENT POINT — the form's <c>type</c> VALUE is, and it must
+    /// agree with what the parent allows.
+    ///
+    /// <para>The value is seeded several sections before <see cref="ICreatableTypesProvider"/> has
+    /// answered (from <c>?type=</c>, the current node, or <c>"Markdown"</c>) — it cannot be
+    /// otherwise, the answer is reactive — and the Create button reads THAT, never the picker's
+    /// items. So a parent declaring <c>CreatableTypes</c> with <c>IncludeGlobalTypes = false</c>
+    /// would render a picker holding only its declared types and still create <c>Markdown</c> for
+    /// anyone who submitted without touching the field: the menu would honour the declaration and
+    /// the write would not.</para>
+    ///
+    /// <para>Non-vacuous by construction: the seed for this node IS <c>Markdown</c> (its type is
+    /// not a NodeType and no <c>?type=</c> is given) and the parent excludes the globals, so before
+    /// the alignment the submitted value was a type the picker does not offer.</para>
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task TheFormNeverSubmitsATypeThePickerWithholds()
+    {
+        var (types, host, _) = await Fixture();
+
+        var (stream, picker) = await RenderedCreateForm($"{host}/Sealed");
+        var offered = PickerPaths(picker);
+        var submitted = await SubmittedType(stream, picker);
+        Output.WriteLine($"offered: {string.Join(", ", offered.OrderBy(x => x))} | submitted: '{submitted}'");
+
+        offered.Should().NotContain("Markdown",
+            "the parent declares CreatableTypes and IncludeGlobalTypes=false, so the seeded default "
+            + "is NOT among the offered types — which is what makes this a measurement");
+        offered.Should().Contain(submitted,
+            "the value the Create button reads must be one the parent allows; a picker that "
+            + "withholds a type while the form still submits it enforces nothing");
+        submitted.Should().Be($"{types}/Question",
+            "with one allowed type it is the one selected — the person sees what will be created");
     }
 
     // ── fixture ────────────────────────────────────────────────────────────────────────────────
@@ -228,10 +279,20 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     /// Two partitions, mirroring <c>Crm</c> + <c>PearlTechnology</c>: the TYPES live in one and the
     /// INSTANCES in the other, so a declared type is provably outside the instance's ancestor chain.
     /// </summary>
-    private async Task<(string Types, string Host)> Fixture()
+    private async Task<(string Types, string Host, string OptedOut)> Fixture()
     {
         var types = "Ct" + Guid.NewGuid().ToString("N")[..8];
         var host = "Ho" + Guid.NewGuid().ToString("N")[..8];
+
+        // A platform type that declares `ExcludeFromContext: ["create"]` — Release, Build,
+        // ModuleBuild, Partition. Taken from the running mesh rather than written as a literal, so
+        // the test follows the platform if the set changes; the assertion that it is non-empty is
+        // in ATypeThatOptedOutOfTheCreateContextIsNeverOffered.
+        var optedOut = Mesh.ServiceProvider.EnumerateStaticNodes()
+            .Where(n => n.IsExcludedFromContext(MeshContexts.Create))
+            .Select(n => n.Path)
+            .OrderBy(p => p, StringComparer.OrdinalIgnoreCase)
+            .First();
 
         await Import(new FakeRepoSource(types)
         {
@@ -244,10 +305,12 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
                 TypeNode($"{types}/Widget", "Part", new NodeTypeDefinition { Configuration = "config => config" }),
                 // The Crm/Offer shape: declares a type in its own partition, which is NOT in the
                 // ancestor chain of the instances that carry this type.
+                // It also names a type that opted OUT of being created, which the type's own
+                // opt-out must beat — a whitelist cannot resurrect an uncreatable type.
                 TypeNode(types, "Offer", new NodeTypeDefinition
                 {
                     Configuration = "config => config",
-                    CreatableTypes = [$"{types}/Question"],
+                    CreatableTypes = [$"{types}/Question", optedOut],
                 }),
                 // Same, with the globals switched off.
                 TypeNode(types, "SealedOffer", new NodeTypeDefinition
@@ -274,7 +337,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             ],
         });
 
-        return (types, host);
+        return (types, host, optedOut);
     }
 
     private async Task Import(FakeRepoSource source)
@@ -322,7 +385,8 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     /// returned. Every child area is subscribed at once so a sibling that has not rendered yet
     /// cannot hold the read.
     /// </summary>
-    private async Task<MeshNodePickerControl> RenderedTypePicker(string nodePath)
+    private async Task<(ISynchronizationStream<JsonElement> Stream, MeshNodePickerControl Picker)>
+        RenderedCreateForm(string nodePath)
     {
         var reference = new LayoutAreaReference(MeshNodeLayoutAreas.CreateNodeArea);
         var stream = GetClient().GetWorkspace()
@@ -338,10 +402,28 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             .Select(a => stream.GetControlStream(a!))
             .ToArray();
 
-        return await Observable.Merge(areas)
+        var picker = await Observable.Merge(areas)
             .OfType<MeshNodePickerControl>()
             .Where(IsTypePicker)
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        return (stream, picker);
+    }
+
+    private async Task<MeshNodePickerControl> RenderedTypePicker(string nodePath)
+        => (await RenderedCreateForm(nodePath)).Picker;
+
+    /// <summary>
+    /// The value the Create button would SUBMIT — the form's own <c>type</c> field, read off the
+    /// rendered area's data at the pointer the picker is bound to. This is the value
+    /// <c>CreateLayoutArea</c>'s click handler reads; the picker's item list is only what a person
+    /// is shown.
+    /// </summary>
+    private static async Task<string> SubmittedType(
+        ISynchronizationStream<JsonElement> stream, MeshNodePickerControl picker)
+    {
+        var pointer = $"{picker.DataContext}/type";
+        return await stream.GetDataStream<string>(new JsonPointerReference(pointer))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await() ?? "";
     }
 
     private static bool IsTypePicker(MeshNodePickerControl picker) =>
@@ -377,7 +459,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     {
         public string Partition => partition;
         public bool Versioned => false;
-        public List<MeshNode> Nodes { get; set; } = [];
+        public ImmutableList<MeshNode> Nodes { get; init; } = [];
         public MeshNode? Root { get; set; }
         public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
         public MeshNode? PartitionRoot => Root;


### PR DESCRIPTION
Follow-up to #4070 (same issue, #4040). **#4070 auto-merged on its first commit while this commit
was still being verified**, so `main` currently carries the half of the fix that restricts the MENU
without the half that restricts the WRITE. This lands the remainder.

Three findings from #4070's Copilot review, all real, plus one the bare-`Subscribe` ratchet caught
locally.

## 1. 🚨 The picker was not the enforcement point — the form's `type` VALUE is

The Create button reads `form["type"]`, never the picker's item list, and that value is seeded
before `ICreatableTypesProvider` has answered (it cannot be otherwise — the answer is reactive).
So as `main` stands, a parent declaring `CreatableTypes` with `IncludeGlobalTypes: false` renders a
picker holding only its declared types **and still creates `Markdown`** for anyone who submits
without touching the field. The menu honours the declaration and the write ignores it — #4040
half-fixed. A `?type=` URL naming an excluded type does the same.

The form now moves the seeded value (and the icon that came with it) onto the first offered type, or
clears it when the parent offers none so the Required field blocks the submit.

`TheFormNeverSubmitsATypeThePickerWithholds` pins it, and was **falsified before being accepted** —
with the alignment disabled it fails with
`Expected collection {"Ct…/Question"} to contain "Markdown"`, i.e. the picker offering only the
declared type while the form would submit `Markdown`.

## 2. A list could resurrect a type that opted out of being created

`CreatableTypes` and `GlobalCreatableTypes` entries resolved through a lookup that skipped the
`context:create` opt-out, so a list naming `Partition` offered it — contradicting the rule #4070
documents and tests. A type's own `ExcludeFromContext: ["create"]` now beats a list that names it: a
whitelist ADDS types the queries could not reach, it does not overrule a type's statement that its
instances are made by the platform rather than by a person. The fixture declares one (taken from the
running mesh, not written as a literal) and asserts it stays withheld.

## 3. Mutable collection in the test fixture

`List<MeshNode>` → `ImmutableList<MeshNode>`, per the repository's collections policy.

## 4. `SubscribeErrorArmRatchetGuard` — 95 against a baseline of 94

The new alignment used a bare `.Subscribe(onNext)`. Rx rethrows a fault out of an `onNext` delegate
onto the scheduler's thread, where nothing catches it — an unhandled exception that ends the process
(#2666: the `Passed! - Failed: 0` shard that reds anyway). It now carries an `onError` that logs and
leaves the picker as it is; a form that cannot read its own seed must not take the host down.

Local: `MeshWeaver.Graph.Test` 1558/1558, `MeshWeaver.Documentation.Test` 432/432 (link integrity,
What's New, and the ratchet guards). Release `-warnaserror` clean on every touched project.

Pairs-with: none — no public type or member leaves `src/`.

Mirror-sync: none — this change adds no catalog key (#4070 carried the one new key,
`create.selectType`, with its handover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFBiMVHLTZM2axNgVvaZN2
