### PR TITLE
#4040 review 2: the runtime opt-out needs a read, and the pinned-URL shape needs the same branch

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
@@ -23,20 +23,31 @@ The picker therefore carries **items and no queries**. That is not a style choic
 set, so a query alongside the provider would re-admit by discovery exactly what a restricting
 parent excluded.
 
-🚨 **The picker is not the enforcement point — the form's `type` VALUE is.** The Create button reads
-`form["type"]`, never the picker's item list, and that value is seeded before the provider has
-answered (it cannot be otherwise — the answer is reactive). So when the resolved offer does not
-contain the seed, the form replaces it with the first offered type, or with nothing when the parent
-offers none, so a Required field blocks the submit. Without that, a parent declaring
+🚨 **Within the form, the picker is not the deciding surface — the `type` VALUE is.** The Create
+button reads `form["type"]`, never the picker's item list, and that value is seeded before the
+provider has answered (it cannot be otherwise — the answer is reactive). So when the resolved offer
+does not contain the seed, the form replaces it with the first offered type, or with nothing when
+the parent offers none, so a Required field blocks the submit. Without that, a parent declaring
 `CreatableTypes` with `IncludeGlobalTypes: false` would render a picker holding only its declared
 types and still create `Markdown` for anyone who submitted without touching the field — the menu
 honouring the declaration and the write ignoring it.
 
+🚨 **But say plainly what this is: CURATION, not access control.** `CreatableTypes` shapes what the
+Create form offers and submits. It is **not** enforced at the create boundary — `CreateNodeRequest`
+runs the permission pipeline and `NodeTypeResolution`, and asks nothing about the parent's
+declaration. A caller that posts a create directly, or forges the form's `/data` value, can still
+create a type the parent does not list; what stops them creating anything at all is
+`Permission.Create`, which is the actual control. Do not reach for `CreatableTypes` to keep a type
+out of a partition — reach for permissions.
+
 🚨 **Both shapes of the field come out of the same resolved set**, and that is why the type field is
