### PR TITLE
fix: platform admins can always see and delete a Space's GitHub sync config, including system-owned Spaces

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -209,6 +209,19 @@ hub.IsGlobalAdmin(userId)    // explicit user
 
 Readers that gate on it: `AdminMenuGate` (Invitations / Inbox tabs), `UserNodeType.GetGlobalAdminTabAsync` (Global Administration tab), `UserProfile`.
 
+### The two type-scoped exceptions: a Space the platform itself owns
+
+"Not a data superuser" holds for every partition a **person** owns — there is always somebody to ask for a grant. It has no answer for a partition **nobody** can own: a Space with a ONE-WAY `_GitSync` is **system-owned** (`AccessAssignmentGuard.IsSystemOwned`) — the repo rewrites it on every sync, `IsForbiddenOnSystemOwned` refuses every Admin/Editor grant on it and `SystemOwnedAccessRetractionHandler` retracts the ones that predate the sync. Measured on memex.meshweaver.cloud 2026-09-12: `MeshWeaver/_GitSync`, created by the platform in a Space owned by `system-security`, re-imported the whole core repository on every green build (Memex#237), and the platform admin got `Not found` on `get` and *"Delete permission denied for 'MeshWeaver/_GitSync'"* on `delete` — no human could remove it through any API.
+
+So two node types carry an `INodeTypeAccessRule` whose non-admin leg is the ordinary fold and whose second leg is `hub.IsGlobalAdmin(userId)` — the same OR `GitHubActivityExtensions.TriggerAuthorizedAsSystem` already applies to every sync trigger ("triggering a sync is a platform action"):
+
+| Node type | Platform admin may | Still on the fold | Where |
+|---|---|---|---|
+| `GitHubSyncConfig` (`{space}/_GitSync`) | **Read, Delete** — always, on every Space | Create, Update | `GitHubSyncConfigAccessRule` (MeshWeaver.GitSync) |
+| `Space` (the ROOT node only) | **Read** — only while the Space is system-owned | Update, Delete, and every child node | `SpaceAccessRule.ReadAccess` (MeshWeaver.Graph) |
+
+The fold itself is untouched — `GetEffectivePermissions` still answers `None` for the admin on both paths, which is what `SystemOwnedSyncConfigIsVisibleToPlatformAdminsTest` pins: the widening comes from the rule, consulted by all three seams (`RlsNodeValidator`, the `[RequiresPermission]` delivery gate, the delete pre-flight) through `NodeTypeAccessRuleGate`, so an ordinary viewer's check is byte-for-byte what it was. A sync config carries the repo, branch and last-sync state — never a credential; that is the separate `GitHubCredential` node in the owner's own partition. Deleting the **Space** of a system-owned partition is deliberately NOT widened: a paid plugin's Space is system-owned too, and its `_Access` entitlement grants would go with it.
+
 ### Where the grant comes from (db-init)
 
 - **Config-driven** — `Auth:GlobalAdmins: [ "rbuergi", … ]` → `GlobalAdminSeed` seeds a static `Admin/_Access/{user}_Access` grant at boot. A fresh DB with the config set comes up with each listed user already a platform admin.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-platform-admins-can-always-see-and-delete-a-sync-config.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-platform-admins-can-always-see-and-delete-a-sync-config.md
@@ -1,0 +1,50 @@
+---
+Name: Platform admins can always see and delete a Space's GitHub sync config
+Category: Fix
+Description: A platform administrator can now read and delete any Space's GitHub sync config, and see the root of a system-owned Space — even when the Space was created by the platform itself and carries no grant a person could hold. Until now such a config answered "Not found" and "Delete permission denied" to the very operator who had to remove it.
+Icon: Checkmark
+Order: -20260912
+---
+
+# Platform admins can always see and delete a Space's GitHub sync config
+
+A Space that syncs **one-way** from a GitHub repository is **system-owned**: the repository rewrites
+it on every sync, so nobody but the importer may write it, and the platform refuses — and retracts —
+every Admin or Editor grant on it. That rule is right, and it has one blind spot: a Space the
+**platform itself** created.
+
+On 2026-09-12 memex.meshweaver.cloud carried exactly that: `MeshWeaver/_GitSync`, wired by the
+platform in a Space owned by `system-security`, importing the **entire** core repository on every
+green build — hundreds of refused nodes per pass, and pods at 9.9 GiB. The platform administrator
+tried to delete it and got:
+
+```
+get    MeshWeaver/_GitSync   →   Not found
+delete MeshWeaver/_GitSync   →   Delete permission denied for 'MeshWeaver/_GitSync'
+```
+
+He could not even see that the Space existed, while the webhook log listed the config among the
+mesh's seventy sync configs. A platform admin is deliberately **not a data superuser** — the
+Admin-partition grant confers no Read on anybody's Space — and on a system-owned Space there is no
+grant anyone *could* hold. The config was unremovable through any API.
+
+## What changed
+
+Two node types now carry their own access rule, with the same second leg the sync **triggers** have
+had since August (triggering a sync is a platform action, so a platform admin may always do it):
+
+- **`GitHubSyncConfig`** (`{space}/_GitSync`) — a platform admin can always **read** and **delete**
+  it, on every Space. Create and Update are unchanged: an admin still cannot repoint somebody's sync.
+- **`Space`** — a platform admin can **read the root node** of a Space *while it is system-owned*.
+  Its content stays gated; Update and Delete are unchanged.
+
+For everybody else nothing moves: the ordinary check is byte-for-byte what it was, and the permission
+fold itself is untouched — the widening comes from the node type's rule, which every seam (the RLS
+read filter, the delivery gate, the delete pre-flight) consults through one gate.
+
+A sync config carries the repository, the branch and the last-sync state — never a credential; that
+lives in a separate node in the owner's own partition. Deleting the **Space** of a system-owned
+partition is deliberately not widened: a paid plugin's Space is system-owned too, and its
+entitlement grants would go with it.
+
+Documented under [Access Control](/Doc/Architecture/AccessControl) → "The two type-scoped exceptions".

