### PR TITLE
docs: name the narrow-instrument/wide-claim failure mode in Reading CI Signals

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -1,7 +1,7 @@
 ---
 Name: Reading CI Signals
 Category: Architecture
-Description: What a check's colour actually means — why a SKIPPED required context counts as satisfied while a never-reported one blocks forever, why a red on a non-required check does not block, the i18n mirror that reds every downstream PR until it lands, and the shape most of these share: a narrow instrument answering correctly while the reader generalises it into a claim it never measured.
+Description: What a check's colour actually means — why a SKIPPED required context counts as satisfied everywhere while a NEVER-REPORTED one blocks forever under classic protection yet merges under a ruleset, why a red on a non-required check does not block, the i18n mirror that reds every downstream PR until it lands, and the shape most of these share: a narrow instrument answering correctly while the reader generalises it into a claim it never measured.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
 ---
 
@@ -127,8 +127,8 @@ keep arriving in new costumes. **In every case below the instrument was working 
 was no bug to find, no error to notice, and no amount of care would have helped: the *reading* was
 wrong, not the measurement. That is exactly why this class needs a control rather than diligence.
 
-Five measured in one session (2026-09-12, while triaging #890 and #2543), by **two different
-readers**. This is not one person's blind spot:
+Five were measured in one session (2026-09-12, while triaging #890 and #2543), by **two different
+readers** — so this is not one person's blind spot:
 
 | the instrument | what it actually answers | what it was read as | what falsified it |
 |---|---|---|---|

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -1,7 +1,7 @@
 ---
 Name: Reading CI Signals
 Category: Architecture
-Description: What a check's colour actually means — why a SKIPPED required context counts as satisfied while a never-reported one blocks forever, why a red on a non-required check does not block, and the i18n mirror that reds every downstream PR until it lands.
+Description: What a check's colour actually means — why a SKIPPED required context counts as satisfied while a never-reported one blocks forever, why a red on a non-required check does not block, the i18n mirror that reds every downstream PR until it lands, and the shape most of these share: a narrow instrument answering correctly while the reader generalises it into a claim it never measured.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
 ---
 
@@ -119,6 +119,66 @@ A **dynamic matrix cannot be a required context** — the shard names change. Re
 **collector** job that `needs:` every shard and fails if any did not succeed (core does this with
 `Consolidate test results`). Requiring shard names by hand orphans a required context the moment the
 shard count changes, and it then waits forever.
+
+## 🚨 A narrow instrument does not answer a wide question — and it is RIGHT while you misread it
+
+Most rules on this page are instances of one shape, and it is worth naming because the instances
+keep arriving in new costumes. **In every case below the instrument was working correctly.** There
+was no bug to find, no error to notice, and no amount of care would have helped: the *reading* was
+wrong, not the measurement. That is exactly why this class needs a control rather than diligence.
+
+Five measured in one session (2026-09-12, while triaging #890 and #2543), by **two different
+readers**. This is not one person's blind spot:
+
+| the instrument | what it actually answers | what it was read as | what falsified it |
+|---|---|---|---|
+| `pendingWork=0` on **one** `[STALE-CALLBACK]` record | the pool's depth at that instant, for that correlation | *"the pool is idle"* — a live starved-pool hypothesis declared dead | max `pendingWork` in the **same log** is 606; across the 15 jobs, **2,501** |
+| a `GATE FAILED — tests:` filter | how many failures matched **that stage** | *"8 occurrences"* | all 15 carry the same 120 s bound and the same `CreateOrUpdateNodeRequest@portal/nodeops` stall trail — **15**; the filter set the count, not the phenomenon |
+| `gh api … 2>/dev/null` across eight repos | whatever survived a **discarded** stderr | *"0 issues, 0 PRs — every repo clean"* | every call was being refused `403`; a total refusal read as a clean sweep |
+| `gh api rate_limit` → `core: 5000/5000` | the **PRIMARY** quota | *"not rate limited"* | the refusals were the **SECONDARY** limit, which that endpoint does not report |
+| `gh api /apps/<slug>` permissions | what the App **declared** | *"the App can write issues and workflows"* | the **installation** carries `contents`, `metadata`, `pull_requests` only — a token minted from it can do neither |
+
+### The test to apply before you publish a claim
+
+**Name the question the instrument actually answers, then say why that is the same as the question
+you asked.** Where the two differ, either widen the instrument or narrow the claim. Both are cheap.
+Publishing the gap is not — each row above was repaired only after someone else re-measured.
+
+### The tell, per family
+
+- **A spot value standing in for a distribution.** State the **maximum and the count**, never the
+  sample you happened to read. One record describes a moment; a hypothesis about a process needs the
+  shape of the whole series.
+- **A filtered count standing in for an occurrence count.** State the **filter** beside the number.
+  *"8 matched `tests:`"* and *"8 occurred"* are different sentences, and only the first is a
+  measurement.
+- **A suppressed error standing in for a measurement.** `2>/dev/null` turns a refusal into a zero.
+  **Check the exit code**, or do not suppress. A zero that cannot distinguish *"none"* from *"could
+  not ask"* is not a result.
+- **A healthy meter standing in for the thing that actually refused.** Read the **refusal**, not the
+  meter. `5000/5000 remaining` while every call is refused is the documented signature of the
+  secondary limit — the meter is honest and answering a different question.
+- **A declaration standing in for an effective capability.** An App's own page lists what it *asked
+  for*; the **installation** lists what it was *granted*. Measured 2026-09-12: `meshweaver-cloud`
+  declares `contents, emails, issues, metadata, pull_requests, workflows`, and its installation on
+  this org carries `contents, metadata, pull_requests` — so `issues`, `workflows` and `emails` are
+  declared and absent. Read `orgs/<org>/installations`, not `/apps/<slug>`. This one is not a CI
+  instrument at all, which is the point: the shape is about how an answer is read, not about CI.
+
+### Why a control catches this and care does not
+
+A broken instrument announces itself: an exception, a mismatch, a number that cannot be right. A
+narrow one does none of that — it returns a true value, promptly, in the expected shape. The only
+thing that separates *"what I measured"* from *"what I claimed"* is an artefact that would have come
+out differently had the claim been false, so the discipline is the same one this repository applies
+to gates: **an assertion that cannot fail is not an assertion.** Before a number becomes a verdict,
+say aloud what reading would have refuted it, and go and look for that reading.
+
+Two neighbouring pages carry the same lesson from other directions:
+[Adoption and the Sweep Count Different Things](/Doc/Architecture/AdoptionAndTheSweepCountDifferentThings)
+(two instruments, neither wrong, neither a census) and
+[The Release Gate's Denominator](/Doc/Architecture/ReleaseGateDenominator) (a rate is meaningless
+until you state what it is over).
 
 ## The same trap in the tools you write to watch CI
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-narrow-instrument-does-not-answer-a-wide-question.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-narrow-instrument-does-not-answer-a-wide-question.md
@@ -17,7 +17,8 @@ claim the instrument was never measuring.** There is no bug to find and no error
 measurement is right and the reading is wrong, which is precisely why care does not catch this class
 and a control does.
 
-Four cases measured in one session, while triaging two long-running issues:
+Five cases were measured in one session, while triaging two long-running issues. Four are CI
+instruments; the fifth deliberately is not, because the shape is about how an answer is read:
 
 - `pendingWork=0` on **one** stale-callback record, read as *"the pool is idle"* — which killed a
   live hypothesis. Maximum `pendingWork` in the same log is 606, and 2,501 across the run set.
@@ -27,6 +28,8 @@ Four cases measured in one session, while triaging two long-running issues:
   fact being refused and the discarded stderr was the only place that said so.
 - A quota endpoint reporting `5000/5000 remaining` while every call was refused — an honest meter,
   answering about the primary limit when the refusals were the secondary one.
+- A GitHub App's **declared** permissions read as what a token can do. The App declares `issues` and
+  `workflows`; the installation that mints the token carries neither.
 
 The section gives the test to apply before a number becomes a verdict — *name the question the
 instrument actually answers, then say why that is the same as the question you asked* — plus the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-narrow-instrument-does-not-answer-a-wide-question.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-narrow-instrument-does-not-answer-a-wide-question.md
@@ -1,0 +1,35 @@
+---
+Name: A narrow instrument does not answer a wide question
+Category: Feature
+Description: Reading CI Signals now names the failure mode most of its own rules are instances of - a correct instrument whose narrow answer gets generalised into a wide claim. Four measured cases from one session, the test to apply before publishing a number, and the tell for each family.
+Icon: Sparkle
+Order: -20260912
+---
+
+# A narrow instrument does not answer a wide question
+
+[Reading CI Signals](/Doc/Architecture/ReadingCiSignals) collects rules for what a check's colour
+actually means. Most of them turn out to be instances of a single shape that the page had never
+named, and naming it is worth a section because the instances keep arriving in new costumes.
+
+The shape: **a narrow instrument returns a correct answer, and the reader generalises it into a
+claim the instrument was never measuring.** There is no bug to find and no error to notice — the
+measurement is right and the reading is wrong, which is precisely why care does not catch this class
+and a control does.
+
+Four cases measured in one session, while triaging two long-running issues:
+
+- `pendingWork=0` on **one** stale-callback record, read as *"the pool is idle"* — which killed a
+  live hypothesis. Maximum `pendingWork` in the same log is 606, and 2,501 across the run set.
+- A count filtered to one gate stage, published as an occurrence count: 8 where the real figure was
+  15, because seven siblings failed at a different checkpoint on the same mechanism.
+- `gh api … 2>/dev/null` over eight repositories reporting every one clean, when every call was in
+  fact being refused and the discarded stderr was the only place that said so.
+- A quota endpoint reporting `5000/5000 remaining` while every call was refused — an honest meter,
+  answering about the primary limit when the refusals were the secondary one.
+
+The section gives the test to apply before a number becomes a verdict — *name the question the
+instrument actually answers, then say why that is the same as the question you asked* — plus the
+specific tell for each family: state the maximum and the count rather than the sample, state the
+filter beside the number, check the exit code rather than suppressing it, and read the refusal
+rather than the meter.


### PR DESCRIPTION
## What

Names, in [Reading CI Signals](src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md), the failure mode that page's own rules keep being instances of but which it never stated:

> **A narrow instrument returns a correct answer, and the reader generalises it into a claim the instrument was never measuring.**

In every case the instrument is *working correctly*. There is no bug to find and no error to notice — the measurement is right and the reading is wrong. That is why care does not catch this class and a control does.

## Why this page, specifically

The page already held **four instances of the shape and never named what they share**: the `jq` `//` that does not fall through on `""`, the rollup that is vacuously green over zero checks, the budget refusal wearing a workflow-defect costume, and the sweep that goes blind when its subject moves repos. Each reads as a separate piece of trivia to be memorised. Naming the shape turns all four into worked examples of one stated rule — which is the argument for the placement, rather than "it fits".

## Why now

Five cases measured in a single session (2026-09-12) while adjudicating whether #890 and #2543 were superseded, by two different readers. Every one was caught only because someone re-measured the same population and disagreed:

| instrument | answers | was read as | falsified by |
|---|---|---|---|
| `pendingWork=0` on **one** `[STALE-CALLBACK]` record | pool depth at that instant, for that correlation | "the pool is idle" — a live starved-pool hypothesis declared dead | max `pendingWork` is 606 in the **same log**, 2,501 across the 15 jobs |
| a `GATE FAILED — tests:` filter | failures matching **that stage** | "8 occurrences" | all 15 share the 120 s bound and the `CreateOrUpdateNodeRequest@portal/nodeops` stall trail — **15** |
| `gh api … 2>/dev/null` × 8 repos | whatever survived a discarded stderr | "0 issues, 0 PRs — all clean" | every call was refused `403` |
| `gh api rate_limit` → `core: 5000/5000` | the **primary** quota | "not rate limited" | the refusals were the **secondary** limit |
| `gh api /apps/<slug>` permissions | what the App **declared** | "the App can write issues and workflows" | the **installation** carries `contents`, `metadata`, `pull_requests` only |

The fifth is deliberately not a CI instrument — the shape is about how an answer is read, not about CI. I re-measured it before including it: `/apps/meshweaver-cloud` declares `contents, emails, issues, metadata, pull_requests, workflows`; `orgs/Systemorph/installations` carries `contents, metadata, pull_requests`. Three declared and absent.

Both issues stay open; the corrections are on [#890](https://github.com/Systemorph/MeshWeaver/issues/890) and [#2543](https://github.com/Systemorph/MeshWeaver/issues/2543). This PR is the conserve-work-products half — the finding belongs in the doc tree, not only in issue threads.

## What the section gives a reader

- **The test**, before a number becomes a verdict: *name the question the instrument actually answers, then say why that is the same as the question you asked.* Where they differ, widen the instrument or narrow the claim.
- **The tell per family**: a spot value standing in for a distribution (state max **and** count); a filtered count standing in for an occurrence count (state the filter); a suppressed error standing in for a measurement (check the exit code); a healthy meter standing in for the thing that refused (read the refusal); a declaration standing in for an effective capability (read the installation, not the App).
- **Why a control is the only remedy** — a broken instrument announces itself; a narrow one returns a true value, promptly, in the expected shape.

Cross-links [Adoption and the Sweep Count Different Things](src/MeshWeaver.Documentation/Data/Architecture/AdoptionAndTheSweepCountDifferentThings.md) and [The Release Gate's Denominator](src/MeshWeaver.Documentation/Data/Architecture/ReleaseGateDenominator.md) rather than restating them.

## Scope

Docs only: one section added to an existing page, that page's frontmatter `Description` widened to cover it (an index entry that misdescribes the page makes the section unfindable), and a What's New entry. No code, no workflows, no test changes.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror` → `Build succeeded. 0 Warning(s) 0 Error(s)`
- `MeshWeaver.Documentation.Test` → **432/432 passed**, fresh `.trx` produced. Confirmed **by name** that the guards actually executed rather than trusting the suite's green: `DocumentationLinkIntegrityTest.AllInternalDocLinks_ResolveToExistingNodes`, `ArchitectureTopicMapTest.EveryArchitecturePage_IsListedInTheTopicMap`, `WhatsNewEntryIntegrityTest.EveryEntry_CarriesTheFrontmatterTheFeedRendersFrom`, `NoConflictMarkersGuard`.

Opened as a **draft** deliberately: `auto-arm.yml` arms auto-merge on every non-draft PR here, and it landed partial work twice on #4040 today. Marking ready only once CI is green and the Copilot review is in and addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
