### PR TITLE
fix(#3583): the upstream gate's three refusals are told apart in the log

### DIFF
--- a/.github/scripts/check-release-availability.sh
+++ b/.github/scripts/check-release-availability.sh
@@ -20,6 +20,23 @@
 # unreadable share, or a missing marker all exit 1 with a reason that says which happened. An
 # availability failure must never be reported as a compatibility verdict, and neither may pass.
 #
+# 🚨 THREE OUTCOMES, THREE HEADLINES — never one count (MeshWeaver#3583). They are greppable and
+# they must stay that way; a test asserts on this text, because a gate whose arms cannot be told
+# apart in a log is the defect:
+#
+#   CANNOT RESOLVE …   no identity could be resolved at all. A REFUSAL: there is no directory to
+#                      ask about, so NOTHING was checked and no source may be called absent.
+#   CANNOT DETERMINE … an identity was resolved, but one or more probes ERRORED. Also a refusal:
+#                      with probes failing, "N of M absent" has an unknown denominator, so the
+#                      absent count is reported only as a FLOOR, under this headline, never as the
+#                      verdict.
+#   release availability: N of M source(s) are not available …
+#                      every probe answered, and the answer was NO. This is the only one that is a
+#                      statement about an upstream, and the only one a reader should act on by
+#                      waiting for or triggering that upstream.
+#
+# All three exit 1. Distinguishing them changes what the reader DOES, never whether the gate fails.
+#
 # 🚨 FAIL LOUD and DISTINGUISHABLE. Every refusal writes ::error:: lines AND a step summary naming
 # exactly what is missing. GitHub renders a skipped job with the same tick as a passed one, so this
 # script never exits 0 on "could not check" — the trapdoor AGENTS.md forbids.
@@ -34,16 +51,26 @@
 # --auth-mode login --backup-intent, i.e. the "Storage File Data Privileged Contributor" role.
 set -uo pipefail
 
-USAGE="usage: check-release-availability.sh <release-version|--identity <id>> [<source> ...]"
+USAGE="usage: check-release-availability.sh <release-version|--identity <id>> [--identity-origin <text>] [<source> ...]"
 
 IDENTITY=""
 VERSION=""
+# 🚨 WHY the caller states the origin: the identity is resolved somewhere else (a repo PIN, a wake
+# payload, a moving release tag), and when this gate holds, "why is it waiting" is a question about
+# THAT step, not this one. Without the origin in the log the reader has to guess which trigger path
+# produced the identity, and the three paths want three different actions — move the pin, wait for
+# the wave, or stop expecting a moving tag to converge (MeshWeaver#3583).
+IDENTITY_ORIGIN=""
 if [ "${1:-}" = "--identity" ]; then
   IDENTITY="${2:?$USAGE}"
   shift 2
 else
   VERSION="${1:?$USAGE}"
   shift
+fi
+if [ "${1:-}" = "--identity-origin" ]; then
+  IDENTITY_ORIGIN="${2:?$USAGE}"
+  shift 2
 fi
 
 SOURCES=("$@")
@@ -84,34 +111,60 @@ if [ -z "$IDENTITY" ]; then
   if ! az storage file download --account-name "$ACCOUNT" --share-name "$SHARE" \
         --path "$ROOT/$RELEASES_DIR/$VERSION" --dest "$MARKER_LOCAL" \
         --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
-    die "release '$VERSION' has no marker at $ROOT/$RELEASES_DIR/$VERSION — its framework identity is unknown, so NO package can be shown available for it. Cannot determine ≠ clear to proceed."
+    die "CANNOT RESOLVE a framework identity: release '$VERSION' has no marker at $ROOT/$RELEASES_DIR/$VERSION. This is a REFUSAL, not a verdict about any upstream — with no identity there is no directory to ask about, so nothing below was checked and NO source may be reported absent. Cannot determine ≠ clear to proceed."
   fi
   IDENTITY=$(tr -d '[:space:]' < "$MARKER_LOCAL")
-  [ -n "$IDENTITY" ] || die "the release marker for '$VERSION' is empty — the producer recorded no framework identity."
-  echo "release $VERSION → framework identity $IDENTITY"
+  [ -n "$IDENTITY" ] || die "CANNOT RESOLVE a framework identity: the release marker for '$VERSION' is empty — the producer recorded none. This is a REFUSAL, not a verdict about any upstream; nothing below was checked."
+  [ -n "$IDENTITY_ORIGIN" ] || IDENTITY_ORIGIN="the release marker at $ROOT/$RELEASES_DIR/$VERSION"
 fi
+
+# 🚨 Printed on EVERY path, before the first probe, whether or not anything is wrong. The identity
+# is the directory name every answer below is keyed on, so a log that does not name it leaves the
+# reader unable to tell "the upstream is late" from "we asked about the wrong identity" — and those
+# have opposite fixes. Stated once, here, rather than only inside a refusal.
+ORIGIN_TEXT="$IDENTITY_ORIGIN"
+[ -n "$ORIGIN_TEXT" ] || ORIGIN_TEXT="the caller's --identity argument (origin not stated)"
+echo "identity resolved: $IDENTITY — from $ORIGIN_TEXT"
+summary "- 🎯 asking about framework identity \`$IDENTITY\` — from $ORIGIN_TEXT"
 
 # ── Assert every named source is SEALED under that identity ─────────────────────────────────────
 # Keyed on the sentinel, never on "the directory exists": the sentinel is written strictly LAST, so
 # a publish that died mid-way leaves a directory the portal's own seeder refuses. Counting it here
 # would clear a release the portal then recompiles — the very outcome the gate exists to prevent.
-MISSING=()
+# 🚨 TWO BUCKETS, NEVER ONE. "This upstream has not published" and "I could not ask" are different
+# failures with different fixes — wait for/trigger the upstream, versus fix the credential, the
+# share or the network — and folding them into one count reported the second as the first. Both
+# still exit 1: neither is a pass, and this gate never goes advisory (MeshWeaver#3583).
+ABSENT=()       # asked, and the answer was NO
+UNDETERMINED=() # could not ask — a REFUSAL, never a smaller number
 for source in "${SOURCES[@]}"; do
   exists=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
     --path "$ROOT/$IDENTITY/$source/$SENTINEL" --auth-mode login --backup-intent \
     --query exists -o tsv --only-show-errors 2>/dev/null || echo "unknown")
   case "$exists" in
     true)  echo "sealed: $source (identity $IDENTITY)"; summary "- ✅ \`$source\` is published for \`$IDENTITY\`";;