--- a/src/MeshWeaver.GitSync/GitHubSyncConfigAccessRule.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfigAccessRule.cs
@@ -1,0 +1,87 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.GitSync;
+
+/// <summary>
+/// The access rule for a Space's GitHub-sync config (<c>{space}/_GitSync</c>,
+/// <see cref="GitHubSyncService.ConfigNodeType"/>): <b>a platform admin can ALWAYS see it and
+/// delete it</b>; everybody else exactly as before.
+///
+/// <para><b>Why a rule at all.</b> The config node had none, so every seam fell through to the
+/// path fold: Read demanded <see cref="Permission.Read"/> on <c>{space}/_GitSync</c>
+/// (<c>RlsNodeValidator</c>), Delete demanded <see cref="Permission.Delete"/> on the Space
+/// (<c>MeshExtensions.CheckDeletePermissionByPath</c> on <c>MainNode</c>, plus the
+/// <c>[RequiresPermission(Delete)]</c> delivery gate on the node's own path) — and a ONE-WAY sync
+/// makes the Space SYSTEM-OWNED, so nobody but <see cref="WellKnownUsers.System"/> can hold either:
+/// <c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c> refuses to write an Admin/Editor grant
+/// there and <see cref="SystemOwnedAccessRetractionHandler"/> retracts the ones that predate the
+/// sync. A platform admin is deliberately NOT a data superuser (<c>hub.IsGlobalAdmin</c> confers no
+/// Read on any other partition), so the very persona who operates the sync machinery got
+/// <c>Not found</c> on <c>get</c> and <i>"Delete permission denied for '{space}/_GitSync'"</i> on
+/// delete — measured on memex.meshweaver.cloud 2026-09-12 on <c>MeshWeaver/_GitSync</c>, a config
+/// the platform itself had created that was re-importing the whole core repository on every green
+/// build (Memex#237), and that no human could remove through any API.</para>
+///
+/// <para><b>What widens, and for whom.</b> Only the platform admin, and only on THIS node type:
+/// the same <c>hub.IsGlobalAdmin</c> OR that <c>GitHubActivityExtensions.TriggerAuthorizedAsSystem</c>
+/// already applies to every sync trigger ("triggering a sync is a platform action") now also covers
+/// seeing the config and removing it. Update stays on the path fold — an admin still cannot repoint
+/// somebody's sync — and the Space's CONTENT stays gated: a sync config carries the repo, branch and
+/// last-sync state, never a credential (that is the separate <see cref="GitHubCredential"/> node
+/// in the owner's own partition).</para>
+///
+/// <para><b>For everybody else nothing changes.</b> The non-admin leg is the fold on the node's
+/// own path, which is what the RLS validator and the delivery gate demanded before; a Delete on
+/// <c>{space}/_GitSync</c> inherits the Space's grants, so it is the pre-flight's demand on
+/// <c>MainNode</c> too. Closed by default, as it was.</para>
+///
+/// <para>Registered in <c>AddGitHubSyncServices</c> — the service-collection entry point every
+/// host composes — next to the retraction handler that creates the situation this rule resolves.
+/// Consulted through <see cref="NodeTypeAccessRuleGate"/> by all three seams (RLS read filter,
+/// delivery gate, delete pre-flight), so they cannot answer differently (#3061).</para>
+/// </summary>
+public sealed class GitHubSyncConfigAccessRule(IMessageHub hub) : INodeTypeAccessRule
+{
+    /// <inheritdoc />
+    public string NodeType => GitHubSyncService.ConfigNodeType;
+
+    /// <summary>
+    /// Read and Delete only. Create and Update deliberately stay on the standard check: this rule
+    /// exists so an operator can SEE and REMOVE a sync, not so a platform grant becomes a licence
+    /// to rewire one.
+    /// </summary>
+    public IReadOnlyCollection<NodeOperation> SupportedOperations =>
+        [NodeOperation.Read, NodeOperation.Delete];
+
+    /// <inheritdoc />
+    public IObservable<bool> HasAccess(NodeValidationContext context, string? userId)
+    {
+        if (string.IsNullOrEmpty(userId) || userId == WellKnownUsers.Anonymous)
+            return Observable.Return(false);
+
+        var required = context.Operation switch
+        {
+            NodeOperation.Read => Permission.Read,
+            NodeOperation.Delete => Permission.Delete,
+            _ => Permission.None
+        };
+        if (required == Permission.None)
+            return Observable.Return(false);
+
+        // The ordinary check first, the platform-admin OR second, and the second only when the first
+        // said no — the admin probe is a second fold (on the Admin scope) and the common case is a
+        // caller who holds the grant. Take(1) on each leg: both ride the live AccessAssignment
+        // query and never complete on their own; the caller (NodeTypeAccessRuleGate.Evaluate)
+        // takes ONE decision off the gate, and an empty leg is reported as Undetermined — fail
+        // closed — never as a grant.
+        return hub.CheckPermission(context.Node.Path, userId, required)
+            .Take(1)
+            .SelectMany(granted => granted
+                ? Observable.Return(true)
+                : hub.IsGlobalAdmin(userId).Take(1));
+    }
+}