-one branch rather than two. A pinned single type (`?type=X`, or `?types=X` from the MeshSearch "+"
-button) renders as a read-only label — but only when the parent allows it. The label used to render
-without asking the provider at all, which made a URL parameter a way around the parent's
-declaration: it seeded the type, presented it as settled, and submitted it.
+one branch rather than two. `?types=X` (the MeshSearch "+" button) RESTRICTS: a single value renders
+as a read-only label, and only when the parent allows it — the label used to render without asking
+the provider at all, which made a URL parameter a way around the parent's declaration. `?type=X`
+(the NodeType page's Create link) only PRE-SELECTS: the full picker still renders, restricted to
+what the parent allows, and the pre-selected value is replaced when the parent does not allow it.
+The two parameters have always differed this way; the restriction holds for both because both come
+out of the same resolved set.
 
 ## The resolution rule
 
@@ -117,6 +128,13 @@ is deliberate), and a point read of an absent node answers a routing NotFound th
 stream and opens the storm-breaker on that path; a `path:a|b|c` alternation names no first segment
 and would fan out over every schema (#3202). One path per query keeps each anchored on its own
 partition.
+
+🚨 **Three outcomes, not two.** That per-path lookup distinguishes *the node* from *a confirmed
+absence* from *a probe that did not complete*, and the third fails CLOSED. Folding a timeout or a
+fault into "no such node" would synthesise the entry and offer a type whose opt-out simply could not
+be read — the opt-out holding while storage is healthy and lapsing under load, which is the one
+condition it most needs to hold under. A host with no query core at all is a configuration fact, not
+a failure: it has no persisted nodes, so every declared non-static path is a confirmed absence.
 
 The exclusion itself is `MeshConfiguration.IsExcludedFromContext(node.NodeType, "create")` **or**
 the node's own `ExcludeFromContext` — the same two halves every query backend applies, written once

--- a/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CreatableTypes.md
@@ -32,6 +32,12 @@ offers none, so a Required field blocks the submit. Without that, a parent decla
 types and still create `Markdown` for anyone who submitted without touching the field — the menu
 honouring the declaration and the write ignoring it.
 
+🚨 **Both shapes of the field come out of the same resolved set**, and that is why the type field is
+one branch rather than two. A pinned single type (`?type=X`, or `?types=X` from the MeshSearch "+"
+button) renders as a read-only label — but only when the parent allows it. The label used to render
+without asking the provider at all, which made a URL parameter a way around the parent's
+declaration: it seeded the type, presented it as settled, and submitted it.
+
 ## The resolution rule
 
 Four sources are merged, deduplicated by NodeType path, and ordered by `Order` then name.
@@ -100,7 +106,24 @@ legs.
 exclusion-aware lookup, so a parent's `CreatableTypes` — or a host's `GlobalCreatableTypes` —
 naming `Partition` does not resurrect it. A whitelist ADDS types the queries could not reach; it
 does not overrule a type's own statement that instances of it are made by the platform rather than
-by a person. See [Query Syntax](/Doc/DataMesh/QuerySyntax) for the `context:` qualifier and the other contexts.
+by a person.
+
+That holds for a RUNTIME NodeType too, and it costs a read to make true. A platform type's opt-out
+is visible in the static registry with no I/O; a persisted type carries it on its node, where the
+create-filtered queries see it and this path would not. So the paths a config source NAMES and the
+static registry does not hold — and only those — are looked up: **one anchored `path:` query each,
+never a point read.** A declared type may legitimately not exist yet (synthesising an entry for it
+is deliberate), and a point read of an absent node answers a routing NotFound that terminates the
+stream and opens the storm-breaker on that path; a `path:a|b|c` alternation names no first segment
+and would fan out over every schema (#3202). One path per query keeps each anchored on its own
+partition.
+
+The exclusion itself is `MeshConfiguration.IsExcludedFromContext(node.NodeType, "create")` **or**
+the node's own `ExcludeFromContext` — the same two halves every query backend applies, written once
+so the menu and the queries feeding it cannot answer differently. Applying only the second half is
+what let the retired form pass 25 *instances* of opted-out types (every `*/_Access/Public_Access`,
+the `Admin/Partition/*` records, the `*/_Policy` nodes, the `Templates/Import/*` templates) into a
+picker that is supposed to list types. See [Query Syntax](/Doc/DataMesh/QuerySyntax) for the `context:` qualifier and the other contexts.
 
 ## Two rules that look like details and are not
 

--- a/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
+++ b/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
@@ -79,8 +79,12 @@ internal sealed class CreatableTypesProvider(
         // GetMeshNodeStream lookup on top of the type-node query.
         var parentDefObs = ResolveParentNodeTypeDefinition(currentType);
 
-        var typesObs = typeNodesObs.CombineLatest(parentDefObs, (typeNodes, parentDef) =>
-            BuildInfos(typeNodes, meshConfiguration, hub.ServiceProvider, currentType, parentDef, hub.JsonSerializerOptions));
+        var typesObs = typeNodesObs
+            .CombineLatest(parentDefObs, (typeNodes, parentDef) => (typeNodes, parentDef))
+            .SelectMany(x => ResolveDeclaredTypeNodes(meshQueryCore, x.parentDef)
+                .Select(declared => BuildInfos(
+                    x.typeNodes, declared, meshConfiguration, hub.ServiceProvider,
+                    currentType, x.parentDef, hub.JsonSerializerOptions)));
 
         // Outer security gate: only apply Create-permission filter for a
         // specific parent path. Root listing (nodePath == "") is global
@@ -190,6 +194,62 @@ internal sealed class CreatableTypesProvider(
     }
 
     /// <summary>
+    /// The nodes behind the type paths a CONFIG source NAMES — <see cref="NodeTypeDefinition.CreatableTypes"/>
+    /// on the parent type and <see cref="MeshConfiguration.GlobalCreatableTypes"/> — restricted to
+    /// the ones the static registry does not already hold, keyed by path.
+    ///
+    /// <para>🚨 <b>Why this read exists.</b> A named path is added by
+    /// <see cref="BuildInfoFromConfig"/> whether or not any query returned it — that is the whole
+    /// point of a declaration, it reaches types no namespace-scoped query can. But a RUNTIME
+    /// NodeType can carry <c>ExcludeFromContext: ["create"]</c> just as a platform one does, and
+    /// without its node in hand that opt-out is invisible here: the create-filtered queries
+    /// correctly omit the type and this path would synthesise it straight back in. So the paths a
+    /// config source names, and only those, are looked up.</para>
+    ///
+    /// <para>🚨 <b>One anchored QUERY per path, never a point read.</b> A declared type MAY NOT
+    /// EXIST — synthesising an entry for a path the mesh does not have yet is deliberate — and a
+    /// point read of an absent node answers a routing NotFound that terminates the stream AND opens
+    /// the storm-breaker on that path (Doc/Architecture/CqrsAndContentAccess). A <c>path:</c> query
+    /// answers zero rows instead. One path per query keeps each one ANCHORED on its own partition;
+    /// a <c>path:a|b|c</c> alternation names no first segment and would fan out over every schema
+    /// (#3202).</para>
+    /// </summary>
+    private IObservable<ImmutableDictionary<string, MeshNode>> ResolveDeclaredTypeNodes(
+        IMeshQueryCore? meshQueryCore, NodeTypeDefinition? parentDef)
+    {
+        var empty = ImmutableDictionary<string, MeshNode>.Empty
+            .WithComparers(StringComparer.OrdinalIgnoreCase);
+        if (meshQueryCore is null)
+            return Observable.Return(empty);
+
+        var declared = (parentDef?.CreatableTypes ?? [])
+            .Concat(meshConfiguration.GlobalCreatableTypes)
+            .Where(p => !string.IsNullOrWhiteSpace(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            // A static registration carries its own ExcludeFromContext in memory — no read needed,
+            // and every platform type that opts out of create is one of those.
+            .Where(p => hub.ServiceProvider.FindStaticNode(p) is null)
+            .ToArray();
+        if (declared.Length == 0)
+            return Observable.Return(empty);
+
+        var lookups = declared.Select(path => meshQueryCore
+            .Query<MeshNode>(
+                MeshQueryRequest.FromQuery($"path:{path} nodeType:NodeType"),
+                hub.JsonSerializerOptions)
+            .Take(1)
+            // Same deadlock guard as QueryTypeNodes: a query that never emits its Initial frame
+            // must not hold the Aggregate below open for ever.
+            .Timeout(TimeSpan.FromSeconds(15), Observable.Empty<QueryResultChange<MeshNode>>())
+            .Catch<QueryResultChange<MeshNode>, Exception>(
+                _ => Observable.Empty<QueryResultChange<MeshNode>>()));
+
+        return Observable.Merge(lookups)
+            .SelectMany(change => change.Items)
+            .Aggregate(empty, (acc, node) => acc.SetItem(node.Path, node));
+    }
+
+    /// <summary>
     /// Resolves the <see cref="NodeTypeDefinition"/> for <paramref name="currentType"/>.
     /// Static config (built-in types) first, then a live
     /// <c>GetMeshNodeStream</c> lookup so RUNTIME NodeTypes — which are not in
@@ -215,6 +275,7 @@ internal sealed class CreatableTypesProvider(
 
     private static IReadOnlyList<CreatableTypeInfo> BuildInfos(
         IReadOnlyList<MeshNode> queryNodes,
+        ImmutableDictionary<string, MeshNode> declaredNodes,
         MeshConfiguration meshConfiguration,
         IServiceProvider serviceProvider,
         string? currentType,
@@ -256,7 +317,7 @@ internal sealed class CreatableTypesProvider(
         //    registered, minus what opted out of `context:create`.
         foreach (var typeNode in serviceProvider.EnumerateStaticNodes())
         {
-            if (typeNode.IsExcludedFromContext(MeshContexts.Create)) continue;
+            if (IsExcludedFromCreate(typeNode, meshConfiguration)) continue;
             if (!Allowed(typeNode.Path)) continue;
             if (!added.Add(typeNode.Path)) continue;
             result.Add(BuildInfoFromMeshNode(typeNode, options));
@@ -274,7 +335,8 @@ internal sealed class CreatableTypesProvider(
                 foreach (var typePath in parentDef.CreatableTypes)
                 {
                     if (!added.Add(typePath)) continue;
-                    var info = BuildInfoFromConfig(typePath, serviceProvider, options);
+                    var info = BuildInfoFromConfig(
+                        typePath, declaredNodes, meshConfiguration, serviceProvider, options);
                     if (info is not null) result.Add(info);
                 }
             }
@@ -286,7 +348,8 @@ internal sealed class CreatableTypesProvider(
             foreach (var typePath in meshConfiguration.GlobalCreatableTypes)
             {
                 if (!added.Add(typePath)) continue;
-                var info = BuildInfoFromConfig(typePath, serviceProvider, options);
+                var info = BuildInfoFromConfig(
+                    typePath, declaredNodes, meshConfiguration, serviceProvider, options);
                 if (info is not null) result.Add(info);
             }
         }
@@ -299,6 +362,17 @@ internal sealed class CreatableTypesProvider(
             .ThenBy(x => x.DisplayName ?? x.NodeTypePath, StringComparer.OrdinalIgnoreCase)
             .ToList();
     }
+
+    /// <summary>
+    /// 🚨 THE create-context exclusion, in the same two halves every query backend applies
+    /// (<c>StorageAdapterMeshQueryProvider.IsExcludedByContext</c> /
+    /// <c>StaticNodeQueryProvider.IsExcludedByContext</c>): the TYPE-level map built from the
+    /// registered nodes, then the node's own <see cref="MeshNode.ExcludeFromContext"/>. Written
+    /// once here so the menu and the queries that feed it cannot answer differently.
+    /// </summary>
+    private static bool IsExcludedFromCreate(MeshNode node, MeshConfiguration meshConfiguration) =>
+        meshConfiguration.IsExcludedFromContext(node.NodeType, MeshContexts.Create)
+        || node.IsExcludedFromContext(MeshContexts.Create);
 
     private static CreatableTypeInfo BuildInfoFromMeshNode(MeshNode node, System.Text.Json.JsonSerializerOptions options)
     {
@@ -326,11 +400,19 @@ internal sealed class CreatableTypesProvider(
     /// static registry, which is where every platform type that declares one lives.</para>
     /// </summary>
     private static CreatableTypeInfo? BuildInfoFromConfig(
-        string typePath, IServiceProvider serviceProvider, System.Text.Json.JsonSerializerOptions options)
+        string typePath,
+        ImmutableDictionary<string, MeshNode> declaredNodes,
+        MeshConfiguration meshConfiguration,
+        IServiceProvider serviceProvider,
+        System.Text.Json.JsonSerializerOptions options)
     {
-        var node = serviceProvider.FindStaticNode(typePath);
+        // Static first (no read), then the node the declared-path lookup found. A path neither
+        // holds is one the mesh does not have — synthesised below, deliberately: a declaration may
+        // name a type an import has not landed yet.
+        var node = serviceProvider.FindStaticNode(typePath)
+                   ?? declaredNodes.GetValueOrDefault(typePath);
         if (node is not null)
-            return node.IsExcludedFromContext(MeshContexts.Create)
+            return IsExcludedFromCreate(node, meshConfiguration)
                 ? null
                 : BuildInfoFromMeshNode(node, options);
         return new CreatableTypeInfo(

--- a/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
+++ b/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
@@ -214,16 +214,19 @@ internal sealed class CreatableTypesProvider(
     /// a <c>path:a|b|c</c> alternation names no first segment and would fan out over every schema
     /// (#3202).</para>
     /// </summary>
-    private IObservable<ImmutableDictionary<string, MeshNode>> ResolveDeclaredTypeNodes(
+    private IObservable<ImmutableDictionary<string, MeshNode?>> ResolveDeclaredTypeNodes(
         IMeshQueryCore? meshQueryCore, NodeTypeDefinition? parentDef)
     {
-        var empty = ImmutableDictionary<string, MeshNode>.Empty
+        var empty = ImmutableDictionary<string, MeshNode?>.Empty
             .WithComparers(StringComparer.OrdinalIgnoreCase);
-        if (meshQueryCore is null)
-            return Observable.Return(empty);
 
+        // 🚨 The globals are probed only when they will be USED. A parent with
+        // IncludeGlobalTypes = false never displays them, and BuildInfos drops them either way —
+        // probing them anyway would spend a query and a 15 s timeout budget per global path on
+        // every render of a sealed parent's Create form.
+        var includeGlobal = parentDef?.IncludeGlobalTypes ?? true;
         var declared = (parentDef?.CreatableTypes ?? [])
-            .Concat(meshConfiguration.GlobalCreatableTypes)
+            .Concat(includeGlobal ? meshConfiguration.GlobalCreatableTypes : [])
             .Where(p => !string.IsNullOrWhiteSpace(p))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             // A static registration carries its own ExcludeFromContext in memory — no read needed,
@@ -233,20 +236,31 @@ internal sealed class CreatableTypesProvider(
         if (declared.Length == 0)
             return Observable.Return(empty);
 
+        // No query core at all is a CONFIGURATION fact, not a failure: a host without one has no
+        // persisted nodes, so a declared path that is not static provably does not exist and the
+        // forgiving synthesis is the right answer. Recorded as CONFIRMED ABSENT, never as unknown.
+        if (meshQueryCore is null)
+            return Observable.Return(
+                declared.Aggregate(empty, (acc, path) => acc.SetItem(path, null)));
+
         var lookups = declared.Select(path => meshQueryCore
             .Query<MeshNode>(
                 MeshQueryRequest.FromQuery($"path:{path} nodeType:NodeType"),
                 hub.JsonSerializerOptions)
             .Take(1)
-            // Same deadlock guard as QueryTypeNodes: a query that never emits its Initial frame
-            // must not hold the Aggregate below open for ever.
-            .Timeout(TimeSpan.FromSeconds(15), Observable.Empty<QueryResultChange<MeshNode>>())
-            .Catch<QueryResultChange<MeshNode>, Exception>(
-                _ => Observable.Empty<QueryResultChange<MeshNode>>()));
+            .Select(change => (path, node: change.Items.FirstOrDefault(), probed: true))
+            // 🚨 A PROBE THAT DID NOT COMPLETE IS NOT AN ANSWER. Folding a timeout or a fault into
+            // the same "no row" the successful empty query produces would make a transient read
+            // failure OFFER the very type this read exists to withhold — the opt-out would hold
+            // when storage is healthy and lapse exactly when it is not. `probed: false` keeps the
+            // two apart and BuildInfoFromConfig fails closed on it.
+            .Timeout(TimeSpan.FromSeconds(15),
+                Observable.Return((path, node: (MeshNode?)null, probed: false)))
+            .Catch<(string path, MeshNode? node, bool probed), Exception>(
+                _ => Observable.Return((path, node: (MeshNode?)null, probed: false))));
 
         return Observable.Merge(lookups)
-            .SelectMany(change => change.Items)
-            .Aggregate(empty, (acc, node) => acc.SetItem(node.Path, node));
+            .Aggregate(empty, (acc, x) => x.probed ? acc.SetItem(x.path, x.node) : acc);
     }
 
     /// <summary>
@@ -275,7 +289,7 @@ internal sealed class CreatableTypesProvider(
 
     private static IReadOnlyList<CreatableTypeInfo> BuildInfos(
         IReadOnlyList<MeshNode> queryNodes,
-        ImmutableDictionary<string, MeshNode> declaredNodes,
+        ImmutableDictionary<string, MeshNode?> declaredNodes,
         MeshConfiguration meshConfiguration,
         IServiceProvider serviceProvider,
         string? currentType,
@@ -399,22 +413,34 @@ internal sealed class CreatableTypesProvider(
     /// would be a hole in the one rule this provider exists to apply. The opt-out is read from the
     /// static registry, which is where every platform type that declares one lives.</para>
     /// </summary>
-    private static CreatableTypeInfo? BuildInfoFromConfig(
+    internal static CreatableTypeInfo? BuildInfoFromConfig(
         string typePath,
-        ImmutableDictionary<string, MeshNode> declaredNodes,
+        ImmutableDictionary<string, MeshNode?> declaredNodes,
         MeshConfiguration meshConfiguration,
         IServiceProvider serviceProvider,
         System.Text.Json.JsonSerializerOptions options)
     {
-        // Static first (no read), then the node the declared-path lookup found. A path neither
-        // holds is one the mesh does not have — synthesised below, deliberately: a declaration may
-        // name a type an import has not landed yet.
-        var node = serviceProvider.FindStaticNode(typePath)
-                   ?? declaredNodes.GetValueOrDefault(typePath);
-        if (node is not null)
-            return IsExcludedFromCreate(node, meshConfiguration)
+        // 1. Static registration — resolved with no read at all.
+        var staticNode = serviceProvider.FindStaticNode(typePath);
+        if (staticNode is not null)
+            return IsExcludedFromCreate(staticNode, meshConfiguration)
                 ? null
-                : BuildInfoFromMeshNode(node, options);
+                : BuildInfoFromMeshNode(staticNode, options);
+
+        // 2. 🚨 THREE OUTCOMES, NOT TWO. A key PRESENT means the probe completed and its answer
+        //    stands; a key ABSENT means the probe did not complete, which is UNKNOWN — and
+        //    unknown fails CLOSED. Treating unknown as "no such node" would synthesise the entry
+        //    and offer a type whose opt-out simply could not be read, which is the failure this
+        //    lookup was added to prevent, arriving only under load.
+        if (!declaredNodes.TryGetValue(typePath, out var probed))
+            return null;
+        if (probed is not null)
+            return IsExcludedFromCreate(probed, meshConfiguration)
+                ? null
+                : BuildInfoFromMeshNode(probed, options);
+
+        // 3. Confirmed absent: the declaration names a type the mesh does not have yet. Offering
+        //    it is deliberate — a declaration may precede the import that lands the type.
         return new CreatableTypeInfo(
             NodeTypePath: typePath,
             DisplayName: GetLastSegment(typePath),

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -454,19 +454,7 @@ public static class CreateLayoutArea
         stack = stack.WithView(Controls.Body(host.Localize("create.autoGenIdHint"))
             .WithStyle("color: var(--neutral-foreground-hint); font-size: 12px; margin-bottom: 16px;"));
 
-        // 6. Type picker (or readonly label if restricted to single value)
-        if (restrictedTypes is { Length: 1 })
-        {
-            // Single type restriction — show readonly info
-            var typeNode = host.Hub.ServiceProvider.FindStaticNode(restrictedTypes[0]);
-            var typeLabel = typeNode?.Name ?? restrictedTypes[0];
-            stack = stack.WithView(Controls.Stack
-                .WithWidth("100%")
-                .WithStyle("margin-bottom: 16px;")
-                .WithView(Controls.Body(host.Localize("ui.type")).WithStyle("font-weight: 600; margin-bottom: 4px;"))
-                .WithView(Controls.Body(typeLabel).WithStyle("color: var(--neutral-foreground-rest);")));
-        }
-        else
+        // 6. Type field — read-only label when one allowed type is pinned, picker otherwise.
         {
             // 🚨 WHAT MAY BE CREATED HERE IS ICreatableTypesProvider'S ANSWER — this form does
             // not build a second one (#4040). It used to run two query literals of its own
@@ -482,6 +470,12 @@ public static class CreateLayoutArea
             // queries, the parent type's own whitelist (which RESTRICTS discovery as well as
             // EXTENDING it), and the global set. The picker therefore carries ITEMS and no
             // queries — a query leg would re-admit exactly what a restricting parent excluded.
+            //
+            // 🚨 ONE branch, on purpose. The single-type shape (`?type=X` / `?types=X`, the
+            // MeshSearch "+" button) used to render a read-only label WITHOUT asking the provider
+            // at all — so a URL naming a type the parent forbids seeded that type, showed it as a
+            // fait accompli, and submitted it. Both shapes of this field now come out of the same
+            // resolved set, and the alignment below runs for both.
             var creatableTypes = host.Hub.ServiceProvider
                 .GetRequiredService<ICreatableTypesProvider>()
                 .GetCreatableTypes(parentPath, currentNode);
@@ -494,10 +488,23 @@ public static class CreateLayoutArea
                 // 🚨 The SEEDED default has to become one the parent allows. `type` was seeded
                 // several sections above (from ?type=, the current node, or "Markdown") — before
                 // anything knew what this parent permits — and the SUBMIT reads that value, not
-                // the picker's contents. So a restricting parent would render a picker offering
-                // only its declared types while a user who never touched the field still created
-                // the stale default. The restriction has to hold on the path that WRITES.
+                // the picker's contents. So a restricting parent would render a field offering
+                // only its declared types while a user who never touched it still created the
+                // stale default. The restriction has to hold on the path that WRITES.
                 AlignSeededTypeWithOffer(h, formId, offered);
+
+                // A pinned type the parent ALLOWS needs no picker — show it and move on. When the
+                // parent does not allow it, `offered` is empty and the picker below renders with
+                // nothing to choose, which is the honest answer: this type cannot be created here.
+                if (restrictedTypes is { Length: 1 } && offered.Length == 1)
+                    return (UiControl)Controls.Stack
+                        .WithWidth("100%")
+                        .WithStyle("margin-bottom: 16px;")
+                        .WithView(Controls.Body(host.Localize("ui.type"))
+                            .WithStyle("font-weight: 600; margin-bottom: 4px;"))
+                        .WithView(Controls.Body(offered[0].DisplayName ?? offered[0].NodeTypePath)
+                            .WithStyle("color: var(--neutral-foreground-rest);"));
+
                 return (UiControl)new MeshNodePickerControl(new JsonPointerReference("type"))
                 {
                     Label = host.Localize("ui.typeRequired"),

--- a/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
@@ -93,8 +93,17 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             "the runtime NodeType in the instance's own partition is what the ancestor-scoped leg is FOR — "
             + "without it in the baseline this comparison is not measuring the query legs at all");
 
+        // The static registrations, under the SAME create-context rule every query backend applies
+        // — the type-level map plus the node's own opt-out. The retired form applied only the
+        // second half to its fixed Items, so it also offered 25 INSTANCES whose type had opted out
+        // (every `*/_Access/Public_Access`, the `Admin/Partition/*` records, the `*/_Policy`
+        // nodes, the `Templates/Import/*` code templates). Not one of them is a type declaration,
+        // and dropping them is the menu and its own query legs finally agreeing; the named
+        // assertion below is what makes sure no TYPE went with them.
+        var config = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>();
         var staticItems = Mesh.ServiceProvider.EnumerateStaticNodes()
-            .Where(n => !n.IsExcludedFromContext(MeshContexts.Create))
+            .Where(n => !config.IsExcludedFromContext(n.NodeType, MeshContexts.Create)
+                        && !n.IsExcludedFromContext(MeshContexts.Create))
             .Select(n => n.Path)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
         staticItems.Should().NotBeEmpty("the form passed these as the picker's fixed Items");
@@ -108,9 +117,17 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             + "silently disappeared, which is #4040 pointed the other way");
         staticItems.Except(offered).OrderBy(x => x).Should().BeEmpty(
             "the static registrations the form handed the picker as fixed Items are the bulk of the "
-            + "menu (Markdown, Group, Role, Redirect, UiContribution, HomeTab, License, WhatsNew — "
-            + "none of which carries NodeType=\"NodeType\", which is why filtering on that stamp "
-            + "kept 7 of 42)");
+            + "menu");
+
+        // 🚨 NAMED, so the assertion above cannot pass by moving with the implementation. These
+        // are platform TYPE REGISTRATIONS and every one of them carries NO NodeType stamp at all —
+        // `AddMeshNodes(new MeshNode("Group") { HubConfiguration = … })` — which is why filtering
+        // the static bucket on `NodeType == "NodeType"` kept 7 of 42 and silently dropped them.
+        string[] platformTypes =
+            ["Markdown", "Group", "Role", "Redirect", "UiContribution", "HomeTab", "License", "WhatsNew"];
+        platformTypes.Except(offered).OrderBy(x => x).Should().BeEmpty(
+            "these are types a person creates from this menu, and none of them is discoverable by "
+            + "any query — they reach it only through the static bucket");
         offered.Should().Contain($"{types}/Widget/Part",
             "the second discovery leg — the child NodeTypes the PARENT'S TYPE defines, so a "
             + "{0}/Widget instance offers {0}/Widget/Part. The retired literals could not reach it "
@@ -215,7 +232,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
     public async Task ATypeThatOptedOutOfTheCreateContextIsNeverOffered()
     {
-        var (_, host, declaredButOptedOut) = await Fixture();
+        var (types, host, declaredButOptedOut) = await Fixture();
 
         var optedOut = Mesh.ServiceProvider.EnumerateStaticNodes()
             .Where(n => n.IsExcludedFromContext(MeshContexts.Create))
@@ -235,6 +252,17 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             "the parent's CreatableTypes names {0}, which opted out of context:create — a "
             + "whitelist ADDS types the queries could not reach, it does not overrule a type's own "
             + "statement that it is not created by hand", declaredButOptedOut);
+
+        // 🚨 And the same for a RUNTIME type, whose opt-out is on the persisted node rather than
+        // in the static registry — so it is invisible without a read. The create-filtered queries
+        // omit it correctly; the declaration would otherwise synthesise it straight back in.
+        declaring.Should().NotContain($"{types}/Internal",
+            "a runtime NodeType carries ExcludeFromContext: [\"create\"] exactly as a platform one "
+            + "does — an opt-out the provider can only see by resolving the declared path, which "
+            + "is the whole reason it does");
+        declaring.Should().Contain($"{types}/Question",
+            "the declared type that did NOT opt out is still offered — this is the control that "
+            + "keeps the assertion above from passing because declarations stopped working");
     }
 
     /// <summary>
@@ -271,6 +299,42 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
             + "withholds a type while the form still submits it enforces nothing");
         submitted.Should().Be($"{types}/Question",
             "with one allowed type it is the one selected — the person sees what will be created");
+    }
+
+    /// <summary>
+    /// 🚨 THE SINGLE-TYPE URL SHAPE IS GOVERNED TOO. <c>?types=X</c> (the MeshSearch "+" button)
+    /// and <c>?type=X</c> pin one type, and that shape used to render a read-only label without
+    /// asking <see cref="ICreatableTypesProvider"/> at all — so a URL naming a type the parent
+    /// forbids seeded it, showed it as a fait accompli, and submitted it. Both shapes of the field
+    /// now come out of the same resolved set.
+    ///
+    /// <para>Non-vacuous: the same URL against the sibling instance whose type declares nothing
+    /// DOES pin the type, so "the field offers nothing" is not simply what this URL always does.</para>
+    /// </summary>
+    [Fact(Timeout = 240000)] // literal: an attribute argument must be a constant.
+    public async Task APinnedTypeTheParentForbidsIsNotSubmittableThroughTheUrl()
+    {
+        var (_, host, _) = await Fixture();
+
+        // The control: a parent that declares nothing allows Markdown, so the pinned URL is
+        // honoured — the field renders as the read-only label and the value stands. Without this
+        // half, the measurement below would pass for a type this URL simply never pins.
+        var (openStream, openContext) = await RenderedFormContext($"{host}/Thing?types=Markdown");
+        (await SubmittedType(openStream, openContext)).Should().Be("Markdown",
+            "the parent declares nothing, so it restricts nothing and the pinned type stands");
+
+        // The measurement: the sealed parent declares CreatableTypes and switches the globals off,
+        // so Markdown is not creatable under it however the URL asks.
+        var (stream, picker) = await RenderedCreateForm($"{host}/Sealed?types=Markdown");
+        var offered = PickerPaths(picker);
+        var submitted = await SubmittedType(stream, picker);
+        Output.WriteLine($"pinned-URL offered: [{string.Join(", ", offered)}] submitted: '{submitted}'");
+
+        offered.Should().NotContain("Markdown",
+            "the parent excludes it, and a URL parameter is not a permission");
+        submitted.Should().NotBe("Markdown",
+            "the field is what the Create button reads — pinning a forbidden type in the URL must "
+            + "not be a route around the parent's declaration");
     }
 
     // ── fixture ────────────────────────────────────────────────────────────────────────────────
@@ -310,7 +374,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
                 TypeNode(types, "Offer", new NodeTypeDefinition
                 {
                     Configuration = "config => config",
-                    CreatableTypes = [$"{types}/Question", optedOut],
+                    CreatableTypes = [$"{types}/Question", optedOut, $"{types}/Internal"],
                 }),
                 // Same, with the globals switched off.
                 TypeNode(types, "SealedOffer", new NodeTypeDefinition
@@ -320,6 +384,11 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
                     IncludeGlobalTypes = false,
                 }),
                 TypeNode(types, "Question", new NodeTypeDefinition { Configuration = "config => config" }),
+                // A RUNTIME NodeType that opts out of being created, declared by Offer below. Its
+                // opt-out lives on the persisted node, not in the static registry, so it is only
+                // visible to a read.
+                TypeNode(types, "Internal", new NodeTypeDefinition { Configuration = "config => config" })
+                    with { ExcludeFromContext = new HashSet<string> { MeshContexts.Create } },
             ],
         });
 
@@ -388,20 +457,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
     private async Task<(ISynchronizationStream<JsonElement> Stream, MeshNodePickerControl Picker)>
         RenderedCreateForm(string nodePath)
     {
-        var reference = new LayoutAreaReference(MeshNodeLayoutAreas.CreateNodeArea);
-        var stream = GetClient().GetWorkspace()
-            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(nodePath), reference);
-
-        var root = await stream.GetControlStream(reference.Area!)
-            .Where(c => c is StackControl { Areas.Count: > 0 })
-            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
-
-        var areas = ((StackControl)root!).Areas
-            .Select(a => a.Area?.ToString())
-            .Where(a => !string.IsNullOrEmpty(a))
-            .Select(a => stream.GetControlStream(a!))
-            .ToArray();
-
+        var (stream, areas) = await RenderedAreas(nodePath);
         var picker = await Observable.Merge(areas)
             .OfType<MeshNodePickerControl>()
             .Where(IsTypePicker)
@@ -413,17 +469,61 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
         => (await RenderedCreateForm(nodePath)).Picker;
 
     /// <summary>
+    /// The rendered form's data pointer, taken from the first form-bound control that arrives —
+    /// used where the type field renders as a read-only LABEL and there is no picker to read it
+    /// off. Every field on this form shares the one <c>DataContext</c>.
+    /// </summary>
+    private async Task<(ISynchronizationStream<JsonElement> Stream, string DataContext)>
+        RenderedFormContext(string nodePath)
+    {
+        var (stream, areas) = await RenderedAreas(nodePath);
+        var dataContext = await Observable.Merge(areas)
+            .Select(c => (c as UiControl)?.DataContext?.ToString())
+            .Where(d => !string.IsNullOrEmpty(d) && d!.StartsWith("/data/", StringComparison.Ordinal))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        return (stream, dataContext!);
+    }
+
+    /// <summary>
     /// The value the Create button would SUBMIT — the form's own <c>type</c> field, read off the
     /// rendered area's data at the pointer the picker is bound to. This is the value
     /// <c>CreateLayoutArea</c>'s click handler reads; the picker's item list is only what a person
     /// is shown.
     /// </summary>
-    private static async Task<string> SubmittedType(
+    private static Task<string> SubmittedType(
         ISynchronizationStream<JsonElement> stream, MeshNodePickerControl picker)
-    {
-        var pointer = $"{picker.DataContext}/type";
-        return await stream.GetDataStream<string>(new JsonPointerReference(pointer))
+        => SubmittedType(stream, picker.DataContext?.ToString() ?? "");
+
+    private static async Task<string> SubmittedType(
+        ISynchronizationStream<JsonElement> stream, string dataContext)
+        => await stream.GetDataStream<string>(new JsonPointerReference($"{dataContext}/type"))
             .FirstAsync().Timeout(TestTimeouts.Convergence).Await() ?? "";
+
+    /// <summary>
+    /// Subscribes to every child area of the rendered Create form at once, so a sibling that has
+    /// not rendered yet can never hold the read.
+    /// </summary>
+    private async Task<(ISynchronizationStream<JsonElement> Stream, IObservable<object?>[] Areas)>
+        RenderedAreas(string nodePath)
+    {
+        var parts = nodePath.Split('?', 2);
+        var reference = new LayoutAreaReference(MeshNodeLayoutAreas.CreateNodeArea)
+        {
+            Id = parts.Length == 2 ? parts[1] : null,
+        };
+        var stream = GetClient().GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(parts[0]), reference);
+
+        var root = await stream.GetControlStream(reference.Area!)
+            .Where(c => c is StackControl { Areas.Count: > 0 })
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+        var areas = ((StackControl)root!).Areas
+            .Select(a => a.Area?.ToString())
+            .Where(a => !string.IsNullOrEmpty(a))
+            .Select(a => stream.GetControlStream(a!))
+            .ToArray();
+        return (stream, areas);
     }
 
     private static bool IsTypePicker(MeshNodePickerControl picker) =>

--- a/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
+++ b/test/MeshWeaver.Graph.Test/CreateMenuHonoursTheParentTypeTest.cs
@@ -388,7 +388,7 @@ public class CreateMenuHonoursTheParentTypeTest(ITestOutputHelper output) : Mono
                 // opt-out lives on the persisted node, not in the static registry, so it is only
                 // visible to a read.
                 TypeNode(types, "Internal", new NodeTypeDefinition { Configuration = "config => config" })
-                    with { ExcludeFromContext = new HashSet<string> { MeshContexts.Create } },
+                    with { ExcludeFromContext = ImmutableHashSet.Create(MeshContexts.Create) },
             ],
         });
 

--- a/test/MeshWeaver.Graph.Test/DeclaredTypeProbeOutcomeTest.cs
+++ b/test/MeshWeaver.Graph.Test/DeclaredTypeProbeOutcomeTest.cs
@@ -1,0 +1,120 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A PROBE THAT DID NOT COMPLETE IS NOT AN ANSWER</b> — the decision
+/// <see cref="CreatableTypesProvider"/> takes for a type path a config source NAMES
+/// (<see cref="NodeTypeDefinition.CreatableTypes"/> or <c>MeshConfiguration.GlobalCreatableTypes</c>)
+/// once the per-path lookup has run.
+///
+/// <para>There are THREE outcomes and only two of them are answers. A key PRESENT in the lookup
+/// means the probe completed — its value is the node, or <c>null</c> for a confirmed absence. A key
+/// ABSENT means the probe timed out or faulted, which is UNKNOWN. Folding unknown into "no such
+/// node" is what would make the create opt-out hold while storage is healthy and lapse exactly when
+/// it is not: a runtime NodeType carrying <c>ExcludeFromContext: ["create"]</c> would be
+/// synthesised straight back into the menu by the transient failure of the very read added to
+/// withhold it.</para>
+///
+/// <para>Tested directly rather than through the mesh because inducing a timeout on one path's
+/// query would mean standing in a query-core double for the whole mesh — a heavier and less honest
+/// test of a decision that is a pure function of the lookup.</para>
+/// </summary>
+public class DeclaredTypeProbeOutcomeTest
+{
+    private const string DeclaredPath = "Acme/Question";
+
+    private static readonly MeshConfiguration Configuration = new(meshNodes: []);
+    private static readonly IServiceProvider NoStaticNodes = new ServiceCollection().BuildServiceProvider();
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static ImmutableDictionary<string, MeshNode?> Lookup() =>
+        ImmutableDictionary<string, MeshNode?>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
+    private static CreatableTypeInfo? Decide(ImmutableDictionary<string, MeshNode?> lookup) =>
+        CreatableTypesProvider.BuildInfoFromConfig(
+            DeclaredPath, lookup, Configuration, NoStaticNodes, Options);
+
+    /// <summary>
+    /// Confirmed ABSENT — the probe ran and found nothing. The declaration is honoured: a type may
+    /// be declared before the import that lands it, and synthesising the entry is deliberate.
+    /// </summary>
+    [Fact]
+    public void AConfirmedAbsenceStillOffersTheDeclaredType()
+    {
+        var info = Decide(Lookup().SetItem(DeclaredPath, null));
+
+        info.Should().NotBeNull(
+            "the probe COMPLETED and found no node, so the declaration names a type the mesh does "
+            + "not have yet — offering it is what lets a declaration precede its import");
+        info!.NodeTypePath.Should().Be(DeclaredPath);
+    }
+
+    /// <summary>The probe found the node and it does not opt out — offered, with its own metadata.</summary>
+    [Fact]
+    public void AResolvedTypeThatDidNotOptOutIsOffered()
+    {
+        var node = new MeshNode("Question", "Acme")
+        {
+            Name = "Question", NodeType = MeshNode.NodeTypePath,
+        };
+
+        var info = Decide(Lookup().SetItem(DeclaredPath, node));
+
+        info.Should().NotBeNull();
+        info!.DisplayName.Should().Be("Question", "the resolved node is what the menu shows");
+    }
+
+    /// <summary>
+    /// The probe found the node and it DOES opt out. A list that names it cannot resurrect it —
+    /// this is the case the per-path lookup was added for.
+    /// </summary>
+    [Fact]
+    public void AResolvedTypeThatOptedOutIsWithheld()
+    {
+        var node = new MeshNode("Question", "Acme")
+        {
+            Name = "Question",
+            NodeType = MeshNode.NodeTypePath,
+            ExcludeFromContext = ImmutableHashSet.Create(MeshContexts.Create),
+        };
+
+        Decide(Lookup().SetItem(DeclaredPath, node)).Should().BeNull(
+            "ExcludeFromContext: [\"create\"] is the type's own statement that its instances are "
+            + "made by the platform; a whitelist ADDS types the queries could not reach, it does "
+            + "not overrule that");
+    }
+
+    /// <summary>
+    /// 🚨 THE ONE THAT WOULD HAVE SHIPPED. The probe did NOT complete — the path is absent from the
+    /// lookup. That is unknown, not absence, and it fails CLOSED.
+    /// </summary>
+    [Fact]
+    public void AnUnavailableProbeWithholdsTheType_NeverSynthesisesIt()
+    {
+        Decide(Lookup()).Should().BeNull(
+            "a timed-out or faulted probe carries no information about the type's opt-out. "
+            + "Synthesising the entry would offer a type whose ExcludeFromContext simply could not "
+            + "be read — the opt-out holding while storage is healthy and lapsing under load, "
+            + "which is the one condition it most needs to hold under");
+    }
+
+    /// <summary>
+    /// The control that keeps the assertion above from passing for the wrong reason: the SAME empty
+    /// lookup returns an entry once the path is recorded as probed. If this failed, the test above
+    /// would be observing "BuildInfoFromConfig never returns anything" rather than a fail-closed.
+    /// </summary>
+    [Fact]
+    public void TheDifferenceIsTheRECORDEDPROBE_NotTheEmptyLookup()
+    {
+        Decide(Lookup()).Should().BeNull();
+        Decide(Lookup().SetItem(DeclaredPath, null)).Should().NotBeNull(
+            "one key, present with a null value, is the whole difference between unknown and "
+            + "confirmed absent");
+    }
+}


### PR DESCRIPTION
Third and final instalment of #4040, after #4070 and #4074. Both of those **auto-merged on the
commit that happened to be pushed when CI went green**, so each review round has had to arrive as
its own PR. This one is opened as a DRAFT on purpose, and will be marked ready once CI is green and
the review is in — so it cannot merge half-finished a third time.

Two findings from the review of #4074, both real.

## 1. 🚨 The create opt-out was only honoured for types the STATIC registry holds

A persisted NodeType carries `ExcludeFromContext: ["create"]` on its node exactly as a platform one
does. The create-filtered queries drop it correctly — and the declaration path then synthesised it
straight back in. The provider now resolves the paths a config source NAMES and the static registry
does not hold, and only those.

🚨 **One anchored `path:` query per path, never a point read.** A declared type may legitimately not
exist yet (synthesising an entry for it is deliberate), and a point read of an absent node answers a
routing NotFound that terminates the stream *and* opens the storm-breaker on that path. A
`path:a|b|c` alternation names no first segment and would fan out over every schema (#3202); one
path per query keeps each anchored on its own partition. The leg is skipped entirely when no such
path exists — the common case, since every default global is static.

## 2. 🚨 The pinned-URL shape bypassed the restriction entirely

`?type=X` / `?types=X` (the MeshSearch "+" button) rendered a read-only label **without asking
`ICreatableTypesProvider` at all**, so a URL naming a type the parent forbids seeded it, presented
it as settled, and submitted it. The type field is now ONE branch: both shapes come out of the same
resolved set, the alignment runs for both, and the label renders only when the parent allows the
pinned type — otherwise the picker renders with nothing to choose, which is the honest answer.

Both are pinned by tests **falsified before being accepted**: reverting either fix reds its test.

## 🚨 What the no-shrink pin caught while fixing (1)

The exclusion is now the canonical two halves every query backend applies —
`MeshConfiguration.IsExcludedFromContext(node.NodeType, "create")` **or** the node's own opt-out —
written once so the menu and the queries feeding it cannot answer differently.

That drops **25** static entries the retired form passed as fixed Items, and the pin went red on it.
All 25 were checked before the baseline was touched: every one is an **instance** —
`*/_Access/Public_Access`, the `Admin/Partition/*` records, the `*/_Policy` nodes, the
`Templates/Import/*` templates — and **not one is a type declaration**. The form applied only the
node-level half to its Items, which is how instances reached a picker that lists types.

The pin's static baseline moves to the canonical rule and gains a **named** assertion — `Markdown`,
`Group`, `Role`, `Redirect`, `UiContribution`, `HomeTab`, `License`, `WhatsNew` — so it cannot pass
by drifting with the implementation.

Local: `MeshWeaver.Graph.Test` 1559/1559, `MeshWeaver.Documentation.Test` 432/432, Release
`-warnaserror` clean on every touched project.

Pairs-with: none — no public type or member leaves `src/`.

Mirror-sync: none — this change adds no catalog key (#4070 carried the one new key,
`create.selectType`, with its handover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KFBiMVHLTZM2axNgVvaZN2