-    false) MISSING+=("$source — no sealed publication under $ROOT/$IDENTITY/$source");;
+    false) ABSENT+=("$source — no sealed publication under $ROOT/$IDENTITY/$source");;
     # 🚨 An errored probe is NOT an absent one, and it is NOT a present one either. Both readings
     # would be a lie; the honest answer is a hold naming the unreadability.
-    *)     MISSING+=("$source — the share could not be queried, so availability CANNOT BE DETERMINED");;
+    *)     UNDETERMINED+=("$source — the share could not be queried at $ROOT/$IDENTITY/$source");;
   esac
 done
 
-if [ "${#MISSING[@]}" -gt 0 ]; then
-  echo "::error::release availability: ${#MISSING[@]} of ${#SOURCES[@]} source(s) are not available for framework identity $IDENTITY${VERSION:+ (release $VERSION)}."
-  for m in "${MISSING[@]}"; do echo "::error::  • $m"; summary "- ❌ $m"; done
+# Reported FIRST and on its own, because it invalidates the other number: when some probes errored,
+# "N of M are not available" is not a measurement anyone may act on — the denominator is unknown.
+if [ "${#UNDETERMINED[@]}" -gt 0 ]; then
+  echo "::error::CANNOT DETERMINE release availability for framework identity $IDENTITY${VERSION:+ (release $VERSION)}: ${#UNDETERMINED[@]} of ${#SOURCES[@]} source(s) could not be queried. This is a REFUSAL, not a verdict — the gate could not ask its question, so nothing here says whether the upstream published. Fix the access to the artifact store (az login / BAKE_PUBLISH_TARGETS / the share) and re-run."
+  for u in "${UNDETERMINED[@]}"; do echo "::error::  • $u"; summary "- ⛔ $u"; done
+  if [ "${#ABSENT[@]}" -gt 0 ]; then
+    echo "::error::  (also, ${#ABSENT[@]} source(s) answered NO — but with probes erroring that count is a floor, not the number.)"
+    for m in "${ABSENT[@]}"; do echo "::error::    • $m"; done
+  fi
+  exit 1
+fi
+
+if [ "${#ABSENT[@]}" -gt 0 ]; then
+  echo "::error::release availability: ${#ABSENT[@]} of ${#SOURCES[@]} source(s) are not available for framework identity $IDENTITY${VERSION:+ (release $VERSION)}."
+  for m in "${ABSENT[@]}"; do echo "::error::  • $m"; summary "- ❌ $m"; done
   exit 1
 fi
 

