### PR TITLE
fix(#3768): a module-only package has nothing to adopt — it is not a miss

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture.md
@@ -280,6 +280,7 @@ Each theme starts with its introductory page, followed by related architecture t
 - [Sealed Publication Generations](SealedPublicationGenerations) — the layout that makes that mix UNREPRESENTABLE (a directory per publication plus a pointer swapped last), the reader contract, the retention rule, and the ordered migration that avoids a new-writer/old-writer half-state
 - [Install Completeness](InstallCompleteness) — what an install RECORD declares landed, compared against what is actually in the mesh; the comparison nothing made until #3485, and why only one of its five verdicts is a pass
 - [CI Content Bake](CiContentBake)
+- [Bundle Delivery Stages](BundleDeliveryStages) — the four independent stages between a merge and a portal serving prebuilt bytes (write · compose · select · deliver), which of #3461 / #3732 / #3768 / #3583 owns each, the instrument that answers for each — and why a reading taken at one stage is not evidence about another
 - [Prebuilt Bundle Retention](PrebuiltBundleRetention) — the sweep that prunes what CI bakes: where it is registered (and why "zero callers" was measured twice and wrong both times), the deletion default that is `true` in code and `false` in the chart, the report that names its denominator, and the pinned satellite gate the protected set cannot see
 - [Deploying a plugin change — merging is not shipping](DeployingPluginChanges)
 - [Module Adoption Policy](ModuleAdoptionPolicy)

--- a/src/MeshWeaver.Documentation/Data/Architecture/BundleDeliveryStages.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BundleDeliveryStages.md
@@ -1,0 +1,208 @@
+---
+nodeType: Markdown
+name: Bundle Delivery Stages
+category: Architecture
+description: The four independent stages between a merge and a portal serving prebuilt bytes — write, compose, select, deliver — which defect lives at each, and why one symptom (a portal compiling what the registry should have served) has four separate causes that must not be triaged as one.
+icon: /static/NodeTypeIcons/box.svg
+---
+
+# Bundle Delivery Stages
+
+A portal that compiles a NodeType locally, when a bundle for it exists somewhere, produces **one
+symptom with four unrelated causes**. Between 2026-09-06 and 2026-09-09 that symptom was filed four
+times — #3461, #3732, #3768, #3583 (+ #3845) — and every thread then re-derived the same shared
+vocabulary before discovering it was about a different stage. This page is the map that makes that
+unnecessary.
+
+> 🚨 **They are not duplicates and must not be collapsed.** They are four consecutive stages of one
+> pipeline. A fix at one stage cannot close a defect at another, and — measured repeatedly — a
+> *reading* taken at one stage was routinely attributed to another. That misattribution is the
+> expensive part: #3583's 2026-09-11 re-measurement cited `bundle_adoption 0 of 25
+> FrameworkDeclined` as proof its own requirement was unmet, when that reading was stage 3's defect
+> and was fixed by #4002 the following morning.
+
+## The pipeline
+
+```
+ merge ──▶ ① WRITE ──────▶ ② COMPOSE ─────▶ ③ SELECT ───────▶ ④ DELIVER ──▶ portal serves
+           who may mutate   what goes into   which publication  do source and
+           a prefix         a publication    is served to whom  bytes arrive in order
+```
+
+| stage | the question | the defect | issue |
+|---|---|---|---|
+| ① **Write** | may two publishers mutate one prefix at once? | two lanes write `prebuilt-bundles/<identity>/plugins` and an overlap seals a mix | [#3461](https://github.com/Systemorph/MeshWeaver/issues/3461) |
+| ② **Compose** | what does a publication *contain*? | a downstream republishes its upstream's modules, and ships siblings the image already has | [#3732](https://github.com/Systemorph/MeshWeaver/issues/3732) |
+| ③ **Select** | which publication answers *this* caller? | the registry answered with its OWN identity, not the caller's | [#3768](https://github.com/Systemorph/MeshWeaver/issues/3768) — **fixed** |
+| ④ **Deliver** | do source and bytes arrive in order? | sources track HEAD; bundles are baked once per identity, so source runs ahead of bytes | [#3583](https://github.com/Systemorph/MeshWeaver/issues/3583) → [#3845](https://github.com/Systemorph/MeshWeaver/issues/3845) |
+
+Each stage has its own instrument, and reading the wrong one is how the attributions went wrong:
+
+| stage | the instrument that answers for it |
+|---|---|
+| ① | the publish lane's own `verify_publication` postcondition, and a MIX refusal in the job log |
+| ② | the `ext-modules` composition assertion (#3905) — *and its printed denominator* |
+| ③ | `/health` → `bundle_adoption`, the `FrameworkDeclined` kind specifically |
+| ④ | `BuildProvenance.StaleAdopted` on the NodeType record; the CI gate *"every upstream must be published for that identity"* |
+
+## Why the identity is what couples them
+
+Every stage is keyed on the **framework identity** — SHA-256 over the sorted
+`(name, reference-assembly hash)` pairs of the platform image's `ContentSurfaceAssemblies`. It is a
+function of the **image**, and it carries no content commit. Two consequences drive all four
+defects:
+
+1. **It moves with nearly every platform build.** Measured 2026-09-11/12 (see below): **18 distinct
+   identities in 24 hours**.
+2. **It is the directory name.** `<root>/<identity>/<source>/…` — so a consumer on a new identity is
+   not "slightly behind", it is looking in a directory nobody has written.
+
+That is the shared vocabulary. It is *not* a shared defect.
+
+## Stage ③ is fixed — and this is the clean, closed case
+
+The registry stamped the bundle index with `FrameworkMvid = FrameworkMvid` — its **own** identity —
+and `PluginBundleClient.Adopt` compared it once and declined the whole index before requesting any
+package. A consumer one image ahead of its registry therefore adopted nothing, however well the
+bundles for its identity had been sealed.
+
+#4002 made the consumer state its lane on the index request and the registry answer for that lane
+when it holds a sealed publication for it (its own identity otherwise, so a genuine bake gap still
+reads as a bake gap). `src/MeshWeaver.PluginCatalog/PluginBundleClient.cs` now sends
+`?identity=…&arch=…` on the fetch.
+
+**Measured on memex.systemorph.com:**
+
+| | 2026-09-11 06:11Z (before) | 2026-09-12 08:0xZ (after) |
+|---|---|---|
+| adoption attempts | 25 | 25 |
+| assemblies adopted | **0** | **25** |
+| `FrameworkDeclined` | **25** | **0** |
+
+Both replicas agree. `FrameworkDeclined` is absent from the payload entirely.
+
+### The follow-on: an empty bundle is not a miss
+
+With the identity gate no longer masking it, a second reading surfaced — 13 of those 25 attempts
+reported `NoAssemblies`, rendered as *"content the registry was meant to serve is compiled here
+instead"*. Every one of the thirteen (`AI`, `Anthropic`, `AppleIntelligence`, `Maps`, `AzureBlob`,
+`AzureFoundry`, `Chat`, `Mcp`, `Notifications`, `OpenAI`, …) is a **module package**: it declares no
+NodeTypes at all, its module lands correctly through the separate `ModuleLandingService` path, and
+nothing whatever is compiled in its place.
+
+🚨 **"This package has no NodeTypes" and "this package's NodeTypes failed to arrive" are different
+sentences** — the exact conflation `BundleAdoptionKind` was split up to prevent, reappearing one
+value further along. `BundleAdoptionKind.NothingToAdopt` now separates them, and
+`BundleOffering.ClassifyEmpty` decides from a **positive declaration** in the manifest (the package
+says it ships a module, or content) and never from the absence of assemblies — so a producer that
+ships a genuinely empty archive stays `NoAssemblies`, and stays loud.
+
+Two consequences beyond the wording:
+
+- `bundle_adoption` no longer reads **Degraded for ever** on a portal with nothing wrong with it.
+  The health check consumes `ledger.Misses` directly, so the flip needs no change in the host.
+- On a `Modules:RequirePrebuilt` mesh, a module-only package previously threw
+  `PrebuiltRequiredException` and **failed the install of a correctly delivered package**. That flag
+  forbids a silent fallback to compiling; a package that compiles nothing has no fallback to forbid.
+
+The ledger's sentence keeps the denominator visible — `… no misses (13 carried no NodeTypes to
+adopt)` — because *"25 attempts, 25 adopted, no misses"* would invite the reader to conclude 25
+packages were served.
+
+## Stage ④ is the one that costs CI today
+
+**Measured 2026-09-11T08:20Z → 2026-09-12T07:51Z on `Systemorph/MeshWeaver.Reinsurance`, counted by
+JOB, zero API errors, every run in the window accounted for:**
+
+```
+91 "Reinsurance Plugins CI" runs   →  45 success, 13 cancelled, 33 failure
+33 failed jobs, classified by failed STEP:
+   23  Gate: every upstream must be published for that identity
+   10  Bake (compiler --output), then gate a mesh against it (--seed)
+```
+
+The 23 are stage ④ in CI rather than on a portal:
+
+```
+release availability: 1 of 2 source(s) are not available for framework identity sf0f9ef77…
+  • crm — no sealed publication under prebuilt-bundles/sf0f9ef77…/crm
+```
+
+- `crm` missing in **23 of 23**; `plugins` in 13 of 23.
+- **18 distinct framework identities** across the 23 — each wake asks about a new one.
+- All 23 were `repository_dispatch`, i.e. the `meshweaver-upstream-published` wake.
+
+The gate is correct and its message is accurate (*"This is a WAIT on the upstream, not a defect in
+this repository"*). What the number shows is the **shape**: nothing bakes for the identities that
+are live, so a consumer that resolves a new identity finds an empty directory, and the wake that is
+supposed to rescue it arrives for a *different* identity than the next one it will resolve.
+
+The 10 remaining failures are Reinsurance content-gate failures (7 `render:`, 3 `tests:`, all on
+`Ifrs17/*`) and belong to none of these five issues.
+
+## Stage ② — what the guard sees, and what it does not
+
+🚨 **#3905's assertion was green in all 10 of those bake jobs — over a denominator of 4:**
+
+```
+module set: 4 MeshWeaver.* assembly file(s) across 4 bundle(s), 4 distinct name(s),
+            0 carried by more than one bundle, 0 carried at more than one BUILD
+```
+
+The 15-copies / 3-builds population #3732 measured lived across a publication's ~40 *module*
+bundles, which the `ext-modules` composition step does not see. **The guard is real and prints its
+denominator honestly; it is not yet pointed at the population that had the defect.** Reading its
+green as "stage ② is clear" is the denominator error this fleet keeps making.
+
+🚨 **The log trap that makes this worse:** in a GitHub Actions log the `echo "module set: $COPIES …"`
+line (the script text) appears *before* the executed output line carrying the numbers. Grepping for
+the words alone matches the echo and reports the assertion as present — or as failing — in runs
+where it never ran. Match on the digits.
+
+## Stage ① — the claim that changed
+
+#3461 was filed as *"an overlap seals a mix **no reader can detect**"*. That is no longer true of the
+whole window. `publish_one_target` now runs `verify_publication` between the last content upload and
+the seal: every uploaded file is stamped with a per-run `publication` token, all stamps are re-read,
+and a set carrying another run's token is **refused, with the foreign seal removed**.
+
+What remains is a genuine residual, and the script states it against itself:
+
+> the interval between the last verification read and the `_complete` upload. A publisher that
+> overwrites a file inside that one-upload window still lands under this run's seal.
+
+Two further corrections that the thread has outgrown, both worth recording because each was acted
+on as if true:
+
+- **"One owner per prefix" would not have helped.** Three independent measurements (09-06, 09-08,
+  09-10) found **zero cross-lane contention**; all 4 observed concurrent publications on one prefix
+  were **same-lane**. The premise that both lanes address one directory is confirmed (7 of 19
+  prefixes, with different source commits) — but the race that actually happens is in-place mutation
+  by *either* lane, which only the generation layout removes.
+- **The retention sweep is NOT dead.** `AddPrebuiltBundleRetention` was reported as having zero
+  callers; it is registered at `memex/Memex.Portal.Shared/MemexConfiguration.cs`. The search covered
+  `src/` and `test/` and this repository ships code from **three** roots. (#3963, closed.)
+
+The landing-order defect recorded on that thread — a later-finishing publication with *older* content
+displacing a newer landed module — was fixed by #3996: `ModuleLandingService` compares versions
+before moving the head, and `ModuleUpdateDecision` answers `SkipOlder`.
+
+## How to triage the next one
+
+1. **Name the stage before naming the issue.** The four instruments above answer different
+   questions; a reading from one is not evidence about another.
+2. **Quote the denominator with every zero.** A green guard over 4 names and a green guard over 40
+   are different claims. `search` is RLS-filtered and `/health` is per-replica — say which replica,
+   and how many distinct payloads you saw.
+3. **Count CI by job, not by run.** One run carries several jobs and a re-run hides executions.
+4. **Read the executed line, not the script echo.**
+
+## Reading
+
+- [Sealed Publication Reads](../SealedPublicationReads) — stage ① and ③, the read answers and the seal
+- [Sealed Publication Generations](../SealedPublicationGenerations) — the layout that removes stage ①'s residual
+- [CI Content Bake](../CiContentBake) — what produces a publication; §"an identity nobody baked"
+- [Module Adoption Policy](../ModuleAdoptionPolicy) — stage ④ on a live portal
+- [Module Owned Siblings Ride](../ModuleOwnedSiblingsRide) — stage ②, one name one build
+- [Rolling Update Build Tolerance](../RollingUpdateBuildTolerance) — one identity per NodeType record (#4071)
+- [Publication Seal Starvation](../PublicationSealStarvation) — when stage ④'s gate never releases (#4063)

--- a/src/MeshWeaver.Documentation/Data/Architecture/BundleDeliveryStages.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BundleDeliveryStages.md
@@ -19,7 +19,7 @@ unnecessary.
 > *reading* taken at one stage was routinely attributed to another. That misattribution is the
 > expensive part: #3583's 2026-09-11 re-measurement cited `bundle_adoption 0 of 25
 > FrameworkDeclined` as proof its own requirement was unmet, when that reading was stage 3's defect
-> and was fixed by #4002 the following morning.
+> and was fixed by #4002 **twenty-nine minutes later** (comment 06:44Z, merge 07:13:45Z).
 
 ## The pipeline
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-module-only-package-is-no-longer-reported-as-a-miss.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-module-only-package-is-no-longer-reported-as-a-miss.md
@@ -1,0 +1,54 @@
+---
+Name: A module-only package is no longer reported as a miss
+Category: Fix
+Description: A package that ships a module and declares no NodeTypes has nothing to adopt — and was being counted as content the registry failed to serve, holding the bundle_adoption health check at Degraded on portals with nothing wrong with them, and failing installs outright on a require-prebuilt mesh. It is now its own outcome, decided from what the bundle declares rather than from what it lacks.
+Icon: Checkmark
+Order: -20260912
+---
+
+# A module-only package is no longer reported as a miss
+
+A prebuilt bundle carries the compiled assemblies for a package's **NodeTypes**. Plenty of packages
+have none: `AI`, `Anthropic`, `Maps`, `Chat`, `Mcp`, `Notifications` and a dozen others ship a
+**module**, which lands by an entirely separate path. Their bundle is complete, correct, and empty
+of assemblies by design.
+
+Until now the portal read that emptiness as a failure. Every one of those packages was recorded as a
+**miss** — rendered on `/health` as *"content the registry was meant to serve is compiled here
+instead"* — when nothing had been missed and nothing was being compiled in its place.
+
+Measured on memex.systemorph.com on 2026-09-12, immediately after the identity-selection fix made
+the underlying state visible:
+
+```
+bundle_adoption: Degraded — 25 adoption attempt(s), 25 adopted, 13 MISS(es) …
+  AI: NoAssemblies (the bundle carried no assemblies); Anthropic: NoAssemblies; Maps: … (+10)
+```
+
+All thirteen had landed correctly. The portal was healthy and its health check could not say so.
+
+Two things follow from that, beyond the wording:
+
+- **`bundle_adoption` was Degraded permanently** on a portal with nothing wrong with it — and it is
+  the instrument the delivery issues are triaged with, so the false reading was being quoted as
+  evidence in other investigations.
+- **On a `Modules:RequirePrebuilt` mesh the install failed.** That flag exists to forbid a silent
+  fallback to compiling; a package that compiles nothing has no fallback to forbid, but it was
+  routed through the same refusal and threw.
+
+An empty bundle is now classified from a **positive declaration** — the package says it ships a
+module, or content — and never from the absence of assemblies. So the benign reading is unreachable
+by accident: a producer that ships a genuinely empty archive, declaring nothing at all, is still
+reported as a miss and still stays loud. Unresolved types the bake could not produce still dominate
+everything else, as before.
+
+The rendered line keeps its denominator, because *"25 attempts, 25 adopted, no misses"* would invite
+you to conclude that twenty-five packages were served:
+
+```
+25 adoption attempt(s), 25 assembly/assemblies adopted, no misses (13 carried no NodeTypes to adopt)
+```
+
+The four independent stages between a merge and a portal serving prebuilt bytes — and which
+instrument answers for each, so a reading from one is not mistaken for evidence about another — are
+written up under [Bundle Delivery Stages](/Doc/Architecture/BundleDeliveryStages).

--- a/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
+++ b/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
@@ -83,13 +83,30 @@ public static class BundleOffering
     /// is a producer defect, and it stays <see cref="BundleAdoptionKind.NoAssemblies"/> so it stays
     /// loud. Inferring the benign reading from emptiness would silence exactly that case.</para>
     ///
-    /// <para>Unresolved producer misses dominate: if the bake could not resolve types it was asked
-    /// for, the bundle is short whatever else it declares, and that is a miss.</para>
+    /// <para>Two things dominate every declaration, and both are misses:</para>
+    /// <list type="number">
+    /// <item>unresolved producer <c>Misses</c> — the bake could not resolve types it was asked for,
+    /// so the bundle is short whatever else it carries;</item>
+    /// <item>🚨 a non-empty <c>Assemblies</c> list. The manifest DECLARED NodeType assemblies and
+    /// none came out, which is a torn bundle, not a module-only one.
+    /// <see cref="BundleReader.Read(System.IO.Stream, System.Collections.Generic.IReadOnlySet{string})"/>
+    /// skips a declared assembly whose archive entry is absent (<c>if (dll is null) continue;</c>)
+    /// — silently, and without recording a miss. A MIXED package (content + NodeTypes + a module)
+    /// whose assembly entries went missing therefore arrives here with zero payloads, a positive
+    /// <c>Module</c> declaration and no <c>Misses</c>, and reading that as "nothing to adopt" would
+    /// hide a genuinely missing NodeType — from <c>Modules:RequirePrebuilt</c> above all, which
+    /// exists to refuse exactly that. Found in review on #4079.</item>
+    /// </list>
     /// </summary>
     /// <param name="manifest">The bundle's manifest, or null from an unreadable bundle.</param>
     public static BundleAdoptionKind ClassifyEmpty(BundleReader.Manifest? manifest)
     {
         if (manifest?.Misses is { Count: > 0 })
+            return BundleAdoptionKind.NoAssemblies;
+
+        // The manifest promised NodeType bytes. Zero of them arrived. That is a miss however the
+        // package describes the rest of itself.
+        if (manifest?.Assemblies is { Count: > 0 })
             return BundleAdoptionKind.NoAssemblies;
 
         var declaresModule = manifest?.Module?.AssemblyName is { Length: > 0 };

--- a/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
+++ b/src/MeshWeaver.PluginCatalog/BundleAdoption.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using MeshWeaver.Plugin.Packaging;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -43,6 +44,66 @@ public enum BundleAdoptionKind
     /// registry serving the wrong bytes under a sealed digest is an integrity failure, never a
     /// transient one.</summary>
     ArtifactRefused,
+
+    /// <summary>
+    /// 🚨 The bundle arrived, was accepted for this lane, and DECLARES that it has no NodeType
+    /// assemblies to adopt — a module-only or content-only package. <b>Not a miss</b>: nothing was
+    /// meant to be served here and nothing is compiled instead.
+    ///
+    /// <para>Appended rather than folded into <see cref="NoAssemblies"/> because the two are the
+    /// same observation with opposite meanings, and collapsing them is the exact conflation this
+    /// enum exists to prevent: "this package has no NodeTypes" and "this package's NodeTypes failed
+    /// to arrive" are DIFFERENT sentences, and reporting the first as the second makes a healthy
+    /// portal read Degraded for ever. Measured 2026-09-12 on memex.systemorph.com: 13 of 25
+    /// attempts — <c>AI</c>, <c>Anthropic</c>, <c>Maps</c>, <c>Chat</c>, <c>Mcp</c>, … , every one
+    /// of them a module package whose module landed correctly through
+    /// <see cref="ModuleLandingService"/> — were counted as misses on that wording (#3768).</para>
+    ///
+    /// <para>🚨 It is decided from a POSITIVE DECLARATION in the manifest (a module, or content),
+    /// never from the absence of assemblies. A bundle that declares nothing at all is genuinely
+    /// empty and stays <see cref="NoAssemblies"/> — loud — because "the producer shipped an empty
+    /// archive" is a real defect that an inference from emptiness would silence.</para>
+    /// </summary>
+    NothingToAdopt,
+}
+
+/// <summary>
+/// How to read a bundle that carried no NodeType assemblies (#3768).
+/// </summary>
+public static class BundleOffering
+{
+    /// <summary>
+    /// Classifies a bundle whose assembly list is EMPTY — the one observation that means two
+    /// opposite things.
+    ///
+    /// <para>🚨 The answer comes from what the manifest DECLARES, never from what it lacks. A
+    /// package that says it ships a module, or content, has no NodeTypes to offer and is complete
+    /// as delivered (<see cref="BundleAdoptionKind.NothingToAdopt"/>). A package that declares
+    /// nothing — no module, no content, and no unresolved types either — is an empty archive, which
+    /// is a producer defect, and it stays <see cref="BundleAdoptionKind.NoAssemblies"/> so it stays
+    /// loud. Inferring the benign reading from emptiness would silence exactly that case.</para>
+    ///
+    /// <para>Unresolved producer misses dominate: if the bake could not resolve types it was asked
+    /// for, the bundle is short whatever else it declares, and that is a miss.</para>
+    /// </summary>
+    /// <param name="manifest">The bundle's manifest, or null from an unreadable bundle.</param>
+    public static BundleAdoptionKind ClassifyEmpty(BundleReader.Manifest? manifest)
+    {
+        if (manifest?.Misses is { Count: > 0 })
+            return BundleAdoptionKind.NoAssemblies;
+
+        var declaresModule = manifest?.Module?.AssemblyName is { Length: > 0 };
+        var declaresContent = manifest?.Content is { Count: > 0 };
+        return declaresModule || declaresContent
+            ? BundleAdoptionKind.NothingToAdopt
+            : BundleAdoptionKind.NoAssemblies;
+    }
+
+    /// <summary>What an empty-but-complete bundle offered instead of NodeTypes, for the log.</summary>
+    public static string OfferingOf(BundleReader.Manifest? manifest) =>
+        manifest?.Module?.AssemblyName is { Length: > 0 } name
+            ? $"module '{name}'"
+            : "content only";
 }
 
 /// <summary>
@@ -66,8 +127,16 @@ public sealed record BundleAdoptionOutcome(
     /// Whether this attempt left content to be COMPILED here that the distribution lane was meant
     /// to serve. Adopting fewer assemblies than were offered counts — a partial adoption is a
     /// partial miss, and rounding it to "adopted" is how a regression hides inside a success.
+    ///
+    /// <para>🚨 <see cref="BundleAdoptionKind.NothingToAdopt"/> is NOT a miss, and it is the one
+    /// exception that has to be stated rather than inferred: a module-only or content-only package
+    /// offers no NodeType assembly, so there is nothing the lane was "meant to serve" and nothing
+    /// compiles here in its place. Counting it left 13 of 25 attempts on memex.systemorph.com
+    /// reading as misses on 2026-09-12 while every one of them had landed correctly.</para>
     /// </summary>
-    public bool IsMiss => Kind != BundleAdoptionKind.Adopted || Adopted < Offered;
+    public bool IsMiss =>
+        Kind is not (BundleAdoptionKind.Adopted or BundleAdoptionKind.NothingToAdopt)
+        || Adopted < Offered;
 
     /// <summary>One line, for a log or a health payload.</summary>
     public string Describe() => Kind switch
@@ -76,6 +145,9 @@ public sealed record BundleAdoptionOutcome(
             $"{PluginId}: adopted {Adopted}/{Offered}",
         BundleAdoptionKind.Adopted =>
             $"{PluginId}: adopted only {Adopted}/{Offered} — the rest compile here",
+        BundleAdoptionKind.NothingToAdopt =>
+            $"{PluginId}: no NodeTypes to adopt"
+            + (string.IsNullOrWhiteSpace(Reason) ? string.Empty : $" ({Reason})"),
         _ => $"{PluginId}: {Kind}"
              + (string.IsNullOrWhiteSpace(Reason) ? string.Empty : $" ({Reason})"),
     };
@@ -146,10 +218,19 @@ public sealed class BundleAdoptionLedger
 
         var misses = all.Where(o => o.IsMiss).ToArray();
         var adopted = all.Sum(o => o.Adopted);
+        // 🚨 The attempts that offered nothing are NAMED in the denominator rather than silently
+        // dropped from it. "25 attempts, 25 adopted, no misses" over a population where 13 carried
+        // no NodeTypes invites the reader to conclude 25 packages were served; saying how many had
+        // nothing to serve is what makes the remaining number readable.
+        var nothing = all.Count(o => o.Kind is BundleAdoptionKind.NothingToAdopt);
+        var nothingSuffix = nothing == 0
+            ? string.Empty
+            : $" ({nothing} carried no NodeTypes to adopt)";
         if (misses.Length == 0)
-            return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted, no misses";
+            return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted, "
+                + $"no misses{nothingSuffix}";
 
-        return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted, "
+        return $"{all.Count} adoption attempt(s), {adopted} assembly/assemblies adopted{nothingSuffix}, "
             + $"{misses.Length} MISS(es) — content the registry was meant to serve is compiled "
             + "here instead: "
             + string.Join("; ", misses.Take(Math.Max(1, maxNamed)).Select(m => m.Describe()))

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -280,6 +280,24 @@ public sealed class PluginBundleClient
         return Observable.Return(0);
     }
 
+    /// <summary>
+    /// Records an attempt that had nothing to adopt and was RIGHT to have nothing — a module-only
+    /// or content-only package (#3768).
+    ///
+    /// <para>🚨 Unlike <see cref="Miss"/> this never throws on a require-prebuilt mesh, and the
+    /// difference is the point rather than an omission. <c>Modules:RequirePrebuilt</c> forbids a
+    /// SILENT FALLBACK TO COMPILING; a package that declares no NodeTypes compiles nothing here, so
+    /// there is no fallback to forbid. Routing it through <see cref="Miss"/> made such a mesh throw
+    /// <see cref="PrebuiltRequiredException"/> for a package that was delivered exactly as
+    /// published — failing the install of a correct package on a correctness flag.</para>
+    /// </summary>
+    private IObservable<int> Nothing(string pluginId, string? reason)
+    {
+        _ledger?.Record(new BundleAdoptionOutcome(
+            pluginId, BundleAdoptionKind.NothingToAdopt, _registryUrl, Reason: reason));
+        return Observable.Return(0);
+    }
+
     /// <summary>The consequence half of a miss LOG LINE, truthful per mode: a default mesh
     /// compiles, a require-prebuilt mesh fails the adoption right after the line (#2198 review).</summary>
     private string MissConsequence(string defaultConsequence) =>
@@ -684,6 +702,32 @@ public sealed class PluginBundleClient
 
                 if (assemblies.Count == 0)
                 {
+                    // 🚨 "The bundle has no NodeTypes" and "the bundle's NodeTypes failed to
+                    // arrive" are the same observation with opposite meanings, and they were the
+                    // same return value until #3768: a module-only package (AI, Anthropic, Maps,
+                    // Chat, Mcp, …) always resolves to zero assemblies, its module lands correctly
+                    // through the separate ModuleLandingService path, and it was still recorded as
+                    // "content the registry was meant to serve is compiled here instead". On
+                    // memex.systemorph.com that was 13 of 25 attempts, holding bundle_adoption at
+                    // Degraded permanently on a portal with nothing wrong with it — and this is the
+                    // instrument three open delivery issues are triaged with.
+                    //
+                    // 🚨 The distinction is drawn from a POSITIVE DECLARATION in the manifest — the
+                    // package says it ships a module, or content — never from the absence of
+                    // assemblies. Inferring "no assemblies ⇒ nothing was expected" would silence
+                    // the real defect of a producer shipping an empty archive, which is exactly the
+                    // fail-closed direction this enum was split up to preserve. A bundle that
+                    // declares nothing at all stays NoAssemblies, and stays a miss.
+                    if (BundleOffering.ClassifyEmpty(manifest)
+                        is BundleAdoptionKind.NothingToAdopt)
+                    {
+                        var offering = BundleOffering.OfferingOf(manifest);
+                        _logger?.LogInformation(
+                            "Bundle for {Plugin} declares no NodeTypes ({Offering}) — nothing to "
+                            + "adopt, and nothing is compiled here in its place", pluginId, offering);
+                        return Nothing(pluginId, $"the package ships {offering}, no NodeTypes");
+                    }
+
                     _logger?.LogInformation(
                         "Bundle for {Plugin} carried no assemblies — {Consequence}", pluginId,
                         MissConsequence("compiling instead"));

--- a/test/Memex.Portal.Shared.Test/ModuleOnlyBundleIsNotAMissTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleOnlyBundleIsNotAMissTest.cs
@@ -1,0 +1,120 @@
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A bundle that carries no NodeType assemblies means two OPPOSITE things, and until #3768 both
+/// were <see cref="BundleAdoptionKind.NoAssemblies"/> — a miss, rendered on <c>/health</c> as
+/// "content the registry was meant to serve is compiled here instead".
+///
+/// <para>Measured 2026-09-12 on memex.systemorph.com: <c>25 adoption attempt(s), 25 adopted,
+/// 13 MISS(es)</c> — and all thirteen (<c>AI</c>, <c>Anthropic</c>, <c>AppleIntelligence</c>,
+/// <c>Maps</c>, <c>AzureBlob</c>, <c>AzureFoundry</c>, <c>Chat</c>, <c>Mcp</c>,
+/// <c>Notifications</c>, <c>OpenAI</c>, …) were module packages whose modules had landed
+/// correctly through the separate <c>ModuleLandingService</c> path. The portal read Degraded
+/// permanently with nothing wrong with it, on the one instrument the delivery issues are triaged
+/// with.</para>
+///
+/// <para>🚨 The falsification arms are the point of this file: the benign reading is taken ONLY
+/// from a positive declaration. An empty archive that declares nothing stays a miss.</para>
+/// </summary>
+public class ModuleOnlyBundleIsNotAMissTest
+{
+    private static BundleReader.Manifest Manifest(
+        BundleReader.ModuleRef? module = null,
+        IReadOnlyList<string>? content = null,
+        IReadOnlyList<string>? misses = null) =>
+        new("AI", "1.7.1", "s3e3c80238a740a8cb895a72b0bfb9cd6",
+            Assemblies: [], Module: module, Architecture: "linux-x64",
+            Misses: misses, Content: content);
+
+    [Fact]
+    public void AModuleOnlyBundle_HasNothingToAdopt_AndIsNotAMiss()
+    {
+        var manifest = Manifest(module: new BundleReader.ModuleRef("MeshWeaver.AI", ["MeshWeaver.AI.dll"]));
+
+        BundleOffering.ClassifyEmpty(manifest).Should().Be(BundleAdoptionKind.NothingToAdopt,
+            "a package that DECLARES a module has no NodeTypes to offer and is complete as delivered");
+        BundleOffering.OfferingOf(manifest).Should().Be("module 'MeshWeaver.AI'");
+
+        new BundleAdoptionOutcome("AI", BundleAdoptionKind.NothingToAdopt, "https://registry")
+            .IsMiss.Should().BeFalse("nothing was meant to be served, so nothing compiles here instead");
+    }
+
+    [Fact]
+    public void AContentOnlyBundle_HasNothingToAdopt()
+    {
+        BundleOffering.ClassifyEmpty(Manifest(content: ["Doc/Readme.md"]))
+            .Should().Be(BundleAdoptionKind.NothingToAdopt);
+    }
+
+    // ---- falsification arms: the benign reading must NOT be reachable by absence ----
+
+    [Fact]
+    public void AnEmptyArchiveThatDeclaresNothing_STAYS_AMiss()
+    {
+        BundleOffering.ClassifyEmpty(Manifest()).Should().Be(BundleAdoptionKind.NoAssemblies,
+            "a producer that shipped an empty archive is a real defect — inferring 'nothing was "
+            + "expected' from emptiness is exactly what would silence it");
+
+        new BundleAdoptionOutcome("AI", BundleAdoptionKind.NoAssemblies, "https://registry")
+            .IsMiss.Should().BeTrue();
+    }
+
+    [Fact]
+    public void UnresolvedProducerMisses_DominateEveryDeclaration_AndStayAMiss()
+    {
+        var shortBundle = Manifest(
+            module: new BundleReader.ModuleRef("MeshWeaver.AI", ["MeshWeaver.AI.dll"]),
+            content: ["Doc/Readme.md"],
+            misses: ["AI/Agent: no artifact for this lane"]);
+
+        BundleOffering.ClassifyEmpty(shortBundle).Should().Be(BundleAdoptionKind.NoAssemblies,
+            "the bake could not resolve a type it was asked for — the bundle is SHORT whatever "
+            + "else it declares, and that is the miss #1751 exists to keep countable");
+    }
+
+    [Fact]
+    public void AnUnreadableManifest_StaysAMiss()
+    {
+        BundleOffering.ClassifyEmpty(null).Should().Be(BundleAdoptionKind.NoAssemblies);
+    }
+
+    // ---- the rendered sentence keeps its denominator ----
+
+    [Fact]
+    public void TheLedgerNamesHowManyHadNothingToOffer_SoTheRestIsReadable()
+    {
+        var ledger = new BundleAdoptionLedger();
+        ledger.Record(new BundleAdoptionOutcome(
+            "Store", BundleAdoptionKind.Adopted, "https://registry", Adopted: 3, Offered: 3));
+        ledger.Record(new BundleAdoptionOutcome(
+            "AI", BundleAdoptionKind.NothingToAdopt, "https://registry"));
+        ledger.Record(new BundleAdoptionOutcome(
+            "Maps", BundleAdoptionKind.NothingToAdopt, "https://registry"));
+
+        ledger.Misses.Should().BeEmpty("two module packages and one fully adopted package is a clean lane");
+
+        var line = ledger.Describe();
+        line.Should().Contain("3 adoption attempt(s)");
+        line.Should().Contain("no misses");
+        line.Should().Contain("2 carried no NodeTypes to adopt",
+            "'3 attempts, 3 adopted, no misses' would invite the reader to conclude three packages "
+            + "were served — the split is what makes the number readable");
+    }
+
+    [Fact]
+    public void ARealMissIsStillLoud_AlongsideThePackagesThatOfferedNothing()
+    {
+        var ledger = new BundleAdoptionLedger();
+        ledger.Record(new BundleAdoptionOutcome("AI", BundleAdoptionKind.NothingToAdopt, "https://registry"));
+        ledger.Record(new BundleAdoptionOutcome(
+            "SocialMedia", BundleAdoptionKind.FrameworkDeclined, "https://registry",
+            Reason: "built against framework s72c27af, live framework is s414bfb2"));
+
+        ledger.Misses.Should().ContainSingle().Which.PluginId.Should().Be("SocialMedia");
+        ledger.Describe().Should().Contain("1 MISS(es)").And.Contain("FrameworkDeclined");
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ModuleOnlyBundleIsNotAMissTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleOnlyBundleIsNotAMissTest.cs
@@ -1,3 +1,6 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text.Json;
 using MeshWeaver.Plugin.Packaging;
 using MeshWeaver.PluginCatalog;
 using Xunit;
@@ -80,6 +83,54 @@ public class ModuleOnlyBundleIsNotAMissTest
     public void AnUnreadableManifest_StaysAMiss()
     {
         BundleOffering.ClassifyEmpty(null).Should().Be(BundleAdoptionKind.NoAssemblies);
+    }
+
+    /// <summary>
+    /// 🚨 The review finding on #4079. A MIXED package declares NodeType assemblies AND a module.
+    /// <see cref="BundleReader.Read(byte[])"/> skips a declared assembly whose archive entry is
+    /// absent — silently, recording no miss — so a torn bundle reaches the empty branch looking
+    /// exactly like a module-only one. Reading it as "nothing to adopt" would hide a genuinely
+    /// missing NodeType, and would hide it from <c>Modules:RequirePrebuilt</c>, which exists to
+    /// refuse precisely that.
+    /// </summary>
+    [Fact]
+    public void ADeclaredNodeTypeThatDidNotArrive_IsAMiss_EvenWhenTheBundleAlsoShipsAModule()
+    {
+        var manifest = new BundleReader.Manifest("Social", "1.2.0", "sframework",
+            Assemblies: [new BundleReader.AssemblyRef("SocialMedia/Post", "Post.dll")],
+            Module: new BundleReader.ModuleRef("MeshWeaver.Social", ["MeshWeaver.Social.dll"]),
+            Content: ["Post/Readme.md"]);
+
+        BundleOffering.ClassifyEmpty(manifest).Should().Be(BundleAdoptionKind.NoAssemblies,
+            "the manifest PROMISED NodeType bytes and none arrived — a torn bundle, not a "
+            + "module-only one, however the package describes the rest of itself");
+    }
+
+    /// <summary>The same thing end to end: a real archive whose declared assembly entry is absent.</summary>
+    [Fact]
+    public void ARealBundleMissingItsDeclaredAssemblyEntry_ReadsEmpty_AndIsStillAMiss()
+    {
+        var declared = new BundleReader.Manifest("Social", "1.2.0", "sframework",
+            Assemblies: [new BundleReader.AssemblyRef("SocialMedia/Post", "Post.dll")],
+            Module: new BundleReader.ModuleRef("MeshWeaver.Social", ["MeshWeaver.Social.dll"]));
+
+        using var buffer = new MemoryStream();
+        using (var archive = new ZipArchive(buffer, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            using var entry = new StreamWriter(
+                archive.CreateEntry(NuGetPackageWriter.ManifestEntry).Open());
+            entry.Write(JsonSerializer.Serialize(declared, new JsonSerializerOptions(JsonSerializerDefaults.Web)));
+        }
+        // NOTE: meshweaver/assemblies/Post.dll is deliberately NOT written.
+
+        var (manifest, assemblies) = BundleReader.Read(buffer.ToArray());
+
+        assemblies.Should().BeEmpty("BundleReader skips a declared assembly with no archive entry");
+        manifest!.Assemblies.Should().ContainSingle("…while the manifest still declares it");
+        (manifest.Misses?.Count ?? 0).Should().Be(0, "and the producer recorded no miss for it");
+
+        BundleOffering.ClassifyEmpty(manifest).Should().Be(BundleAdoptionKind.NoAssemblies,
+            "which is exactly the shape that must NOT read as 'nothing to adopt'");
     }
 
     // ---- the rendered sentence keeps its denominator ----


### PR DESCRIPTION
## The reading this removes

`#4002` fixed the identity-selection defect (#3768) and, in doing so, stopped masking a second one.
Measured on **memex.systemorph.com, 2026-09-12**, both replicas agreeing:

```
bundle_adoption: Degraded — 25 adoption attempt(s), 25 assembly/assemblies adopted, 13 MISS(es)
  — content the registry was meant to serve is compiled here instead:
  AI: NoAssemblies (the bundle carried no assemblies); Anthropic: NoAssemblies;
  AppleIntelligence, Maps, AzureBlob, AzureFoundry, Chat, Mcp, Notifications, OpenAI, …(+3)
```

All thirteen are **module packages**. They declare no NodeTypes, their bundle is complete and empty
by design, their module lands through `ModuleLandingService` — a different path, which `SeedAll`
does not touch — and **nothing is compiled here in their place**.

## Two costs, not one

- **`bundle_adoption` read Degraded permanently on a healthy portal.** That is the instrument the
  open delivery issues are triaged with, so the false reading was being quoted as evidence in other
  investigations.
- **On a `Modules:RequirePrebuilt` mesh the install FAILED.** `Miss()` throws
  `PrebuiltRequiredException`, so a module-only package failed the install of a correctly delivered
  package. The flag forbids a silent fallback to *compiling*; a package that compiles nothing has no
  fallback to forbid. `Nothing()` deliberately does not throw, and says why.

## The shape

`BundleAdoptionKind.NothingToAdopt` separates *"this package has no NodeTypes"* from *"this
package's NodeTypes failed to arrive"* — the exact conflation this enum was split up to prevent,
reappearing one value further along.

🚨 **`BundleOffering.ClassifyEmpty` decides from a POSITIVE DECLARATION** in the manifest (the
package says it ships a module, or content), never from the absence of assemblies — so the benign
reading cannot be reached by accident:

| bundle | verdict |
|---|---|
| declares a module, no assemblies | `NothingToAdopt` — not a miss |
| declares content, no assemblies | `NothingToAdopt` — not a miss |
| declares **nothing** at all | `NoAssemblies` — **still a miss**, still loud |
| producer `Misses` non-empty | `NoAssemblies` — dominates every declaration |
| unreadable manifest | `NoAssemblies` |

The ledger keeps the denominator visible — `no misses (13 carried no NodeTypes to adopt)` — because
*"25 attempts, 25 adopted, no misses"* would invite the reader to conclude 25 packages were served.

## Verification

- `dotnet build src/MeshWeaver.PluginCatalog -c Release -warnaserror` → **0 Error(s)**, 21.6 s
- `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` → **0 Error(s)**
- `ModuleOnlyBundleIsNotAMissTest` → **7 passed**, `.trx` written
- 🚨 **Mutation-checked:** reverting `IsMiss` to its pre-fix predicate turns **3 of the 7 red**, so
  the test cannot pass on no evidence. Restored and re-verified green.
- `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`, existing
  `PluginBundleArtifactFetchTest` → all green.

The Plugins-side `BundleAdoptionHealthCheck` reads `ledger.Misses` / `ledger.Describe()` directly,
so the Degraded→Healthy flip needs **no change in the host**.

## Surface

Purely **additive** — one enum member, one new public static class, no removals, so no
`Pairs-with:` applies. No exhaustive switch on `BundleAdoptionKind` exists in core `src/`, `memex/`,
`test/`, or MeshWeaver.Plugins `src/` (checked); the only other consumer asserts `ArtifactRefused`.

## Conserved

`Doc/Architecture/BundleDeliveryStages` records the wider finding this came out of: the **four
independent stages** between a merge and a portal serving prebuilt bytes — write (#3461), compose
(#3732), select (#3768), deliver (#3583 → #3845) — which instrument answers for each, and the
measurements showing that today's live CI cost belongs to stage 4, not to #3732:

> 2026-09-11T08:20Z → 2026-09-12T07:51Z, `MeshWeaver.Reinsurance`, counted **by job**: 91 runs,
> 33 failed jobs — **23** at `Gate: every upstream must be published for that identity`
> (`crm` missing in 23/23, across **18 distinct framework identities**), **10** on Ifrs17 content
> gates. **#3905's module-set assertion was green in all 10 — over a denominator of 4.**

Refs #3768, #3583, #3732, #3461.

🤖 Generated with [Claude Code](https://claude.com/claude-code)