--- a/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs
@@ -122,6 +122,12 @@ public static class GitHubSyncConfiguration
             sp.GetRequiredService<IStorageAdapter>(),
             sp.GetService<AccessService>(),
             sp.GetService<ILoggerFactory>()?.CreateLogger<SystemOwnedAccessRetractionHandler>()));
+        // …and the other half of that invariant: once nobody but System may hold a grant on the
+        // space, the config that made it so must still be VISIBLE and REMOVABLE by the persona who
+        // operates the platform. Platform admins always Read + Delete a sync config; everybody else
+        // exactly as before (see GitHubSyncConfigAccessRule).
+        services.AddSingleton<INodeTypeAccessRule>(sp =>
+            new GitHubSyncConfigAccessRule(sp.GetRequiredService<IMessageHub>()));
         // On-disk per-user git working trees (clone/edit/commit/push) — the working-tree
         // counterpart to content sync, shared by the AI harness + the in-portal editor.
         // Root binds from GitWorkspace:Root (env GitWorkspace__Root=/workspace in the portal,

--- a/src/MeshWeaver.GitSync/GitHubSyncService.cs
+++ b/src/MeshWeaver.GitSync/GitHubSyncService.cs
@@ -27,7 +27,7 @@ namespace MeshWeaver.GitSync;
 public sealed class GitHubSyncService
 {
     /// <summary>The fixed node id of a Space's GitHub-sync config satellite (<c>{space}/_GitSync</c>).</summary>
-    public const string ConfigId = "_GitSync";
+    public const string ConfigId = AccessAssignmentGuard.SyncConfigId;
     /// <summary>The <see cref="MeshNode.NodeType"/> of the sync config node.</summary>
     public const string ConfigNodeType = "GitHubSyncConfig";
     /// <summary>The <see cref="MeshNode.NodeType"/> identifying a Space (the unit GitHub sync acts on).</summary>

--- a/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
@@ -341,7 +341,8 @@ public static class SpaceNodeType
 
     /// <summary>
     /// DI-registered access rule for Space nodes.
-    /// Read: requires partition Read permission. Create: any authenticated identity for a
+    /// Read: requires partition Read permission — or, for a platform admin, the Space being
+    /// system-owned (see <see cref="ReadAccess"/>). Create: any authenticated identity for a
     /// top-level Space (the creator becomes its Admin), parent Create otherwise. Update: requires
     /// <see cref="Permission.Update"/>; Delete: requires <see cref="Permission.Delete"/>.
     /// </summary>
@@ -358,7 +359,7 @@ public static class SpaceNodeType
                 return Observable.Return(false);
 
             if (context.Operation == NodeOperation.Read)
-                return hub.CheckPermission(context.Node.Path, userId, Permission.Read);
+                return ReadAccess(context.Node.Path, userId);
 
             if (context.Operation == NodeOperation.Create)
             {
@@ -394,5 +395,46 @@ public static class SpaceNodeType
 
             return Observable.Return(false);
         }
+
+        /// <summary>
+        /// Read on the Space's ROOT node: the ordinary fold, OR — for a platform admin only — the
+        /// Space being SYSTEM-OWNED.
+        ///
+        /// <para>A one-way <c>_GitSync</c> makes a Space system-owned: every write grant on it is
+        /// refused (<c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c>) or retracted
+        /// (<c>SystemOwnedAccessRetractionHandler</c>), so NO human can hold Read on it the ordinary
+        /// way, and a platform admin — deliberately not a data superuser — holds nothing there
+        /// either. The platform created such a Space (<c>MeshWeaver</c> on memex.meshweaver.cloud,
+        /// 2026-09-12), the platform re-imports it on every green build, and the operator who has
+        /// to stop that could not even see that the Space existed. This is the ownership case the
+        /// Admin-partition model has no answer for: a partition owned by the platform itself, with
+        /// nobody to ask for a grant.</para>
+        ///
+        /// <para><b>Scope of the widening.</b> The Space node only — its name, description and
+        /// kind — never its content: children are their own node types and go through the fold,
+        /// where the admin still holds nothing. Update and Delete are untouched; an admin can look
+        /// at a system-owned Space and remove its sync config (<c>GitHubSyncConfigAccessRule</c>),
+        /// and nothing more. A bijective sync is not system-owned (<c>AccessAssignmentGuard.IsSystemOwned</c>):
+        /// there the mesh nodes are somebody's working copy, and their space stays theirs.</para>
+        ///
+        /// <para><b>Cost.</b> The probe — one storage read of <c>{space}/_GitSync</c> — runs only
+        /// after the fold denied AND the caller is a platform admin; an ordinary viewer's Read is
+        /// byte-for-byte the check it always was. Each leg is a live, never-completing fold, hence
+        /// the <c>Take(1)</c>s; an empty leg completes empty and the caller's
+        /// <c>NodeTypeAccessRuleGate.Evaluate</c> reports it Undetermined — fail closed.</para>
+        /// </summary>
+        private IObservable<bool> ReadAccess(string spacePath, string userId)
+            => hub.CheckPermission(spacePath, userId, Permission.Read)
+                .Take(1)
+                .SelectMany(granted => granted
+                    ? Observable.Return(true)
+                    : hub.IsGlobalAdmin(userId)
+                        .Take(1)
+                        .SelectMany(isAdmin => isAdmin
+                            ? NodeTypeAccessRuleGate
+                                .ReadSubjectNode(hub, AccessAssignmentGuard.SyncConfigPath(spacePath))
+                                .Select(sync => AccessAssignmentGuard.IsSystemOwned(
+                                    sync, hub.JsonSerializerOptions))
+                            : Observable.Return(false)));
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1818,7 +1818,7 @@ public static class MeshExtensions
         // does not carry (HealPartitionRoot writes the root as System, so root.CreatedBy is
         // never the owner), and it is what distinguishes "I am creating my own partition" from
         // "I am a deploy touching somebody else's".
-        var syncObs = ReadNodeAuthoritative(hub, persistence, $"{partition}/_GitSync");
+        var syncObs = ReadNodeAuthoritative(hub, persistence, AccessAssignmentGuard.SyncConfigPath(partition));
 
         return Observable.Zip(rootObs, grantObs, syncObs, (root, grant, sync) => (root, grant, sync))
             .SelectMany(t =>
@@ -3995,7 +3995,7 @@ public static class MeshExtensions
             return Observable.Return<LocalizableText?>(null);
 
         var partition = AccessAssignmentGuard.PartitionOf(scope);
-        return ReadNodeAuthoritative(hub, persistence, $"{partition}/_GitSync")
+        return ReadNodeAuthoritative(hub, persistence, AccessAssignmentGuard.SyncConfigPath(partition))
             .Select(sync => AccessAssignmentGuard.SystemOwnedRefusal(
                 node, assignment,
                 systemOwned: AccessAssignmentGuard.IsSystemOwned(sync, hub.JsonSerializerOptions)));

--- a/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs
@@ -38,6 +38,18 @@ public static class AccessAssignmentGuard
     public const string AccessFolder = "_Access";
 
     /// <summary>
+    /// The fixed id of a partition's GitHub-sync config node (<c>{partition}/_GitSync</c>) — the
+    /// node whose existence (one-way) makes the partition SYSTEM-OWNED (<see cref="IsSystemOwned"/>).
+    /// Declared HERE, below the GitSync assembly, because the ownership question is asked by the
+    /// write boundary (this guard), the partition bootstrap and the Space access rule, none of
+    /// which reference GitSync; <c>GitHubSyncService.ConfigId</c> aliases it so the two cannot drift.
+    /// </summary>
+    public const string SyncConfigId = "_GitSync";
+
+    /// <summary>The sync-config node path for a partition: <c>{partition}/_GitSync</c>.</summary>
+    public static string SyncConfigPath(string partition) => $"{partition}/{SyncConfigId}";
+
+    /// <summary>
     /// The scope a grant's PATH encodes: everything before the trailing <c>/_Access/{id}</c>.
     /// <c>Admin/_Access/x_Access</c> → <c>Admin</c>; <c>Store/Plugin/_Access/x</c> →
     /// <c>Store/Plugin</c> (scopes nest); a root-level <c>_Access/x</c> → <c>""</c> (the

--- a/test/MeshWeaver.Hosting.Test/SystemOwnedSyncConfigIsVisibleToPlatformAdminsTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SystemOwnedSyncConfigIsVisibleToPlatformAdminsTest.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A platform admin can ALWAYS see and delete a Space's GitHub-sync config — including on a
+/// SYSTEM-OWNED Space, where nobody can be granted anything.</b> A non-admin still cannot.
+///
+/// <para>Measured on memex.meshweaver.cloud 2026-09-12: <c>MeshWeaver/_GitSync</c> — a config the
+/// platform itself had created, in a Space owned by <c>system-security</c>, re-importing the whole
+/// core repository on every green build (Memex#237) — answered <c>Not found</c> to the platform
+/// admin's <c>get</c> and <i>"Delete permission denied for 'MeshWeaver/_GitSync'"</i> to his
+/// <c>delete</c>, while the webhook log listed it among the mesh's 70 sync configs. The Space is
+/// system-owned (one-way sync), so <c>AccessAssignmentGuard.IsForbiddenOnSystemOwned</c> refuses
+/// every write grant on it and there is no ordinary way IN; and a platform admin is deliberately
+/// not a data superuser, so the Admin-partition grant reaches nothing there either. The config was
+/// unremovable through any API.</para>
+///
+/// <para>The tests below hold the fold FIXED — the admin holds NO Read on the config path, asserted
+/// as a verdict — so the widening can only come from the node type's own rules
+/// (<c>GitHubSyncConfigAccessRule</c>, <c>SpaceAccessRule.ReadAccess</c>), and the negative half is
+/// non-vacuous by construction: the same row is read back under the admin identity FIRST.</para>
+///
+/// <para>🚨 <c>ConfigureMeshBase</c>, not <c>base.ConfigureMesh</c>: the latter chains
+/// <c>PublicAdminAccess()</c>, which grants Public the Admin role in every default partition — under
+/// it the non-admin would hold Read outright and the negative assertions would pass proving
+/// nothing.</para>
+/// </summary>
+public class SystemOwnedSyncConfigIsVisibleToPlatformAdminsTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    /// <summary>The Admin partition: an Admin grant HERE is the platform-admin shape (<c>hub.IsGlobalAdmin</c>).</summary>
+    private const string AdminPartition = "Admin";
+
+    /// <summary>A platform admin: <c>Permission.All</c> at scope <c>Admin</c>, and nothing on any Space.</summary>
+    private const string PlatformAdmin = "platform-boss";
+
+    /// <summary>An ordinary user with a real grant on their OWN partition, and nothing on Admin.</summary>
+    private const string PlainUser = "plain-jane";
+
+    private const string RepoUrl = "https://github.com/test/system-owned";
+
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    private GitHubSyncService Sync => Mesh.ServiceProvider.GetRequiredService<GitHubSyncService>();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(AdminPartition) { Name = "Admin", NodeType = "Markdown" },
+                new MeshNode(PlainUser) { Name = "Plain Jane", NodeType = "Markdown" },
+                // THE platform-admin shape: the Admin role in the Admin partition's _Access
+                // namespace. Not a root grant — that is the data-superuser shape and deliberately
+                // not how platform admins are provisioned.
+                AssignmentNodeFactory.UserRole(PlatformAdmin, "Admin", AdminPartition),
+                // The ordinary user owns their own partition and holds nothing on Admin.
+                AssignmentNodeFactory.UserRole(PlainUser, "Admin", PlainUser))
+            .AddGitHubSyncTypes()
+            .ConfigureServices(services =>
+            {
+                services.AddGitHubSyncServices();
+                return services;
+            });
+
+    private static AccessContext Identity(string userId) => new() { ObjectId = userId, Name = userId };
+
+    /// <summary>
+    /// A Space with a ONE-WAY sync — i.e. system-owned. Created under the harness's DevLogin
+    /// identity (a root grant, so the create is allowed); neither test subject holds anything on it.
+    /// </summary>
+    private async Task<string> PrepareSystemOwnedSpace()
+    {
+        var space = "Owned" + Guid.NewGuid().ToString("N")[..8];
+        await NodeFactory.CreateNode(new MeshNode(space)
+        {
+            NodeType = "Space", Name = "System-owned space", State = MeshNodeState.Active,
+            Content = new Space(),
+        }).Should().Within(Budget).Emit("the Space fixture must be created");
+
+        var config = await Sync.SaveConfig(space, RepoUrl, "main", null, false, false,
+                direction: SyncDirection.ImportOnly, twoWay: false)
+            .Should().Within(Budget).Emit("the one-way sync config must be written");
+        Assert.Equal(GitHubSyncService.ConfigPath(space), config.Path);
+        Assert.Equal(GitHubSyncService.ConfigNodeType, config.NodeType);
+        Assert.True(AccessAssignmentGuard.IsSystemOwned(config, Mesh.JsonSerializerOptions),
+            "a one-way _GitSync is THE definition of system-owned");
+        return space;
+    }
+
+    /// <summary>The RLS-filtered read the MCP <c>get</c> and every listing ride: the rows at
+    /// <paramref name="path"/> as <paramref name="viewer"/> sees them.</summary>
+    private IObservable<bool> IsVisibleTo(string path, string viewer)
+        => NodeFactory
+            .Query<MeshNode>(MeshQueryRequest.FromQuery($"path:{path}").ForViewer(viewer))
+            .Select(change => change.Items.Any(n =>
+                string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase)));
+
+    private IObservable<DeleteNodeResponse> DeleteAs(string path, string viewer)
+        => ObserveNodeOperation(
+                new DeleteNodeRequest(path),
+                o => o.WithAccessContext(Identity(viewer)))
+            .Select(d => d.Message)
+            .Take(1);
+
+    /// <summary>
+    /// The two identities, stated as verdicts before anything is read through them — and the fold
+    /// itself, FIXED: the admin's Admin-partition grant confers no Read on the config path. What the
+    /// tests below see through the RLS filter is therefore the node type's rule, nothing else.
+    /// </summary>
+    private async Task AssertTheFoldIsUnchanged(string configPath)
+    {
+        await Mesh.IsGlobalAdmin(PlatformAdmin).Should().Within(Budget).Match(a => a,
+            "an Admin-partition grant IS the platform-admin predicate");
+        await Mesh.IsGlobalAdmin(PlainUser).Should().Within(Budget).Match(a => !a,
+            "owning your own partition does not make you a platform admin");
+        await Mesh.GetEffectivePermissions(configPath, PlatformAdmin).Should().Within(Budget)
+            .Match(p => !p.HasFlag(Permission.Read) && !p.HasFlag(Permission.Delete),
+                "a platform admin is NOT a data superuser: the fold on a system-owned Space stays "
+                + "None for them — the widening must come from the node type's rule, never from a grant");
+        await Mesh.GetEffectivePermissions(configPath, PlainUser).Should().Within(Budget)
+            .Match(p => !p.HasFlag(Permission.Read) && !p.HasFlag(Permission.Delete),
+                "the non-admin holds nothing on somebody else's Space");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE READ HALF.</b> The sync config AND the system-owned Space's root node are visible
+    /// to the platform admin through the RLS-filtered read, and to nobody else. Admin first — the
+    /// positive control that makes the non-admin's empty answer a VERDICT rather than a timing story.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task APlatformAdmin_SeesTheSyncConfigAndItsSystemOwnedSpace_ANonAdminSeesNeither()
+    {
+        var space = await PrepareSystemOwnedSpace();
+        var configPath = GitHubSyncService.ConfigPath(space);
+        await AssertTheFoldIsUnchanged(configPath);
+
+        await IsVisibleTo(configPath, PlatformAdmin).Should().Within(Budget).Match(seen => seen,
+            "the platform admin must be able to SEE the config that re-imports a repository");
+        await IsVisibleTo(space, PlatformAdmin).Should().Within(Budget).Match(seen => seen,
+            "the platform admin must be able to see that the system-owned Space EXISTS");
+
+        var configSeenByPlainUser = await IsVisibleTo(configPath, PlainUser)
+            .Should().Within(Budget).Emit("the query itself must answer, so the emptiness is a verdict");
+        Assert.False(configSeenByPlainUser, "a non-admin still cannot see somebody else's sync config");
+        var spaceSeenByPlainUser = await IsVisibleTo(space, PlainUser)
+            .Should().Within(Budget).Emit("the query itself must answer, so the emptiness is a verdict");
+        Assert.False(spaceSeenByPlainUser, "a non-admin still cannot see a Space they hold nothing on");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE DELETE HALF — Memex#237's blocker.</b> The non-admin's delete is refused with a
+    /// permission verdict (not an availability failure); the platform admin's succeeds, and the
+    /// config is gone from storage afterwards.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task APlatformAdmin_CanDeleteTheSyncConfigOfASystemOwnedSpace_ANonAdminCannot()
+    {
+        var space = await PrepareSystemOwnedSpace();
+        var configPath = GitHubSyncService.ConfigPath(space);
+        await AssertTheFoldIsUnchanged(configPath);
+
+        var refused = await DeleteAs(configPath, PlainUser)
+            .Should().Within(Budget).Emit("the delete must answer");
+        Assert.False(refused.Success, "a non-admin must not be able to remove somebody else's sync");
+        Assert.Equal(NodeDeletionRejectionReason.Unauthorized, refused.RejectionReason);
+        Assert.NotNull(await NodeTypeAccessRuleGate.ReadSubjectNode(Mesh, configPath)
+            .Should().Within(Budget).Emit("the refused delete must have left the config in place"));
+
+        var deleted = await DeleteAs(configPath, PlatformAdmin)
+            .Should().Within(Budget).Emit("the delete must answer");
+        Assert.True(deleted.Success,
+            $"the platform admin's delete must succeed, but was refused: {deleted.Error}");
+        var afterwards = await NodeTypeAccessRuleGate.ReadSubjectNode(Mesh, configPath)
+            .Should().Within(Budget).Emit("storage must answer about the deleted path");
+        Assert.Null(afterwards);
+    }
+}


### PR DESCRIPTION
## The refusal, measured

memex.meshweaver.cloud, 2026-09-12, as the platform administrator (`rbuergi`, an `Admin/_Access` grant):

```
get    MeshWeaver/_GitSync            → Not found
get    MeshWeaver                     → Not found
delete MeshWeaver/_GitSync            → Delete permission denied for 'MeshWeaver/_GitSync'
GUI    /MeshWeaver/_GitSync/Delete    → no permission
```

while the mesh's own webhook log lists `MeshWeaver/_GitSync` among its 70 sync configs. The config was created by the platform in a Space owned by `system-security`, syncs the whole `Systemorph/MeshWeaver` repo with no subdirectory, and re-imports the entire core repository on every green core build — Memex#237 (389 refused nodes per pass, pods at 9.9 GiB). Nobody could remove it through any API.

## The mechanism (file:line, on `main` before this PR)

1. **`GitHubSyncConfig` had no `INodeTypeAccessRule`** — `src/MeshWeaver.GitSync/GitHubSyncConfiguration.cs:183-189` registers the type with `IsSatelliteType = false` and nothing else; `NodeTypeAccessRuleSet.Find` therefore returns null for it, and every seam falls through to its closed-by-default path check.
2. **Read → "Not found".** `StorageAdapterMeshQueryProvider.ValidateRead` (`src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs:946`, applied per row at `:515`) runs `RlsNodeValidator.Validate` (`src/MeshWeaver.Graph/Security/RlsNodeValidator.cs:72`): no rule (`CheckCustomRule`, `:255-257`) → `CheckPermission(Permission.Read)` on the node's own path (`PathToCheck`, `:183-186`) → the fold on `MeshWeaver/_GitSync` has no grant for the admin → `None` → the row is filtered, and an RLS-filtered node reads as `Not found`, the same string an absent node gets.
3. **Delete → "Delete permission denied".** `MeshExtensions.CheckDeletePermissionForNode` (`src/MeshWeaver.Mesh.Contract/MeshExtensions.cs:3757-3776`): rule null → `CheckDeletePermissionByPath` (`:3837-3872`) demands `Permission.Delete` on `node.MainNode ?? node.Path` = the Space → denied → `PostFailed("Delete permission denied for '…'")` (`:2649`). The `[RequiresPermission(Delete)]` delivery gate (`src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs:145-200`) reconsiders a denial only through a rule — and there was none.
4. **The Space → "Not found".** `SpaceAccessRule` (`src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs:348-400`): Read is `CheckPermission(space, Read)` → `None`.
5. **Why the admin holds nothing and cannot be granted anything.** A one-way `_GitSync` makes the Space SYSTEM-OWNED: `AccessAssignmentGuard.IsSystemOwned` (`src/MeshWeaver.Mesh.Contract/Services/AccessAssignmentGuard.cs:315`), `IsForbiddenOnSystemOwned` (`:235-283`) refuses every Admin/Editor grant on it, `SystemOwnedAccessRetractionHandler` (`src/MeshWeaver.GitSync/SystemOwnedAccessRetractionHandler.cs`) retracts the ones that predate the sync. And a platform admin is deliberately not a data superuser: `hub.IsGlobalAdmin` (`src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs:238-254`) is `Permission.All` at scope `Admin` and confers no Read elsewhere; `AccessControl.md:402`: "There is deliberately no global-admin short-circuit."
6. **The one existing exception is the sync TRIGGER** (the 2026-08 "sync triggers run as system" change): `GitHubActivityExtensions.TriggerAuthorizedAsSystem` (`src/MeshWeaver.GitSync/GitHubActivityExtensions.cs:90-98`) ORs `hub.IsGlobalAdmin(userId)` into the authorization of every sync op, precisely because "a global admin … may hold no Read on the Space at all — without the OR, the very persona who runs deploys could not even `check`". Seeing and removing the config had no such OR.

So a Space the platform itself owns is the case the Admin-partition model had no answer for: a partition nobody can own, with nobody to ask for a grant.

## The change — the default permission model for the node type, not a one-off grant

- **`GitHubSyncConfigAccessRule`** (new, `src/MeshWeaver.GitSync/`, registered in `AddGitHubSyncServices` next to the retraction handler): **Read and Delete** = the fold on the node's own path **OR `hub.IsGlobalAdmin(userId)`** — the same OR the trigger has. Create/Update stay on the fold (an admin still cannot repoint somebody's sync). Consulted by all three seams (RLS read filter, delivery gate, delete pre-flight) through `NodeTypeAccessRuleGate`, so they cannot disagree (#3061).
- **`SpaceAccessRule.ReadAccess`**: Read on the Space ROOT node = the fold, or — only after it denied AND the caller is a platform admin — one storage read of `{space}/_GitSync` granting iff `IsSystemOwned`. Children go through the fold; Update/Delete untouched; a bijective sync is not system-owned. An ordinary viewer's check is byte-for-byte what it was.
- **`AccessAssignmentGuard.SyncConfigId` / `SyncConfigPath`**: one definition of `{partition}/_GitSync`, replacing three literals (`GitHubSyncService.ConfigId` now aliases it — public surface unchanged).
- **Not widened, deliberately:** Delete of the **Space** of a system-owned partition. A paid plugin's Space is system-owned too, and its `_Access` entitlement grants (purchases, coupons) would go with the partition. Once `_GitSync` is deleted the Space is no longer system-owned and the admin's Read on it lapses — removing the `MeshWeaver` Space itself stays a maintainer decision.
- Docs: `AccessControl.md` → "The two type-scoped exceptions"; What's New entry (`Category: Fix`).

## Test

`test/MeshWeaver.Hosting.Test/SystemOwnedSyncConfigIsVisibleToPlatformAdminsTest.cs` — a Space with a one-way sync, a platform admin (`Admin/_Access` grant, nothing on the Space) and a plain user, under `ConfigureMeshBase` (no `PublicAdminAccess`). The fold is asserted FIXED first (`GetEffectivePermissions` on the config is `None` for the admin), so the widening can only come from the rules:

- `APlatformAdmin_SeesTheSyncConfigAndItsSystemOwnedSpace_ANonAdminSeesNeither` — RLS-filtered read as each viewer; admin first (positive control), then the non-admin's empty answer.
- `APlatformAdmin_CanDeleteTheSyncConfigOfASystemOwnedSpace_ANonAdminCannot` — non-admin refused `Unauthorized` and the row survives; admin's delete succeeds and the row is gone.

Negative control, run with the two rule changes reverted (`git apply -R`), fix restored byte-identically afterwards:

```
test WITHOUT the fix (expect FAILURES)
  Failed …APlatformAdmin_CanDeleteTheSyncConfigOfASystemOwnedSpace_ANonAdminCannot [651 ms]
   the platform admin's delete must succeed, but was refused: Delete permission denied for 'Owned89ef4cac/_GitSync'
  Failed …APlatformAdmin_SeesTheSyncConfigAndItsSystemOwnedSpace_ANonAdminSeesNeither [36 s]
   Expected the observable to emit a value matching the predicate within 36s because the platform admin must be able to SEE the config that re-imports a repository, but it did not. Last of 1 emission(s) was: False.
Failed!  - Failed:     2, Passed:     0, Skipped:     0, Total:     2

test WITH the fix (expect PASS)
Passed!  - Failed:     0, Passed:     2, Skipped:     0, Total:     2, Duration: 730 ms - MeshWeaver.Hosting.Test.dll (net10.0)
```

Builds (`-c Release -warnaserror`, one project per invocation): `MeshWeaver.GitSync` (+ Mesh.Contract, Graph) `0 Warning(s) 0 Error(s)`; `MeshWeaver.Hosting.Test` `0 Warning(s) 0 Error(s)`; `MeshWeaver.Documentation.Test` `0 Warning(s) 0 Error(s)`, `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` `Passed! 2/2`.

## Residual

The GUI's node menu and Overview gate on the raw `GetEffectivePermissions(hubPath)` fold (`MeshNodeLayoutAreas.cs:285/324/2057`), not on the rule — so the admin's Delete now succeeds through the MCP `delete` tool and the `DeleteNodeRequest` API, while the `/…/_GitSync/Delete` menu entry still will not be offered to him. Making the GUI consult the node type's rule is a separate, GUI-wide change.

Addresses Memex#237's blocker (the unremovable `MeshWeaver/_GitSync`). Pairs-with: none — no public surface removed. Mirror-sync: none — no catalog key touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