--- a/.github/scripts/test-release-availability-refusals.py
+++ b/.github/scripts/test-release-availability-refusals.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""EXECUTE `check-release-availability.sh` and assert its three outcomes are TOLD APART in the log.
+
+WHY
+---
+This gate is the one that held `MeshWeaver.Reinsurance` 23 times in 24 hours (MeshWeaver#3583).
+Every refusal exits 1 — that is correct and is not what this tests. What it tests is that a reader
+can tell, from the log alone, WHICH of three different things happened, because they want three
+different actions:
+
+  * CANNOT RESOLVE …  no identity at all. Nothing was checked; no upstream may be called absent.
+  * CANNOT DETERMINE … an identity, but a probe ERRORED. The absent count is a floor, not a verdict.
+  * release availability: N of M … every probe answered NO. The only one that is a statement about
+    an upstream, and the only one to act on by waiting for it.
+
+Before this change the middle case was folded into the last one's count, so "I could not ask" was
+reported as "the upstream has not published" — a smaller number in place of a refusal.
+
+HOW IT STAYS HONEST
+-------------------
+* The REAL script is executed, never a copy — a copy passes while the real thing rots.
+* `az` is a PATH stub driven by env vars, so no credential and no network are involved.
+* Every case asserts on the DISTINGUISHING TEXT and also asserts the OTHER headlines are ABSENT.
+  Asserting only "exit 1" would pass even if all three printed the same sentence, which is the
+  defect being fixed.
+* Case 4 is a CONTROL that must PASS (exit 0). A harness whose every case is a failure cannot tell
+  "the gate refuses correctly" from "the gate always refuses".
+* Case 5 asserts the resolved identity and its ORIGIN are printed on the success path too — the
+  log has to answer "which identity did we ask about" when nothing is wrong, or it cannot be
+  compared against a run where something is.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+SCRIPT = ROOT / "check-release-availability.sh"
+
+RESOLVE = "CANNOT RESOLVE"
+DETERMINE = "CANNOT DETERMINE"
+ABSENT = "are not available for framework identity"
+
+# `az` stub. Behaviour per invocation is chosen by env vars the case sets:
+#   AZ_MARKER_FAIL=1   -> `storage file download` fails (no release marker)
+#   AZ_EXISTS=<v>      -> `storage file exists` prints <v> ("true"/"false")
+#   AZ_EXISTS_FAIL=1   -> `storage file exists` exits non-zero (an ERRORED probe)
+#   AZ_EXISTS_MAP      -> "source=true;source2=false" per-source override
+AZ_STUB = r"""#!/usr/bin/env bash
+args="$*"
+case "$args" in
+  *"storage file download"*)
+    if [ "${AZ_MARKER_FAIL:-0}" = "1" ]; then exit 1; fi
+    dest=""; prev=""
+    for a in "$@"; do [ "$prev" = "--dest" ] && dest="$a"; prev="$a"; done
+    printf '%s' "${AZ_MARKER_VALUE:-sdeadbeefdeadbeefdeadbeefdeadbeef}" > "$dest"
+    exit 0 ;;
+  *"storage file exists"*)
+    path=""; prev=""
+    for a in "$@"; do [ "$prev" = "--path" ] && path="$a"; prev="$a"; done
+    src=$(printf '%s' "$path" | awk -F/ '{print $(NF-1)}')
+    if [ -n "${AZ_EXISTS_MAP:-}" ]; then
+      for pair in $(printf '%s' "$AZ_EXISTS_MAP" | tr ';' ' '); do
+        k="${pair%%=*}"; v="${pair#*=}"
+        if [ "$k" = "$src" ]; then
+          [ "$v" = "error" ] && exit 3
+          printf '%s\n' "$v"; exit 0
+        fi
+      done
+    fi
+    if [ "${AZ_EXISTS_FAIL:-0}" = "1" ]; then exit 3; fi
+    printf '%s\n' "${AZ_EXISTS:-true}"; exit 0 ;;
+esac
+exit 0
+"""
+
+
+def run(args, **env):
+    """Execute the real script with the az stub on PATH. Returns (rc, combined output)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        stub = Path(tmp) / "az"
+        stub.write_text(AZ_STUB)
+        stub.chmod(0o755)
+        e = dict(os.environ)
+        e["PATH"] = f"{tmp}:{e['PATH']}"
+        e["BAKE_PUBLISH_TARGETS"] = "acct/share/base"
+        e.pop("GITHUB_STEP_SUMMARY", None)
+        e.update({k: str(v) for k, v in env.items()})
+        p = subprocess.run([str(SCRIPT), *args], capture_output=True, text=True, env=e)
+        return p.returncode, p.stdout + p.stderr
+
+
+FAILURES: list[str] = []
+
+
+def check(case, cond, detail):
+    if cond:
+        print(f"  ok   {case}: {detail}")
+    else:
+        print(f"  FAIL {case}: {detail}")
+        FAILURES.append(f"{case}: {detail}")
+
+
+def expect_only(case, out, present, absent_list):
+    check(case, present in out, f"says {present!r}")
+    for other in absent_list:
+        check(case, other not in out, f"does NOT also say {other!r}")
+
+
+def main() -> int:
+    print("case 1 — no release marker: CANNOT RESOLVE, and nothing is called absent")
+    rc, out = run(["3.0.0-ci.9999", "crm"], AZ_MARKER_FAIL=1)
+    check("case 1", rc != 0, f"exits non-zero (got {rc})")
+    expect_only("case 1", out, RESOLVE, [ABSENT, DETERMINE])
+    check("case 1", "crm" not in out.split(RESOLVE)[-1].split("\n")[0],
+          "the refusal line does not name an upstream as absent")
+
+    print("case 2 — identity resolves, upstream absent: the availability verdict, not a refusal")
+    rc, out = run(["--identity", "sabc", "crm"], AZ_EXISTS="false")
+    check("case 2", rc != 0, f"exits non-zero (got {rc})")
+    expect_only("case 2", out, ABSENT, [RESOLVE, DETERMINE])
+    check("case 2", "crm" in out, "names the upstream that has not published")
+
+    print("case 3 — identity resolves, probe ERRORS: CANNOT DETERMINE, never an absent count")
+    rc, out = run(["--identity", "sabc", "crm"], AZ_EXISTS_FAIL=1)
+    check("case 3", rc != 0, f"exits non-zero (got {rc})")
+    expect_only("case 3", out, DETERMINE, [RESOLVE, ABSENT])
+
+    print("case 3b — one errored probe + one genuine NO: the NO is a FLOOR under the refusal")
+    rc, out = run(["--identity", "sabc", "crm", "plugins"],
+                  AZ_EXISTS_MAP="crm=error;plugins=false")
+    check("case 3b", rc != 0, f"exits non-zero (got {rc})")
+    expect_only("case 3b", out, DETERMINE, [RESOLVE, ABSENT])
+    check("case 3b", "floor, not the number" in out,
+          "says the absent count is a floor while probes are erroring")
+
+    print("case 4 — CONTROL: everything sealed must PASS")
+    rc, out = run(["--identity", "sabc", "crm", "plugins"], AZ_EXISTS="true")
+    check("case 4", rc == 0, f"exits 0 (got {rc})")
+    for h in (RESOLVE, DETERMINE, ABSENT):
+        check("case 4", h not in out, f"prints no {h!r}")
+
+    print("case 5 — the identity and its ORIGIN are logged, including on the success path")
+    rc, out = run(["--identity", "sabc", "--identity-origin", "the portal image 'x:1' (event=schedule)",
+                   "crm"], AZ_EXISTS="true")
+    check("case 5", rc == 0, f"exits 0 (got {rc})")
+    check("case 5", "identity resolved: sabc" in out, "names the identity it asked about")
+    check("case 5", "event=schedule" in out, "names WHY that identity — the origin the caller gave")
+
+    print("case 6 — origin is stated as unknown rather than silently omitted")
+    rc, out = run(["--identity", "sabc", "crm"], AZ_EXISTS="true")
+    check("case 6", "identity resolved: sabc" in out, "still names the identity")
+    check("case 6", "origin not stated" in out, "says the origin was not supplied")
+
+    print()
+    if FAILURES:
+        print(f"FAILED — {len(FAILURES)} assertion(s):")
+        for f in FAILURES:
+            print(f"  • {f}")
+        return 1
+    print("PASSED — all three outcomes are distinguishable, and the control still passes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-release-availability-refusals.py
+++ b/.github/scripts/test-release-availability-refusals.py
@@ -94,6 +94,20 @@ def run(args, **env):
         return p.returncode, p.stdout + p.stderr
 
 
+WORKFLOW = ROOT.parent / "workflows" / "node-repo-publish-bake.yml"
+STEP_ID = "upstream-gate"
+
+# The `${{ }}` expressions the harness knows how to supply. Anything else in the step is a REFUSAL,
+# not a silent substitution: a step that grew a new input must fail this harness loudly rather than
+# be executed with a guess.
+KNOWN_EXPRESSIONS = {
+    "steps.identity.outputs.identity": "sfeedface",
+    "inputs.upstream-sources": "crm",
+    "inputs.bake-publish-targets": "acct/share/base",
+    "steps.platform.outputs.ref": "portal:resolved-by-this-run",
+    "github.event.action": "meshweaver-framework-released",
+}
+
 FAILURES: list[str] = []
 
 
@@ -109,6 +123,84 @@ def expect_only(case, out, present, absent_list):
     check(case, present in out, f"says {present!r}")
     for other in absent_list:
         check(case, other not in out, f"does NOT also say {other!r}")
+
+
+def extract_step():
+    """The step's `run:` and `env:`, EXTRACTED from the workflow by id — never a copy."""
+    import re as _re
+
+    import yaml  # noqa: PLC0415
+
+    doc = yaml.safe_load(WORKFLOW.read_text())
+    for job in doc.get("jobs", {}).values():
+        for step in job.get("steps", []) or []:
+            if step.get("id") == STEP_ID:
+                run, env = step["run"], step.get("env", {}) or {}
+
+                def fill(text):
+                    def sub(m):
+                        expr = m.group(1).strip()
+                        if expr not in KNOWN_EXPRESSIONS:
+                            raise SystemExit(
+                                f"REFUSING to execute: step '{STEP_ID}' uses an expression this "
+                                f"harness cannot supply: ${{{{ {expr} }}}}. Add it to "
+                                f"KNOWN_EXPRESSIONS deliberately — never guess."
+                            )
+                        return KNOWN_EXPRESSIONS[expr]
+                    return _re.sub(r"\$\{\{([^}]*)\}\}", sub, text)
+
+                return fill(run), {k: fill(str(v)) for k, v in env.items()}
+    raise SystemExit(f"REFUSING: no step with id '{STEP_ID}' in {WORKFLOW}")
+
+
+def run_step(headline: str):
+    """Run the extracted step with the availability script stubbed to print `headline` and fail."""
+    run, env = extract_step()
+    with tempfile.TemporaryDirectory() as tmp:
+        gate = Path(tmp) / "mw-platform-gate" / ".github" / "scripts"
+        gate.mkdir(parents=True)
+        stub = gate / "check-release-availability.sh"
+        stub.write_text("#!/usr/bin/env bash\n"
+                        f"echo {headline!r}\n"
+                        "echo 'identity resolved: sfeedface — from ...'\n"
+                        "exit 1\n" if headline else
+                        "#!/usr/bin/env bash\necho ok\nexit 0\n")
+        stub.chmod(0o755)
+        summary = Path(tmp) / "summary.md"
+        summary.write_text("")
+        e = dict(os.environ)
+        e.update(env)
+        e.update({"GITHUB_STEP_SUMMARY": str(summary), "RUNNER_TEMP": tmp,
+                  "GITHUB_EVENT_NAME": "repository_dispatch"})
+        p = subprocess.run(["bash", "-c", run], cwd=tmp, capture_output=True, text=True, env=e)
+        return p.returncode, p.stdout + p.stderr, summary.read_text()
+
+
+def workflow_cases():
+    upstream_absent = "release availability: 1 of 1 source(s) are not available for framework identity sfeedface."
+    for headline, label, must_say, must_not_say in [
+        (upstream_absent, "upstream absent", "Upstreams not ready",
+         ["Could not resolve", "Could not query"]),
+        ("::error::CANNOT RESOLVE a framework identity: ...", "cannot resolve",
+         "Could not resolve a framework identity", ["Upstreams not ready", "Could not query"]),
+        ("::error::CANNOT DETERMINE release availability ...", "cannot determine",
+         "Could not query the artifact store", ["Upstreams not ready", "Could not resolve"]),
+    ]:
+        rc, out, summary = run_step(headline)
+        both = out + summary
+        check(f"case 7 ({label})", rc != 0, f"the step still fails (rc={rc})")
+        check(f"case 7 ({label})", must_say in both, f"reports {must_say!r}")
+        for other in must_not_say:
+            check(f"case 7 ({label})", other not in both,
+                  f"does NOT also report {other!r}")
+
+    # 🚨 The claim that is FALSE on the refusal paths, asserted directly: a refusal must never say an
+    # upstream has no sealed publication, because nothing was checked.
+    for headline, label in [("::error::CANNOT RESOLVE x", "cannot resolve"),
+                            ("::error::CANNOT DETERMINE x", "cannot determine")]:
+        _, out, summary = run_step(headline)
+        check(f"case 7 ({label})", "has no sealed" not in (out + summary),
+              "never claims an upstream has no sealed publication")
 
 
 def main() -> int:
@@ -155,6 +247,9 @@ def main() -> int:
     rc, out = run(["--identity", "sabc", "crm"], AZ_EXISTS="true")
     check("case 6", "identity resolved: sabc" in out, "still names the identity")
     check("case 6", "origin not stated" in out, "says the origin was not supplied")
+
+    print("case 7 — the WORKFLOW step must not re-collapse what the script distinguished")
+    workflow_cases()
 
     print()
     if FAILURES:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2250,6 +2250,18 @@ jobs:
     - name: "Execute publish-bake-bundles.sh with two publishers on one prefix"
       run: python3 .github/scripts/test-publish-bake-overlap.py
 
+    # The READER side of the same lane, and a log-quality gate rather than a byte one (#3583).
+    # `check-release-availability.sh` is the step that held MeshWeaver.Reinsurance 23 times in 24
+    # hours. Every refusal exits 1 and must keep doing so — that is not what this asserts. It
+    # asserts the three outcomes are TOLD APART in the log, because they want three different
+    # actions: "no identity at all" (nothing was checked), "a probe errored" (the absent count has
+    # an unknown denominator), and "the upstream answered NO" (the only one to act on by waiting
+    # for it). The middle case used to be folded into the last one's count, reporting "I could not
+    # ask" as "the upstream has not published" — a smaller number in place of a refusal. A control
+    # case must still PASS, so the harness cannot confuse "refuses correctly" with "always refuses".
+    - name: "Execute check-release-availability.sh — the three refusals stay distinguishable"
+      run: python3 .github/scripts/test-release-availability-refusals.py
+
     # The MODULE registry hand-over (MeshWeaver#3878). `node-repo-module-publish.yml` is a
     # `workflow_call` lane a SATELLITE invokes, so nothing on a core pull request runs it — the
     # first execution of an edit to it would otherwise be a satellite's production publication,

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -884,11 +884,20 @@ jobs:
         env:
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
           UPSTREAMS: ${{ inputs.upstream-sources }}
+          PLATFORM_IMAGE: ${{ inputs.platform-image }}
+          PLATFORM_DIGEST: ${{ inputs.platform-image-digest }}
         run: |
           set -uo pipefail
+          # 🚨 The identity is resolved two steps up, from the PORTAL image — and WHICH portal image
+          # this run got depends entirely on the trigger (a repo PIN on push/pull_request, the wake's
+          # payload on repository_dispatch, a MOVING release tag on schedule). When this gate holds,
+          # "why is it waiting" is a question about that choice, and the three paths want three
+          # different actions. Stating it here makes the log self-contained (MeshWeaver#3583).
+          ORIGIN="the portal image '$PLATFORM_IMAGE'${PLATFORM_DIGEST:+ @ $PLATFORM_DIGEST}, chosen by this run's trigger (event=$GITHUB_EVENT_NAME)"
           # shellcheck disable=SC2086
           if mw-platform-gate/.github/scripts/check-release-availability.sh \
-               --identity "${{ steps.identity.outputs.identity }}" $UPSTREAMS; then
+               --identity "${{ steps.identity.outputs.identity }}" \
+               --identity-origin "$ORIGIN" $UPSTREAMS; then
             echo "every upstream is published for ${{ steps.identity.outputs.identity }} — building."
             exit 0
           fi

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -879,13 +879,27 @@ jobs:
           subscription-id: ${{ secrets.azure-subscription-id }}
       # The framework identity BOTH the upstream gate and the scope decision key on is resolved
       # above (steps.identity) — from the PORTAL's /app, unconditionally, since MeshWeaver#3022.
+      # `id:` so test-release-availability-refusals.py can EXTRACT and execute this step rather than
+      # re-implement it — a copy of a workflow step passes while the step itself rots.
       - name: "Gate: every upstream must be published for that identity"
+        id: upstream-gate
         if: inputs.upstream-sources != ''
         env:
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
           UPSTREAMS: ${{ inputs.upstream-sources }}
-          PLATFORM_IMAGE: ${{ inputs.platform-image }}
-          PLATFORM_DIGEST: ${{ inputs.platform-image-digest }}
+          # 🚨 The RESOLVED ref, not the declared input. `steps.platform` resolves it from the wake's
+          # payload or from <platform-image>:<released-version>, and `steps.identity` reads its /app
+          # — so on the dispatch paths `inputs.platform-image` can name a DIFFERENT image from the
+          # one the identity actually came from. Logging the declaration instead of the effective
+          # value is the same defect this whole change is about (Copilot on #4084).
+          PORTAL_REF: ${{ steps.platform.outputs.ref }}
+          # Both repository_dispatch actions land on one event_name and they are NOT the same wait:
+          # `meshweaver-framework-released` carries a NEW platform identity nothing may have baked
+          # for yet, while `meshweaver-upstream-published` carries a set the upstream just sealed.
+          # Measured 2026-09-11/12 on MeshWeaver.Reinsurance: 20 of the 23 gate refusals were the
+          # first kind and 3 the second, so collapsing them loses the distinction that explains the
+          # number.
+          EVENT_ACTION: ${{ github.event.action }}
         run: |
           set -uo pipefail
           # 🚨 The identity is resolved two steps up, from the PORTAL image — and WHICH portal image
@@ -893,13 +907,50 @@ jobs:
           # payload on repository_dispatch, a MOVING release tag on schedule). When this gate holds,
           # "why is it waiting" is a question about that choice, and the three paths want three
           # different actions. Stating it here makes the log self-contained (MeshWeaver#3583).
-          ORIGIN="the portal image '$PLATFORM_IMAGE'${PLATFORM_DIGEST:+ @ $PLATFORM_DIGEST}, chosen by this run's trigger (event=$GITHUB_EVENT_NAME)"
+          TRIGGER="event=$GITHUB_EVENT_NAME"
+          [ -z "${EVENT_ACTION:-}" ] || TRIGGER="$TRIGGER action=$EVENT_ACTION"
+          ORIGIN="the portal image '$PORTAL_REF' (the ref this run RESOLVED, whose /app the identity was read from), chosen by this run's trigger ($TRIGGER)"
+          GATE_LOG="$RUNNER_TEMP/upstream-gate.log"
           # shellcheck disable=SC2086
           if mw-platform-gate/.github/scripts/check-release-availability.sh \
                --identity "${{ steps.identity.outputs.identity }}" \
-               --identity-origin "$ORIGIN" $UPSTREAMS; then
+               --identity-origin "$ORIGIN" $UPSTREAMS 2>&1 | tee "$GATE_LOG"; then
             echo "every upstream is published for ${{ steps.identity.outputs.identity }} — building."
             exit 0
+          fi
+          # 🚨 The script distinguishes three outcomes; this block used to assert "at least one
+          # upstream has no sealed publication" for ALL of them, which re-collapsed the distinction
+          # one line after the script made it — and said something FALSE on the refusal paths, where
+          # nothing was ever checked. Branch on the classification the script printed (Copilot on
+          # #4084). A refusal is not a wait on an upstream and must not be reported as one.
+          if grep -q "CANNOT RESOLVE" "$GATE_LOG"; then
+            {
+              echo "### ⛔ Could not resolve a framework identity — did NOT build"
+              echo ""
+              echo "The gate could not determine which framework identity to ask about, so **no"
+              echo "upstream was checked** and none is being reported as unpublished. This is a"
+              echo "REFUSAL, not a wait: nothing in \`$UPSTREAMS\` is implicated."
+              echo ""
+              echo "See the step log for which resolution failed. Re-running will not change it."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Could not resolve a framework identity::the gate could not resolve an identity, so nothing was checked and no upstream is implicated. This is a refusal, not a wait on an upstream."
+            exit 1
+          fi
+          if grep -q "CANNOT DETERMINE" "$GATE_LOG"; then
+            {
+              echo "### ⛔ Could not query the artifact store — did NOT build"
+              echo ""
+              echo "An identity was resolved, but one or more availability probes **errored**, so"
+              echo "the gate could not ask its question. Any count of absent sources in the log is a"
+              echo "**floor**, not a verdict — this says nothing about whether \`$UPSTREAMS\`"
+              echo "published."
+              echo ""
+              echo "This is an ACCESS problem, not an upstream one: check \`az login\` / the OIDC"
+              echo "federation, \`BAKE_PUBLISH_TARGETS\`, and the share's reachability. Waiting for"
+              echo "an upstream will not clear it."
+            } >> "$GITHUB_STEP_SUMMARY"
+            echo "::error title=Could not query the artifact store::availability could not be determined for framework identity ${{ steps.identity.outputs.identity }} — probes errored. This is a refusal, not a verdict about any upstream; fix access to the artifact store."
+            exit 1
           fi
           {
             echo "### ⛔ Upstreams not ready — did NOT build"


### PR DESCRIPTION
The residual piece from the #3583 triage. **Log quality only — no resolution change, nothing advisory, no retry, no fallback.** Every refusal still exits 1 and the gate still fails loudly when an upstream genuinely has not published.

## The defect

`check-release-availability.sh` is the step that held `MeshWeaver.Reinsurance` **23 times in 24 hours**. It folded an *errored probe* into the same `MISSING` array as a *genuinely absent seal*, so the headline read:

```
release availability: 1 of 2 source(s) are not available for framework identity sf0f9ef77…
```

…whether the share had answered "no" or had not answered at all. "I could not ask" was reported as "the upstream has not published" — a smaller number in place of a refusal, which sends the reader to chase an upstream when the fault is a credential, the share, or the network.

## Three outcomes, three headlines

| headline | meaning | what the reader does |
|---|---|---|
| `CANNOT RESOLVE …` | no identity at all | nothing was checked; **no upstream may be called absent** |
| `CANNOT DETERMINE …` | identity resolved, a probe **errored** | denominator unknown — the absent count prints as a **floor** under this headline, never as the verdict |
| `release availability: N of M source(s) are not available …` | every probe answered **NO** | the only one that is a statement about an upstream — wait for it or trigger it |

All three exit 1. Distinguishing them changes what the reader *does*, never whether the gate fails.

## Second half — which identity, and why

The identity and its **origin** now print on every path, before the first probe, success included. The identity is resolved two steps up from the portal image, and *which* portal image a run gets depends entirely on the trigger — a repo **pin** on `push`, the **wake payload** on `repository_dispatch`, a **moving release tag** on `schedule`. Those want different actions (move the pin / wait for the wave / stop expecting a moving tag to converge), so the caller now states it:

```
identity resolved: sf0f9ef77… — from the portal image 'memex-portal-ai:3.0.0-ci.8372', chosen by this run's trigger (event=schedule)
```

## Verification — by execution, not "the YAML parses"

`test-release-availability-refusals.py` runs the **real** script against an `az` PATH stub (no credential, no network) and asserts on the **distinguishing text** *and* the **absence** of the other two headlines — asserting exit codes alone would pass even if all three printed one sentence, which is the defect. **Case 4 is a control that must PASS**, so the harness cannot confuse "refuses correctly" with "always refuses".

🚨 **Falsified three ways before acceptance:**

| mutation | result |
|---|---|
| fold the errored probe back into the absent count (**the pre-change behaviour**) | **5 assertions fail** — cases 3, 3b |
| drop the `identity resolved` line | **4 assertions fail** — cases 5, 6 |
| give the resolve-failure the absent headline | **2 assertions fail** — case 1 |
| restored | **0 failures** |

That the first mutation is exactly the old behaviour is the point: this test would have caught the original defect.

**It also caught a real bug in this change before it shipped** — escaped backticks inside a `${VAR:-default}` expansion broke the substitution and would have errored on *every* gate run, including the success path. Found by running it, not by reading it.

`check-workflow-timeouts`: **84 jobs checked, 0 violations**, cap 45; the job the new step joins is capped at **10**.

## Scope

- **Core shared lane only** — `check-release-availability.sh`, `node-repo-publish-bake.yml`, `dotnet-test.yml`, plus the new test. **No satellite `ci.yml` is touched** (another session is editing those).
- **4b is NOT in here.** Resolving the identity from the newest *sealed* set is a resolution change and stays open — and per the measurement in #4082, phase 1 of the CI refactor removes 20 of the 23 failures by a different route, leaving 4b's remaining target as the `schedule` path alone.

Refs #3583. Companion docs: #4082 (`FrameworkIdentityChurn`), #4079 (`BundleDeliveryStages`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)