### PR TITLE
ci: node-repo-ci-failure — one ci-main-red issue per repo on main (only closes what it opened), and a signed event to the control portal's triage inbox

### DIFF
--- a/.github/lane-caller-grants.yml
+++ b/.github/lane-caller-grants.yml
@@ -76,6 +76,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       - workflow: ci.yml
         job: validate
         lane: node-repo-validate.yml
@@ -108,6 +121,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       # `inherit` means the caller writes no `permissions:` block at all and takes the repository
       # default. It is satisfied only up to DEFAULT_FLOOR (contents/packages/metadata read) — never
       # `id-token`, which always needs an explicit grant.
@@ -144,6 +170,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       - workflow: ci.yml
         job: validate
         lane: node-repo-validate.yml
@@ -184,6 +223,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       - workflow: ci.yml
         job: validate
         lane: node-repo-validate.yml
@@ -213,6 +265,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       - workflow: ci.yml
         job: validate
         lane: node-repo-validate.yml
@@ -246,6 +311,19 @@ repos:
         job: test-repos
         lane: node-repo-gate.yml
         grants: {contents: read, id-token: write}
+      # ── ci-failure ledger (MeshWeaver PR `ci/node-repo-ci-failure`, 2026-09-12) — ARRIVING. The lane lands
+      # in core first so its `{contents: read, issues: write, actions: read}` demand is paired against the
+      # caller template BEFORE any satellite wires it; each satellite's ci.yml wiring PR spends these two.
+      - workflow: ci.yml
+        job: ci-failure
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
+      - workflow: ci.yml
+        job: ci-green
+        lane: node-repo-ci-failure.yml
+        grants: {contents: read, issues: write, actions: read}
+        pending: the caller template is in node-repo-ci-failure.yml's header; this repository's ci.yml wiring PR lands it (maintainer decision 2026-09-12, core PR ci/node-repo-ci-failure)
       - workflow: ci.yml
         job: validate
         lane: node-repo-validate.yml

--- a/.github/scripts/ci-failure-ledger.py
+++ b/.github/scripts/ci-failure-ledger.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""ci-failure-ledger.py — ONE `ci-failure` issue per repository, kept true by every run of `main`.
+"""ci-failure-ledger.py — ONE `ci-main-red` issue per repository, kept true by every run of `main`.
 
 (The name on this first line is load-bearing: node-repo-ci-failure.yml fetches this file at its
 scripts ref and refuses a body whose first 400 bytes do not name it — the same shape as
@@ -12,8 +12,17 @@ Every satellite runs its full build on `push: [main]` and once a day on `schedul
 is attached to no pull request, no reviewer and no check list — it is red in an empty room, the twin
 of a gate that cannot fail (AGENTS.md → "a SCHEDULED lane's honest red is red in an EMPTY ROOM").
 This script routes it onto an artefact that outlives the run: one issue in the calling repository,
-labelled `ci-failure`, whose BODY is a dated ledger with one entry per red run. The lane then POSTs
+labelled `ci-main-red`, whose BODY is a dated ledger with one entry per red run. The lane then POSTs
 a signed event to the control portal, whose triage agent opens a thread on it.
+
+🚨 A MECHANISM MAY ONLY CLOSE AN ISSUE IT OPENED. Core's main-cd.yml files and heals its own
+`ci-failure` issue (a DELIVERY hole, a different subject) by listing that label alone, `--limit 1`.
+Sharing the label would let a CD heal CLOSE this ledger while CI is still red — and between that
+close and the next reopen the signal reads "resolved". So this ledger has its OWN label
+(`ci-main-red`, never `ci-failure`) and its own ownership mark, a hidden line in the body
+(`<!-- ci-main-red ledger -->`). "Matching" is label AND exact title AND that marker: an issue
+lacking any of the three is never appended to, reopened, commented on or closed — it is logged and
+left alone, and a fresh ledger is filed beside it if one is needed.
 
 THE FOUR RULES, each covered by --self-test
 --------------------------------------------
@@ -25,10 +34,8 @@ THE FOUR RULES, each covered by --self-test
   * `success` + a matching OPEN issue    → comment `green again: <run URL>` and CLOSE it.
     `success` + none                     → no-op, and NO event (nothing changed).
 
-"Matching" is label AND exact title. The title is what keeps this ledger apart from another
-`ci-failure` writer in the same repository (core's main-cd.yml files "CD failed on main: run N"
-under the same label): listing by label alone would append this story onto that issue and close it
-on the next green.
+An issue this script creates never carries `ci-failure` — that label is CD's, and CD's search
+must never find the ledger any more than the ledger finds CD's.
 
 IT CANNOT PASS SILENTLY. A malformed `failed-jobs` input, an outcome that is neither word, a token
 that cannot write issues (403 → the message names the `issues: write` grant on the CALLER job), an
@@ -52,11 +59,12 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 
 API = "https://api.github.com"
-DEFAULT_LABEL = "ci-failure"
-DEFAULT_TITLE = "ci-failure: main is red"
+DEFAULT_LABEL = "ci-main-red"
+DEFAULT_TITLE = "ci-main-red: main is red"
 DEFAULT_REOPEN_WINDOW_DAYS = 7
 MAX_LEDGER_ENTRIES = 40          # ~500 bytes an entry; GitHub caps a body at 65,536 characters
-LEDGER_MARK = "<!-- ci-failure-ledger -->"
+LEDGER_MARK = "<!-- ci-main-red ledger -->"  # the ownership mark: only an issue carrying it is ours
+FORBIDDEN_LABEL = "ci-failure"               # CD's label; the ledger never files under it
 ENTRY_HEAD = "### "              # every ledger entry starts with this at column 0
 FAILED_CONCLUSIONS = ("failure", "timed_out")
 
@@ -132,8 +140,15 @@ def _parse_iso(ts: str) -> datetime:
     return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 
+def owns(issue: Issue, label: str, title: str) -> bool:
+    """The ownership test: label AND exact title AND the hidden marker in the body. All three, so a
+    hand-labelled issue, a same-titled issue from another writer, or a body somebody rewrote is
+    never something this ledger closes."""
+    return label in issue.labels and issue.title == title and LEDGER_MARK in (issue.body or "")
+
+
 def decide(outcome: str, matching: list[Issue], now: datetime, reopen_window_days: int) -> Verdict:
-    """The rule table above, over the issues that carry the label AND the exact title."""
+    """The rule table above, over the issues this ledger OWNS (see `owns`)."""
     if outcome not in ("failure", "success"):
         raise Red(f"outcome must be `failure` or `success`, got {outcome!r}")
     open_ones = sorted((i for i in matching if i.state == "open"), key=lambda i: i.number)
@@ -269,18 +284,19 @@ class GitHub:
     def ensure_label(self, label: str) -> None:
         status, _ = self.call("POST", "labels", body={
             "name": label, "color": "B60205",
-            "description": "main is red — the ledger issue every red run on main appends to"}, ok=(201, 422))
+            "description": "main is red — the CI ledger every red run on main appends to (not CD's ci-failure)"}, ok=(201, 422))
         # 422 = already exists, which is the idempotent path; 201 = created now.
         _ = status
 
-    def matching_issues(self, label: str, title: str) -> list[Issue]:
+    def labelled_issues(self, label: str) -> list[Issue]:
+        """Every issue (never a pull request) carrying `label`, any state — ownership is judged by `owns`."""
         out: list[Issue] = []
         for page in range(1, 6):
             _, items = self.call("GET", "issues", {"labels": label, "state": "all", "per_page": 100,
                                                    "page": page, "sort": "updated", "direction": "desc"})
             items = items or []
             for it in items:
-                if "pull_request" in it or it.get("title") != title:
+                if "pull_request" in it:
                     continue
                 out.append(Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
                                  tuple(l["name"] for l in it.get("labels", [])), it.get("closed_at")))
@@ -289,8 +305,11 @@ class GitHub:
         return out
 
     def create_issue(self, title: str, label: str, body: str) -> Issue:
+        if label == FORBIDDEN_LABEL or LEDGER_MARK not in body:
+            raise Red(f"refusing to file a ledger issue under `{label}` / without its ownership mark — that is CD's label, and an unmarked issue is one this ledger could never prove it opened")
         _, it = self.call("POST", "issues", body={"title": title, "labels": [label], "body": body})
-        return Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"])
+        return Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
+                     tuple(l["name"] for l in it.get("labels", [])))
 
     def update_issue(self, number: int, **fields) -> Issue:
         _, it = self.call("PATCH", f"issues/{number}", body=fields)
@@ -318,6 +337,24 @@ class GitHub:
 
 # ── apply the verdict ─────────────────────────────────────────────────────────────────────────
 
+def owned_issues(gh, label: str, title: str) -> tuple[list[Issue], list[Issue]]:
+    """(the issues this ledger owns, the same-label issues it does NOT and will never touch)."""
+    seen = gh.labelled_issues(label)
+    mine = [i for i in seen if owns(i, label, title)]
+    foreign = [i for i in seen if not owns(i, label, title)]
+    return mine, foreign
+
+
+def _owned(gh, label: str, title: str, number: int) -> Issue:
+    """The issue, re-read and re-proven ours right before a write — never a number trusted from earlier."""
+    mine, _ = owned_issues(gh, label, title)
+    for i in mine:
+        if i.number == number:
+            return i
+    raise Red(f"#{number} is not (or no longer) this ledger's issue — it lacks the `{label}` label, the exact "
+              f"title or the `{LEDGER_MARK}` mark. A mechanism may only close an issue it opened; nothing written.")
+
+
 def apply(gh, run: Run, verdict: Verdict, title: str, label: str, now: datetime,
           reopen_window_days: int) -> tuple[Issue | None, str | None]:
     """Perform the verdict. Returns (the issue touched, the event body to POST or None)."""
@@ -325,6 +362,7 @@ def apply(gh, run: Run, verdict: Verdict, title: str, label: str, now: datetime,
         return None, None
     if verdict.action == "close":
         assert verdict.issue is not None
+        _owned(gh, label, title, verdict.issue)          # re-proven at the moment of the write
         gh.comment(verdict.issue, f"green again: {run.run_url}\n\n"
                                   f"Commit `{run.sha}`, trigger `{run.trigger}`. Closing; a red within "
                                   f"{reopen_window_days} days reopens this issue rather than filing a new one.")
@@ -336,11 +374,11 @@ def apply(gh, run: Run, verdict: Verdict, title: str, label: str, now: datetime,
         issue = gh.create_issue(title, label, append_entry(new_body(run.repo, reopen_window_days), entry))
     elif verdict.action == "append":
         assert verdict.issue is not None
-        current = next(i for i in gh.matching_issues(label, title) if i.number == verdict.issue)
+        current = _owned(gh, label, title, verdict.issue)
         issue = gh.update_issue(verdict.issue, body=append_entry(current.body, entry))
     elif verdict.action == "reopen":
         assert verdict.issue is not None
-        current = next(i for i in gh.matching_issues(label, title) if i.number == verdict.issue)
+        current = _owned(gh, label, title, verdict.issue)
         issue = gh.update_issue(verdict.issue, state="open", body=append_entry(current.body, entry))
     else:
         raise Red(f"unknown verdict {verdict.action!r}")
@@ -379,7 +417,7 @@ def main(argv: list[str]) -> int:
     try:
         token = env("GH_TOKEN") or env("GITHUB_TOKEN") or ""
         if not token:
-            raise Red("no GH_TOKEN — the caller must pass `secrets: github-token: ${{ secrets.GITHUB_TOKEN }}`; refusing to report 'nothing to do' on no access")
+            raise Red("no GH_TOKEN — the caller must forward its secrets.GITHUB_TOKEN as `secrets: github-token:`; refusing to report 'nothing to do' on no access")
         for name, value in (("repo", a.repo), ("outcome", a.outcome), ("run-id", a.run_id),
                             ("run-url", a.run_url), ("sha", a.sha), ("trigger", a.trigger)):
             if not value:
@@ -400,10 +438,15 @@ def main(argv: list[str]) -> int:
         run = Run(a.repo, a.outcome, str(a.run_id), a.run_url, a.sha, a.trigger, failed_jobs,
                   a.platform_set or "", jobs_note)
 
-        matching = gh.matching_issues(a.label, a.title)
+        if a.label == FORBIDDEN_LABEL:
+            raise Red(f"the ledger label must never be `{FORBIDDEN_LABEL}` — that is main-cd.yml's delivery alert, and sharing it lets a CD heal close this ledger while CI is red")
+        matching, foreign = owned_issues(gh, a.label, a.title)
+        for f in foreign:
+            print(f"leaving #{f.number} alone ({f.state}, {f.title!r}): it carries `{a.label}` but not this ledger's "
+                  f"title and `{LEDGER_MARK}` mark, so this mechanism did not open it and will not touch it")
         verdict = decide(a.outcome, matching, now, a.reopen_window_days)
         print(f"{verdict.action.upper():7} {verdict.reason} (label `{a.label}`, title {a.title!r}, "
-              f"{len(matching)} matching issue(s) seen)")
+              f"{len(matching)} owned issue(s), {len(foreign)} foreign)")
         issue, body = apply(gh, run, verdict, a.title, a.label, now, a.reopen_window_days)
         if issue is not None:
             print(f"issue #{issue.number} {issue.state}: {issue.html_url}")
@@ -438,10 +481,11 @@ class _Fake:
         self.writes += 1
         self.labels.add(label)
 
-    def matching_issues(self, label, title):
-        return [i for i in self.issues.values() if label in i.labels and i.title == title]
+    def labelled_issues(self, label):
+        return [i for i in self.issues.values() if label in i.labels]
 
     def create_issue(self, title, label, body):
+        assert label != FORBIDDEN_LABEL and LEDGER_MARK in body, "the fake mirrors the real refusal"
         self.writes += 1
         n = self.next_number
         self.next_number += 1
@@ -481,7 +525,7 @@ def self_test() -> int:
                    tuple(failed), "3.0.0-ci.4711", note)
 
     def go(gh, r):
-        v = decide(r.outcome, gh.matching_issues(label, title), now, 7)
+        v = decide(r.outcome, owned_issues(gh, label, title)[0], now, 7)
         issue, body = apply(gh, r, v, title, label, now, 7)
         return v, issue, body
 
@@ -493,6 +537,8 @@ def self_test() -> int:
     check("no issue -> create", v.action == "create" and len(gh.issues) == 1 and issue is not None)
     check("created body carries the ledger mark and ONE entry",
           issue is not None and LEDGER_MARK in issue.body and issue.body.count("\n" + ENTRY_HEAD) == 1)
+    check("the ledger's issue carries `ci-main-red` and NEVER `ci-failure` (CD's label)",
+          issue is not None and label in issue.labels and FORBIDDEN_LABEL not in issue.labels and label != FORBIDDEN_LABEL)
     ev = json.loads(body or "{}")
     check("ci-failure event names repo, run, issue and the failed job",
           ev.get("event") == "ci-failure" and ev.get("run") == 555 and ev.get("issueNumber") == issue.number
@@ -547,13 +593,40 @@ def self_test() -> int:
     v, issue7, _ = go(gh7, run("failure", [job]))
     check("closed 9 d ago -> create a fresh issue", v.action == "create" and issue7 is not None and issue7.number != 8 and len(gh7.issues) == 2)
 
-    # 8. another writer's open ci-failure issue (different title) is neither appended to nor closed
-    other = Issue(9, "CD failed on main: run 42", "open", "cd", "https://github.com/o/r/issues/9", (label,))
-    gh8 = _Fake([other])
+    # 8. CD's own open `ci-failure` issue (main-cd.yml's shape) is never touched — different label, so
+    #    the ledger never even lists it; and the ledger's create never files under that label.
+    cd = Issue(9, "CD failed on main: run 42", "open", "CD failed on main: [run 42](u) for commit `abc`.",
+               "https://github.com/o/r/issues/9", (FORBIDDEN_LABEL,))
+    gh8 = _Fake([cd])
     v, issue8, _ = go(gh8, run("failure", [job]))
-    check("a same-label issue with another title is not this ledger", v.action == "create" and issue8 is not None and issue8.number != 9)
-    v, _, _ = go(_Fake([other]), run("success"))
-    check("green never closes another writer's issue", v.action == "noop")
+    check("CD's `ci-failure` issue is never this ledger: a fresh `ci-main-red` one is filed beside it",
+          v.action == "create" and issue8 is not None and issue8.number != 9 and gh8.issues[9].state == "open"
+          and gh8.issues[9].body == cd.body and FORBIDDEN_LABEL not in issue8.labels)
+    gh8b = _Fake([cd])
+    v, _, _ = go(gh8b, run("success"))
+    check("green never closes or comments on CD's issue", v.action == "noop" and gh8b.writes == 0 and gh8b.issues[9].state == "open")
+    try:
+        _Fake().create_issue(title, FORBIDDEN_LABEL, new_body("o/r", 7))
+        check("filing under `ci-failure` is refused", False, "was accepted")
+    except AssertionError:
+        check("filing under `ci-failure` is refused", True)
+
+    # 8b. a `ci-main-red` issue WITHOUT the ownership mark (hand-labelled, or a rewritten body) is never
+    #     closed, commented on, reopened or appended to — logged as foreign, left exactly as found.
+    unmarked = Issue(10, title, "open", "someone labelled this by hand", "https://github.com/o/r/issues/10", (label,))
+    gh8c = _Fake([unmarked])
+    mine, foreign = owned_issues(gh8c, label, title)
+    check("an unmarked `ci-main-red` issue is FOREIGN, not owned", mine == [] and [f.number for f in foreign] == [10])
+    v, _, _ = go(gh8c, run("success"))
+    check("green never closes an unmarked `ci-main-red` issue", v.action == "noop" and gh8c.writes == 0 and gh8c.issues[10].state == "open")
+    v, issue8c, _ = go(gh8c, run("failure", [job]))
+    check("red files a fresh marked issue beside the unmarked one, which is untouched",
+          v.action == "create" and issue8c is not None and issue8c.number != 10 and gh8c.issues[10].body == unmarked.body)
+    try:
+        _owned(gh8c, label, title, 10)
+        check("a write aimed at an unmarked issue is refused at the moment of the write", False, "was allowed")
+    except Red:
+        check("a write aimed at an unmarked issue is refused at the moment of the write", True)
 
     # 9. the ledger is bounded
     b = new_body("o/r", 7)
@@ -582,7 +655,8 @@ def self_test() -> int:
         print("::error title=ci-failure-ledger self-test::" + "; ".join(fails), file=sys.stderr)
         return 1
     print("✓ ci-failure-ledger self-test: create / append / reopen-recent / create-after-old / close-with-comment / "
-          "noop-when-green / refuse-malformed / other-writer-untouched / bounded-ledger / jobs-listed — every rule fires and stays silent as designed")
+          "noop-when-green / refuse-malformed / cd-ci-failure-untouched / unmarked-ci-main-red-untouched / never-labelled-ci-failure / "
+          "bounded-ledger / jobs-listed — every rule fires and stays silent as designed")
     return 0
 
 

--- a/.github/scripts/ci-failure-ledger.py
+++ b/.github/scripts/ci-failure-ledger.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""ci-failure-ledger.py — ONE `ci-failure` issue per repository, kept true by every run of `main`.
+
+(The name on this first line is load-bearing: node-repo-ci-failure.yml fetches this file at its
+scripts ref and refuses a body whose first 400 bytes do not name it — the same shape as
+check-workflow-timeouts.py and compile-check.py.)
+
+WHY (maintainer, 2026-09-12: "put the ci-failure on all repos, in main; triaging is done by
+systemorph-com; communicate via MCP — open a thread with a triage agent")
+-------------------------------------------------------------------------------------------------
+Every satellite runs its full build on `push: [main]` and once a day on `schedule`. A red run there
+is attached to no pull request, no reviewer and no check list — it is red in an empty room, the twin
+of a gate that cannot fail (AGENTS.md → "a SCHEDULED lane's honest red is red in an EMPTY ROOM").
+This script routes it onto an artefact that outlives the run: one issue in the calling repository,
+labelled `ci-failure`, whose BODY is a dated ledger with one entry per red run. The lane then POSTs
+a signed event to the control portal, whose triage agent opens a thread on it.
+
+THE FOUR RULES, each covered by --self-test
+--------------------------------------------
+  * `failure` + no matching issue        → CREATE one (label + exact title), first ledger entry.
+  * `failure` + a matching OPEN issue    → APPEND an entry to its body. Never a second open issue.
+  * `failure` + a matching issue CLOSED
+    within the last REOPEN_WINDOW_DAYS   → REOPEN it and append (flapping: one story, one issue).
+    Closed longer ago                    → CREATE a fresh one (its age is the outage's age, #3176).
+  * `success` + a matching OPEN issue    → comment `green again: <run URL>` and CLOSE it.
+    `success` + none                     → no-op, and NO event (nothing changed).
+
+"Matching" is label AND exact title. The title is what keeps this ledger apart from another
+`ci-failure` writer in the same repository (core's main-cd.yml files "CD failed on main: run N"
+under the same label): listing by label alone would append this story onto that issue and close it
+on the next green.
+
+IT CANNOT PASS SILENTLY. A malformed `failed-jobs` input, an outcome that is neither word, a token
+that cannot write issues (403 → the message names the `issues: write` grant on the CALLER job), an
+API failure — each is RED naming the cause, never a quiet "nothing to do". The one deliberate
+"nothing to do" (green, no open issue) SAYS so with the denominator.
+
+    python3 ci-failure-ledger.py                 # in Actions: everything from the environment
+    python3 ci-failure-ledger.py --self-test     # prove every rule, against a fake GitHub
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+
+API = "https://api.github.com"
+DEFAULT_LABEL = "ci-failure"
+DEFAULT_TITLE = "ci-failure: main is red"
+DEFAULT_REOPEN_WINDOW_DAYS = 7
+MAX_LEDGER_ENTRIES = 40          # ~500 bytes an entry; GitHub caps a body at 65,536 characters
+LEDGER_MARK = "<!-- ci-failure-ledger -->"
+ENTRY_HEAD = "### "              # every ledger entry starts with this at column 0
+FAILED_CONCLUSIONS = ("failure", "timed_out")
+
+
+class Red(Exception):
+    """Something this lane needs could not be established. Never downgraded to 'nothing to do'."""
+
+
+# ── the pure parts ────────────────────────────────────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Run:
+    repo: str
+    outcome: str
+    run_id: str
+    run_url: str
+    sha: str
+    trigger: str
+    failed_jobs: tuple[dict, ...]
+    platform_set: str
+    jobs_note: str = ""          # set when the run's jobs could not be listed (recorded, then RED)
+
+
+@dataclass
+class Issue:
+    number: int
+    title: str
+    state: str
+    body: str
+    html_url: str
+    labels: tuple[str, ...] = ()
+    closed_at: str | None = None
+
+
+@dataclass
+class Verdict:
+    action: str                  # create | append | reopen | close | noop
+    issue: int | None
+    reason: str
+
+
+def parse_failed_jobs(raw: str) -> tuple[dict, ...]:
+    """The caller's `failed-jobs` input as a tuple of {name, url, step}. Anything else is refused.
+
+    Refused BEFORE any write: an entry that names no job is a ledger that cannot be triaged, and a
+    ledger written from garbage looks exactly like one written from evidence.
+    """
+    raw = (raw or "").strip() or "[]"
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise Red(f"failed-jobs is not JSON ({e}); expected an array of {{name, url, step}}") from e
+    if not isinstance(data, list):
+        raise Red(f"failed-jobs must be a JSON ARRAY of {{name, url, step}}, got {type(data).__name__}")
+    out = []
+    for i, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise Red(f"failed-jobs[{i}] is {type(item).__name__}, expected an object {{name, url, step}}")
+        name, url, step = item.get("name"), item.get("url"), item.get("step", "")
+        if not isinstance(name, str) or not name.strip():
+            raise Red(f"failed-jobs[{i}] has no string `name`")
+        if not isinstance(url, str) or not url.startswith("https://"):
+            raise Red(f"failed-jobs[{i}] (`{name}`) has no https `url`")
+        if step is None:
+            step = ""
+        if not isinstance(step, str):
+            raise Red(f"failed-jobs[{i}] (`{name}`) has a non-string `step`")
+        out.append({"name": name.strip(), "url": url, "step": step.strip()})
+    return tuple(out)
+
+
+def _parse_iso(ts: str) -> datetime:
+    return datetime.fromisoformat(ts.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def decide(outcome: str, matching: list[Issue], now: datetime, reopen_window_days: int) -> Verdict:
+    """The rule table above, over the issues that carry the label AND the exact title."""
+    if outcome not in ("failure", "success"):
+        raise Red(f"outcome must be `failure` or `success`, got {outcome!r}")
+    open_ones = sorted((i for i in matching if i.state == "open"), key=lambda i: i.number)
+    if outcome == "success":
+        if open_ones:
+            return Verdict("close", open_ones[0].number, "main is green again — closing the open ledger")
+        return Verdict("noop", None, "main is green and no ci-failure ledger is open — nothing changed, nothing to tell")
+    if open_ones:
+        return Verdict("append", open_ones[0].number, "an open ledger exists — appending, never a second open issue")
+    window = timedelta(days=reopen_window_days)
+    recent = [i for i in matching
+              if i.state == "closed" and i.closed_at and now - _parse_iso(i.closed_at) <= window]
+    if recent:
+        newest = max(recent, key=lambda i: _parse_iso(i.closed_at or ""))
+        return Verdict("reopen", newest.number,
+                       f"#{newest.number} was closed {now - _parse_iso(newest.closed_at or ''):} ago (inside "
+                       f"{reopen_window_days} d) — flapping: reopening it rather than filing a second story")
+    return Verdict("create", None, "no ledger is open or recently closed — filing a fresh one")
+
+
+def ledger_entry(run: Run, now: datetime) -> str:
+    stamp = now.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if run.failed_jobs:
+        jobs = "<br>".join(
+            f"[{j['name']}]({j['url']})" + (f" — step `{j['step']}`" if j["step"] else "")
+            for j in run.failed_jobs)
+    else:
+        jobs = run.jobs_note or "_(none listed)_"
+    return "\n".join([
+        f"{ENTRY_HEAD}{stamp} — **{run.outcome}** — [run {run.run_id}]({run.run_url})",
+        "",
+        "| | |",
+        "|---|---|",
+        f"| commit | `{run.sha}` |",
+        f"| trigger | `{run.trigger}` |",
+        f"| platform set | {('`' + run.platform_set + '`') if run.platform_set else '_(none)_'} |",
+        f"| failed jobs | {jobs} |",
+    ])
+
+
+def new_body(repo: str, reopen_window_days: int) -> str:
+    return "\n".join([
+        f"`main` of **{repo}** is red. This issue is the ledger: every red run on `main` appends a dated "
+        f"entry below, and the run that goes green again closes it. A red within {reopen_window_days} days "
+        f"of the close REOPENS this issue rather than filing a second one, so one outage is one story.",
+        "",
+        "Each entry is also POSTed, signed, to the control portal's triage inbox "
+        "(`Hosting/PlatformBuilds` on memex.systemorph.com), whose triage agent opens a thread on it. "
+        "Read the newest entry first — the failed jobs link straight to their logs.",
+        "",
+        LEDGER_MARK,
+        "",
+        "## Ledger",
+    ])
+
+
+_TRIM_RE = re.compile(r"_(\d+) older entr(?:y|ies) trimmed[^_]*_")
+
+
+def append_entry(body: str, entry: str, max_entries: int = MAX_LEDGER_ENTRIES) -> str:
+    """The body with `entry` appended, oldest entries trimmed past `max_entries` (the head stays).
+
+    The trim count is CUMULATIVE across calls, so a long-lived ledger says how much history it has
+    shed in total rather than "1 older entry trimmed" on every append past the cap.
+    """
+    body = (body or "").rstrip()
+    if LEDGER_MARK not in body:
+        # A body edited by hand into something unrecognisable still gets its ledger back.
+        body = body + "\n\n" + LEDGER_MARK
+    head, _, tail = body.partition(LEDGER_MARK)
+    parts = tail.split("\n" + ENTRY_HEAD)
+    lead, old = parts[0], parts[1:]
+    if lead.strip().startswith(ENTRY_HEAD):             # an entry glued straight onto the mark
+        old, lead = [lead.strip()[len(ENTRY_HEAD):]] + old, ""
+    m = _TRIM_RE.search(lead)
+    already = int(m.group(1)) if m else 0
+    entries = [ENTRY_HEAD + e.strip() for e in old if e.strip()] + [entry.strip()]
+    dropped = max(0, len(entries) - max_entries)
+    entries = entries[dropped:]
+    total = already + dropped
+    note = (f"\n\n_{total} older entr{'y' if total == 1 else 'ies'} trimmed — the run list on the Actions tab keeps them._"
+            if total else "")
+    return head.rstrip() + "\n\n" + LEDGER_MARK + "\n\n## Ledger" + note + "\n\n" + "\n\n".join(entries) + "\n"
+
+
+def event_body(kind: str, run: Run, issue: Issue) -> str:
+    """The EXACT bytes the lane signs and POSTs — one shape per event, field order fixed."""
+    if kind == "ci-failure":
+        obj = {"event": "ci-failure", "repo": run.repo, "sha": run.sha, "run": int(run.run_id),
+               "runUrl": run.run_url, "trigger": run.trigger, "failedJobs": list(run.failed_jobs),
+               "platformSet": run.platform_set, "issueUrl": issue.html_url, "issueNumber": issue.number}
+    elif kind == "ci-green":
+        obj = {"event": "ci-green", "repo": run.repo, "sha": run.sha, "run": int(run.run_id),
+               "runUrl": run.run_url, "issueNumber": issue.number}
+    else:
+        raise Red(f"unknown event kind {kind!r}")
+    return json.dumps(obj, separators=(",", ":"), ensure_ascii=False)
+
+
+# ── GitHub, and what a token that cannot write looks like ─────────────────────────────────────
+
+class GitHub:
+    def __init__(self, repo: str, token: str):
+        self.repo, self.token = repo, token
+
+    def call(self, method: str, path: str, params: dict | None = None, body: dict | None = None,
+             ok=(200, 201)) -> tuple[int, object]:
+        url = f"{API}/repos/{self.repo}/{path}"
+        if params:
+            url += "?" + urllib.parse.urlencode(params)
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(url, data=data, method=method, headers={
+            "Authorization": f"Bearer {self.token}", "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28", "Content-Type": "application/json",
+            "User-Agent": "ci-failure-ledger"})
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                status, text = resp.status, resp.read().decode()
+        except urllib.error.HTTPError as e:
+            status, text = e.code, e.read().decode(errors="replace")
+        except urllib.error.URLError as e:
+            raise Red(f"{method} {path}: could not reach api.github.com ({e.reason})") from e
+        if status == 403 or status == 401:
+            raise Red(f"{method} {path} answered HTTP {status}. The token this lane was handed cannot do that: "
+                      f"the CALLER job must grant `permissions: {{issues: write, contents: read, actions: read}}` "
+                      f"and pass `secrets: github-token: ${{{{ secrets.GITHUB_TOKEN }}}}` — a called workflow can "
+                      f"only narrow what its caller granted, never widen it. Body: {text[:300]}")
+        if status not in ok:
+            raise Red(f"{method} {path} answered HTTP {status}: {text[:300]}")
+        return status, (json.loads(text) if text.strip() else None)
+
+    # -- the reads and writes the ledger needs, each one call --
+    def ensure_label(self, label: str) -> None:
+        status, _ = self.call("POST", "labels", body={
+            "name": label, "color": "B60205",
+            "description": "main is red — the ledger issue every red run on main appends to"}, ok=(201, 422))
+        # 422 = already exists, which is the idempotent path; 201 = created now.
+        _ = status
+
+    def matching_issues(self, label: str, title: str) -> list[Issue]:
+        out: list[Issue] = []
+        for page in range(1, 6):
+            _, items = self.call("GET", "issues", {"labels": label, "state": "all", "per_page": 100,
+                                                   "page": page, "sort": "updated", "direction": "desc"})
+            items = items or []
+            for it in items:
+                if "pull_request" in it or it.get("title") != title:
+                    continue
+                out.append(Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
+                                 tuple(l["name"] for l in it.get("labels", [])), it.get("closed_at")))
+            if len(items) < 100:
+                break
+        return out
+
+    def create_issue(self, title: str, label: str, body: str) -> Issue:
+        _, it = self.call("POST", "issues", body={"title": title, "labels": [label], "body": body})
+        return Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"])
+
+    def update_issue(self, number: int, **fields) -> Issue:
+        _, it = self.call("PATCH", f"issues/{number}", body=fields)
+        return Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"])
+
+    def comment(self, number: int, body: str) -> None:
+        self.call("POST", f"issues/{number}/comments", body={"body": body})
+
+    def failed_jobs_of_run(self, run_id: str) -> tuple[dict, ...]:
+        """{name, url, step} for every job of the run that concluded failure/timed_out."""
+        found: list[dict] = []
+        for page in range(1, 11):
+            _, data = self.call("GET", f"actions/runs/{run_id}/jobs", {"per_page": 100, "page": page})
+            jobs = (data or {}).get("jobs", [])
+            for j in jobs:
+                if j.get("conclusion") not in FAILED_CONCLUSIONS:
+                    continue
+                step = next((s.get("name", "") for s in j.get("steps", [])
+                             if s.get("conclusion") in FAILED_CONCLUSIONS), "")
+                found.append({"name": j.get("name", "?"), "url": j.get("html_url", ""), "step": step})
+            if len(jobs) < 100:
+                break
+        return tuple(found)
+
+
+# ── apply the verdict ─────────────────────────────────────────────────────────────────────────
+
+def apply(gh, run: Run, verdict: Verdict, title: str, label: str, now: datetime,
+          reopen_window_days: int) -> tuple[Issue | None, str | None]:
+    """Perform the verdict. Returns (the issue touched, the event body to POST or None)."""
+    if verdict.action == "noop":
+        return None, None
+    if verdict.action == "close":
+        assert verdict.issue is not None
+        gh.comment(verdict.issue, f"green again: {run.run_url}\n\n"
+                                  f"Commit `{run.sha}`, trigger `{run.trigger}`. Closing; a red within "
+                                  f"{reopen_window_days} days reopens this issue rather than filing a new one.")
+        issue = gh.update_issue(verdict.issue, state="closed", state_reason="completed")
+        return issue, event_body("ci-green", run, issue)
+    entry = ledger_entry(run, now)
+    gh.ensure_label(label)
+    if verdict.action == "create":
+        issue = gh.create_issue(title, label, append_entry(new_body(run.repo, reopen_window_days), entry))
+    elif verdict.action == "append":
+        assert verdict.issue is not None
+        current = next(i for i in gh.matching_issues(label, title) if i.number == verdict.issue)
+        issue = gh.update_issue(verdict.issue, body=append_entry(current.body, entry))
+    elif verdict.action == "reopen":
+        assert verdict.issue is not None
+        current = next(i for i in gh.matching_issues(label, title) if i.number == verdict.issue)
+        issue = gh.update_issue(verdict.issue, state="open", body=append_entry(current.body, entry))
+    else:
+        raise Red(f"unknown verdict {verdict.action!r}")
+    return issue, event_body("ci-failure", run, issue)
+
+
+def _emit_outputs(path: str | None, **kv) -> None:
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        for k, v in kv.items():
+            fh.write(f"{k}={v}\n")
+
+
+def main(argv: list[str]) -> int:
+    env = os.environ.get
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[0])
+    ap.add_argument("--repo", default=env("GITHUB_REPOSITORY"))
+    ap.add_argument("--outcome", default=env("LEDGER_OUTCOME"))
+    ap.add_argument("--run-id", default=env("LEDGER_RUN_ID"))
+    ap.add_argument("--run-url", default=env("LEDGER_RUN_URL"))
+    ap.add_argument("--sha", default=env("LEDGER_SHA"))
+    ap.add_argument("--trigger", default=env("LEDGER_TRIGGER"))
+    ap.add_argument("--failed-jobs", default=env("LEDGER_FAILED_JOBS", "[]"))
+    ap.add_argument("--platform-set", default=env("LEDGER_PLATFORM_SET", ""))
+    ap.add_argument("--title", default=env("LEDGER_ISSUE_TITLE") or DEFAULT_TITLE)
+    ap.add_argument("--label", default=env("LEDGER_LABEL") or DEFAULT_LABEL)
+    ap.add_argument("--reopen-window-days", type=int, default=int(env("LEDGER_REOPEN_WINDOW_DAYS") or DEFAULT_REOPEN_WINDOW_DAYS))
+    ap.add_argument("--event-out", default=env("LEDGER_EVENT_OUT"), help="file the exact event body is written to")
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args(argv)
+
+    if a.self_test:
+        return self_test()
+
+    try:
+        token = env("GH_TOKEN") or env("GITHUB_TOKEN") or ""
+        if not token:
+            raise Red("no GH_TOKEN — the caller must pass `secrets: github-token: ${{ secrets.GITHUB_TOKEN }}`; refusing to report 'nothing to do' on no access")
+        for name, value in (("repo", a.repo), ("outcome", a.outcome), ("run-id", a.run_id),
+                            ("run-url", a.run_url), ("sha", a.sha), ("trigger", a.trigger)):
+            if not value:
+                raise Red(f"--{name} is empty — the lane's inputs are incomplete")
+        failed_jobs = parse_failed_jobs(a.failed_jobs)
+        now = datetime.now(timezone.utc)
+        gh = GitHub(a.repo, token)
+
+        jobs_note = ""
+        listing_error: Red | None = None
+        if a.outcome == "failure" and not failed_jobs:
+            try:
+                failed_jobs = gh.failed_jobs_of_run(a.run_id)
+            except Red as e:
+                # Recorded in the entry and then RED below: the ledger stays intact, the mis-grant is named.
+                listing_error = e
+                jobs_note = f"_(could not list this run's jobs — {e})_"
+        run = Run(a.repo, a.outcome, str(a.run_id), a.run_url, a.sha, a.trigger, failed_jobs,
+                  a.platform_set or "", jobs_note)
+
+        matching = gh.matching_issues(a.label, a.title)
+        verdict = decide(a.outcome, matching, now, a.reopen_window_days)
+        print(f"{verdict.action.upper():7} {verdict.reason} (label `{a.label}`, title {a.title!r}, "
+              f"{len(matching)} matching issue(s) seen)")
+        issue, body = apply(gh, run, verdict, a.title, a.label, now, a.reopen_window_days)
+        if issue is not None:
+            print(f"issue #{issue.number} {issue.state}: {issue.html_url}")
+        if body is not None and a.event_out:
+            with open(a.event_out, "w", encoding="utf-8") as fh:
+                fh.write(body)
+        _emit_outputs(env("GITHUB_OUTPUT"), action=verdict.action,
+                      **{"issue-number": issue.number if issue else "", "issue-url": issue.html_url if issue else "",
+                         "post": "true" if body is not None else "false"})
+        if listing_error is not None:
+            raise Red(f"the ledger entry is written, but this run's failed jobs could not be listed: {listing_error}")
+        return 0
+    except Red as e:
+        print(f"::error title=ci-failure-ledger::{e}", file=sys.stderr)
+        return 1
+
+
+# ── self-test: prove every rule against a fake GitHub ─────────────────────────────────────────
+
+class _Fake:
+    """Enough of GitHub to run `apply` end to end and count every write."""
+
+    def __init__(self, issues: list[Issue] | None = None, run_jobs: list[dict] | None = None):
+        self.issues = {i.number: i for i in (issues or [])}
+        self.next_number = max(self.issues, default=100) + 1
+        self.comments: list[tuple[int, str]] = []
+        self.writes = 0
+        self.labels: set[str] = set()
+        self.run_jobs = run_jobs or []
+
+    def ensure_label(self, label):
+        self.writes += 1
+        self.labels.add(label)
+
+    def matching_issues(self, label, title):
+        return [i for i in self.issues.values() if label in i.labels and i.title == title]
+
+    def create_issue(self, title, label, body):
+        self.writes += 1
+        n = self.next_number
+        self.next_number += 1
+        self.issues[n] = Issue(n, title, "open", body, f"https://github.com/o/r/issues/{n}", (label,))
+        return self.issues[n]
+
+    def update_issue(self, number, **fields):
+        self.writes += 1
+        i = self.issues[number]
+        for k, v in fields.items():
+            if k in ("state", "body"):
+                setattr(i, k, v)
+        return i
+
+    def comment(self, number, body):
+        self.writes += 1
+        self.comments.append((number, body))
+
+    def failed_jobs_of_run(self, run_id):
+        return tuple({"name": j["name"], "url": j["html_url"],
+                      "step": next((s["name"] for s in j.get("steps", []) if s.get("conclusion") == "failure"), "")}
+                     for j in self.run_jobs if j.get("conclusion") in FAILED_CONCLUSIONS)
+
+
+def self_test() -> int:
+    now = datetime(2026, 9, 12, 10, 0, tzinfo=timezone.utc)
+    title, label = DEFAULT_TITLE, DEFAULT_LABEL
+    fails: list[str] = []
+
+    def check(name: str, cond: bool, detail: str = "") -> None:
+        print(f"  {'ok  ' if cond else 'FAIL'} {name}" + (f" — {detail}" if detail and not cond else ""))
+        if not cond:
+            fails.append(name)
+
+    def run(outcome, failed=(), note=""):
+        return Run("o/r", outcome, "555", "https://github.com/o/r/actions/runs/555", "abc123", "schedule",
+                   tuple(failed), "3.0.0-ci.4711", note)
+
+    def go(gh, r):
+        v = decide(r.outcome, gh.matching_issues(label, title), now, 7)
+        issue, body = apply(gh, r, v, title, label, now, 7)
+        return v, issue, body
+
+    job = {"name": "Portal hosts (shard 0)", "url": "https://github.com/o/r/actions/runs/555/job/1", "step": "Run tests"}
+
+    # 1. no issue → create, one entry, a ci-failure event naming the issue
+    gh = _Fake()
+    v, issue, body = go(gh, run("failure", [job]))
+    check("no issue -> create", v.action == "create" and len(gh.issues) == 1 and issue is not None)
+    check("created body carries the ledger mark and ONE entry",
+          issue is not None and LEDGER_MARK in issue.body and issue.body.count("\n" + ENTRY_HEAD) == 1)
+    ev = json.loads(body or "{}")
+    check("ci-failure event names repo, run, issue and the failed job",
+          ev.get("event") == "ci-failure" and ev.get("run") == 555 and ev.get("issueNumber") == issue.number
+          and ev.get("failedJobs") == [job] and ev.get("platformSet") == "3.0.0-ci.4711" and ev.get("trigger") == "schedule")
+    check("event bytes are compact and field-ordered", (body or "").startswith('{"event":"ci-failure","repo":"o/r","sha":"abc123","run":555,'))
+
+    # 2. open issue → append, not duplicate
+    v, issue2, _ = go(gh, run("failure", [job]))
+    check("open issue -> append, never a second open issue",
+          v.action == "append" and len(gh.issues) == 1 and issue2 is not None and issue2.number == issue.number)
+    check("appended body has TWO entries", issue2 is not None and issue2.body.count("\n" + ENTRY_HEAD) == 2)
+
+    # 3. green with an open issue → comment 'green again: <run URL>' and close; ci-green event
+    v, issue3, body3 = go(gh, run("success"))
+    check("green -> close", v.action == "close" and issue3 is not None and issue3.state == "closed")
+    check("green comment says `green again: <run URL>`",
+          any(n == issue.number and c.startswith("green again: https://github.com/o/r/actions/runs/555") for n, c in gh.comments))
+    check("ci-green event is posted", json.loads(body3 or "{}").get("event") == "ci-green")
+
+    # 4. green with no open issue → no-op, no write, no event
+    gh4 = _Fake()
+    v, issue4, body4 = go(gh4, run("success"))
+    check("green with no issue -> noop, zero writes, no event", v.action == "noop" and gh4.writes == 0 and body4 is None and issue4 is None)
+
+    # 5. malformed failed-jobs → refused before any write
+    for bad in ('{"name": "x"}', "[1]", '[{"url": "https://x"}]', '[{"name": "j", "url": "http://insecure"}]', "not json"):
+        try:
+            parse_failed_jobs(bad)
+            check(f"malformed failed-jobs refused: {bad!r}", False, "was accepted")
+        except Red:
+            check(f"malformed failed-jobs refused: {bad!r}", True)
+    check("empty failed-jobs is the empty list", parse_failed_jobs("") == () and parse_failed_jobs("[]") == ())
+    try:
+        decide("cancelled", [], now, 7)
+        check("an outcome that is neither word is refused", False)
+    except Red:
+        check("an outcome that is neither word is refused", True)
+
+    # 6. closed 2 days ago → reopened and appended, not duplicated
+    closed_recent = Issue(7, title, "closed", new_body("o/r", 7) + "\n\n" + ENTRY_HEAD + "old — **failure** — [run 1](u)\n",
+                          "https://github.com/o/r/issues/7", (label,), (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    gh6 = _Fake([closed_recent])
+    v, issue6, _ = go(gh6, run("failure", [job]))
+    check("closed 2 d ago -> reopen the same issue", v.action == "reopen" and issue6 is not None and issue6.number == 7
+          and issue6.state == "open" and len(gh6.issues) == 1)
+    check("reopened body gained an entry", issue6 is not None and issue6.body.count("\n" + ENTRY_HEAD) == 2)
+
+    # 7. closed 9 days ago → a fresh issue
+    closed_old = Issue(8, title, "closed", "x", "https://github.com/o/r/issues/8", (label,),
+                       (now - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    gh7 = _Fake([closed_old])
+    v, issue7, _ = go(gh7, run("failure", [job]))
+    check("closed 9 d ago -> create a fresh issue", v.action == "create" and issue7 is not None and issue7.number != 8 and len(gh7.issues) == 2)
+
+    # 8. another writer's open ci-failure issue (different title) is neither appended to nor closed
+    other = Issue(9, "CD failed on main: run 42", "open", "cd", "https://github.com/o/r/issues/9", (label,))
+    gh8 = _Fake([other])
+    v, issue8, _ = go(gh8, run("failure", [job]))
+    check("a same-label issue with another title is not this ledger", v.action == "create" and issue8 is not None and issue8.number != 9)
+    v, _, _ = go(_Fake([other]), run("success"))
+    check("green never closes another writer's issue", v.action == "noop")
+
+    # 9. the ledger is bounded
+    b = new_body("o/r", 7)
+    for i in range(MAX_LEDGER_ENTRIES + 3):
+        b = append_entry(b, ledger_entry(run("failure", [job]), now + timedelta(minutes=i)))
+    check(f"the ledger keeps at most {MAX_LEDGER_ENTRIES} entries and says it trimmed",
+          b.count("\n" + ENTRY_HEAD) == MAX_LEDGER_ENTRIES and "3 older entries trimmed" in b)
+    check("a hand-mangled body gets its ledger mark back", LEDGER_MARK in append_entry("someone rewrote this", "### e"))
+
+    # 10. an empty failed-jobs on failure lists the run's jobs (the lane does this via the API)
+    gh10 = _Fake(run_jobs=[
+        {"name": "Build", "html_url": "https://github.com/o/r/actions/runs/555/job/2", "conclusion": "success", "steps": []},
+        {"name": "Test (shard 3)", "html_url": "https://github.com/o/r/actions/runs/555/job/3", "conclusion": "failure",
+         "steps": [{"name": "Restore", "conclusion": "success"}, {"name": "Run tests", "conclusion": "failure"}]},
+        {"name": "Docs", "html_url": "https://github.com/o/r/actions/runs/555/job/4", "conclusion": "timed_out", "steps": []},
+    ])
+    listed = gh10.failed_jobs_of_run("555")
+    check("listing keeps only failed/timed-out jobs and names the failed step",
+          [j["name"] for j in listed] == ["Test (shard 3)", "Docs"] and listed[0]["step"] == "Run tests")
+    v, issue10, body10 = go(gh10, run("failure", listed))
+    check("the listed jobs reach the entry and the event",
+          issue10 is not None and "[Test (shard 3)]" in issue10.body and "step `Run tests`" in issue10.body
+          and len(json.loads(body10 or "{}")["failedJobs"]) == 2)
+
+    if fails:
+        print("::error title=ci-failure-ledger self-test::" + "; ".join(fails), file=sys.stderr)
+        return 1
+    print("✓ ci-failure-ledger self-test: create / append / reopen-recent / create-after-old / close-with-comment / "
+          "noop-when-green / refuse-malformed / other-writer-untouched / bounded-ledger / jobs-listed — every rule fires and stays silent as designed")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/.github/scripts/ci-failure-ledger.py
+++ b/.github/scripts/ci-failure-ledger.py
@@ -20,9 +20,16 @@ a signed event to the control portal, whose triage agent opens a thread on it.
 Sharing the label would let a CD heal CLOSE this ledger while CI is still red — and between that
 close and the next reopen the signal reads "resolved". So this ledger has its OWN label
 (`ci-main-red`, never `ci-failure`) and its own ownership mark, a hidden line in the body
-(`<!-- ci-main-red ledger -->`). "Matching" is label AND exact title AND that marker: an issue
-lacking any of the three is never appended to, reopened, commented on or closed — it is logged and
-left alone, and a fresh ledger is filed beside it if one is needed.
+(`<!-- ci-main-red ledger -->`). Label, title and marker are all PUBLIC fields anyone with triage
+can put on any issue, so the fourth term is the one a human cannot forge: the issue's AUTHOR must be
+the Actions bot (`user.login == "github-actions[bot]"`, `user.type == "Bot"`) — which is also why
+the lane takes the caller's GITHUB_TOKEN and nothing else. An issue lacking any of the four is never
+appended to, reopened, commented on or closed — it is logged and left alone, and a fresh ledger is
+filed beside it if one is needed.
+
+The control-portal URL is validated BEFORE anything is signed (`--check-url`): https, the expected
+host (`control-webhook-host`, default memex.systemorph.com), a path under /api/hooks/. A signed
+HMAC must never travel to whatever non-empty string a caller put in a variable.
 
 THE FOUR RULES, each covered by --self-test
 --------------------------------------------
@@ -44,6 +51,7 @@ API failure — each is RED naming the cause, never a quiet "nothing to do". The
 
     python3 ci-failure-ledger.py                 # in Actions: everything from the environment
     python3 ci-failure-ledger.py --self-test     # prove every rule, against a fake GitHub
+    python3 ci-failure-ledger.py --check-url URL --expected-host HOST   # the inbox URL, or red
 """
 from __future__ import annotations
 
@@ -65,6 +73,8 @@ DEFAULT_REOPEN_WINDOW_DAYS = 7
 MAX_LEDGER_ENTRIES = 40          # ~500 bytes an entry; GitHub caps a body at 65,536 characters
 LEDGER_MARK = "<!-- ci-main-red ledger -->"  # the ownership mark: only an issue carrying it is ours
 FORBIDDEN_LABEL = "ci-failure"               # CD's label; the ledger never files under it
+BOT_LOGIN, BOT_TYPE = "github-actions[bot]", "Bot"   # the only author whose issues this ledger owns
+INBOX_PATH_PREFIX = "/api/hooks/"
 ENTRY_HEAD = "### "              # every ledger entry starts with this at column 0
 FAILED_CONCLUSIONS = ("failure", "timed_out")
 
@@ -97,6 +107,8 @@ class Issue:
     html_url: str
     labels: tuple[str, ...] = ()
     closed_at: str | None = None
+    author: str = ""
+    author_type: str = ""
 
 
 @dataclass
@@ -141,10 +153,38 @@ def _parse_iso(ts: str) -> datetime:
 
 
 def owns(issue: Issue, label: str, title: str) -> bool:
-    """The ownership test: label AND exact title AND the hidden marker in the body. All three, so a
-    hand-labelled issue, a same-titled issue from another writer, or a body somebody rewrote is
+    """The ownership test: label AND exact title AND the hidden marker in the body AND authored by
+    the Actions bot. The first three are public fields anyone can set on any issue; the author is
+    the term a human cannot forge, so a marker on a human-authored issue is FOREIGN. A hand-labelled
+    issue, a same-titled issue from another writer, a rewritten body, or a copy someone pasted is
     never something this ledger closes."""
-    return label in issue.labels and issue.title == title and LEDGER_MARK in (issue.body or "")
+    return (label in issue.labels and issue.title == title and LEDGER_MARK in (issue.body or "")
+            and issue.author == BOT_LOGIN and issue.author_type == BOT_TYPE)
+
+
+def validate_control_url(url: str, expected_host: str) -> str | None:
+    """None when `url` is the control portal's inbox; otherwise the sentence that names what is wrong.
+
+    Nothing is signed until this says None: an HMAC over the event, sent to an arbitrary URL, is a
+    credential handed to whoever owns that host.
+    """
+    try:
+        u = urllib.parse.urlsplit(url or "")
+    except ValueError as e:                                     # noqa: BLE001 - reported, not raised
+        return f"control-webhook-url {url!r} does not parse ({e})"
+    if u.scheme != "https":
+        return f"control-webhook-url {url!r} is not https — the signature would travel in clear"
+    if u.username or u.password:
+        return f"control-webhook-url {url!r} carries userinfo — refused"
+    if (u.hostname or "").lower() != (expected_host or "").lower() or not expected_host:
+        return (f"control-webhook-url {url!r} points at host {u.hostname!r}, not the control portal "
+                f"{expected_host!r} (inputs.control-webhook-host) — refusing to sign an event for it")
+    if u.port not in (None, 443):
+        return f"control-webhook-url {url!r} uses port {u.port} — the control portal serves 443 only"
+    if not u.path.startswith(INBOX_PATH_PREFIX):
+        return (f"control-webhook-url {url!r} path {u.path!r} is not under {INBOX_PATH_PREFIX} — the webhook "
+                f"inbox lives at /api/hooks/<target> (e.g. /api/hooks/Hosting/PlatformBuilds)")
+    return None
 
 
 def decide(outcome: str, matching: list[Issue], now: datetime, reopen_window_days: int) -> Verdict:
@@ -298,8 +338,10 @@ class GitHub:
             for it in items:
                 if "pull_request" in it:
                     continue
+                user = it.get("user") or {}
                 out.append(Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
-                                 tuple(l["name"] for l in it.get("labels", [])), it.get("closed_at")))
+                                 tuple(l["name"] for l in it.get("labels", [])), it.get("closed_at"),
+                                 str(user.get("login") or ""), str(user.get("type") or "")))
             if len(items) < 100:
                 break
         return out
@@ -308,8 +350,16 @@ class GitHub:
         if label == FORBIDDEN_LABEL or LEDGER_MARK not in body:
             raise Red(f"refusing to file a ledger issue under `{label}` / without its ownership mark — that is CD's label, and an unmarked issue is one this ledger could never prove it opened")
         _, it = self.call("POST", "issues", body={"title": title, "labels": [label], "body": body})
-        return Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
-                     tuple(l["name"] for l in it.get("labels", [])))
+        user = it.get("user") or {}
+        issue = Issue(it["number"], it["title"], it["state"], it.get("body") or "", it["html_url"],
+                      tuple(l["name"] for l in it.get("labels", [])), it.get("closed_at"),
+                      str(user.get("login") or ""), str(user.get("type") or ""))
+        if not (issue.author == BOT_LOGIN and issue.author_type == BOT_TYPE):
+            raise Red(f"the ledger issue #{issue.number} was created as {issue.author!r} ({issue.author_type!r}), "
+                      f"not as {BOT_LOGIN!r} — the token is not the caller's GITHUB_TOKEN, so this ledger could "
+                      f"never own the issue it just filed and would file a fresh one every run. Pass "
+                      f"`secrets: github-token:` = secrets.GITHUB_TOKEN and nothing else.")
+        return issue
 
     def update_issue(self, number: int, **fields) -> Issue:
         _, it = self.call("PATCH", f"issues/{number}", body=fields)
@@ -409,10 +459,19 @@ def main(argv: list[str]) -> int:
     ap.add_argument("--reopen-window-days", type=int, default=int(env("LEDGER_REOPEN_WINDOW_DAYS") or DEFAULT_REOPEN_WINDOW_DAYS))
     ap.add_argument("--event-out", default=env("LEDGER_EVENT_OUT"), help="file the exact event body is written to")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--check-url", help="validate this control-webhook-url and exit; nothing else runs")
+    ap.add_argument("--expected-host", default=env("LEDGER_CONTROL_HOST") or "memex.systemorph.com")
     a = ap.parse_args(argv)
 
     if a.self_test:
         return self_test()
+    if a.check_url is not None:
+        problem = validate_control_url(a.check_url, a.expected_host)
+        if problem:
+            print(f"::error title=ci-failure-ledger::{problem}", file=sys.stderr)
+            return 1
+        print(f"control-webhook-url is the control portal's inbox ({a.expected_host}, under {INBOX_PATH_PREFIX}) — safe to sign for")
+        return 0
 
     try:
         token = env("GH_TOKEN") or env("GITHUB_TOKEN") or ""
@@ -489,7 +548,8 @@ class _Fake:
         self.writes += 1
         n = self.next_number
         self.next_number += 1
-        self.issues[n] = Issue(n, title, "open", body, f"https://github.com/o/r/issues/{n}", (label,))
+        self.issues[n] = Issue(n, title, "open", body, f"https://github.com/o/r/issues/{n}", (label,),
+                               None, BOT_LOGIN, BOT_TYPE)
         return self.issues[n]
 
     def update_issue(self, number, **fields):
@@ -579,7 +639,8 @@ def self_test() -> int:
 
     # 6. closed 2 days ago → reopened and appended, not duplicated
     closed_recent = Issue(7, title, "closed", new_body("o/r", 7) + "\n\n" + ENTRY_HEAD + "old — **failure** — [run 1](u)\n",
-                          "https://github.com/o/r/issues/7", (label,), (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+                          "https://github.com/o/r/issues/7", (label,), (now - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                          BOT_LOGIN, BOT_TYPE)
     gh6 = _Fake([closed_recent])
     v, issue6, _ = go(gh6, run("failure", [job]))
     check("closed 2 d ago -> reopen the same issue", v.action == "reopen" and issue6 is not None and issue6.number == 7
@@ -587,8 +648,8 @@ def self_test() -> int:
     check("reopened body gained an entry", issue6 is not None and issue6.body.count("\n" + ENTRY_HEAD) == 2)
 
     # 7. closed 9 days ago → a fresh issue
-    closed_old = Issue(8, title, "closed", "x", "https://github.com/o/r/issues/8", (label,),
-                       (now - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+    closed_old = Issue(8, title, "closed", new_body("o/r", 7), "https://github.com/o/r/issues/8", (label,),
+                       (now - timedelta(days=9)).strftime("%Y-%m-%dT%H:%M:%SZ"), BOT_LOGIN, BOT_TYPE)
     gh7 = _Fake([closed_old])
     v, issue7, _ = go(gh7, run("failure", [job]))
     check("closed 9 d ago -> create a fresh issue", v.action == "create" and issue7 is not None and issue7.number != 8 and len(gh7.issues) == 2)
@@ -613,7 +674,8 @@ def self_test() -> int:
 
     # 8b. a `ci-main-red` issue WITHOUT the ownership mark (hand-labelled, or a rewritten body) is never
     #     closed, commented on, reopened or appended to — logged as foreign, left exactly as found.
-    unmarked = Issue(10, title, "open", "someone labelled this by hand", "https://github.com/o/r/issues/10", (label,))
+    unmarked = Issue(10, title, "open", "someone labelled this by hand", "https://github.com/o/r/issues/10", (label,),
+                     None, BOT_LOGIN, BOT_TYPE)
     gh8c = _Fake([unmarked])
     mine, foreign = owned_issues(gh8c, label, title)
     check("an unmarked `ci-main-red` issue is FOREIGN, not owned", mine == [] and [f.number for f in foreign] == [10])
@@ -627,6 +689,38 @@ def self_test() -> int:
         check("a write aimed at an unmarked issue is refused at the moment of the write", False, "was allowed")
     except Red:
         check("a write aimed at an unmarked issue is refused at the moment of the write", True)
+
+    # 8c. a HUMAN-authored issue carrying label + title + marker — all three are public fields anyone
+    #     with triage can set — is FOREIGN: the author is the term that cannot be forged.
+    forged = Issue(11, title, "open", new_body("o/r", 7), "https://github.com/o/r/issues/11", (label,),
+                   None, "some-human", "User")
+    gh8d = _Fake([forged])
+    mine, foreign = owned_issues(gh8d, label, title)
+    check("a human-authored issue with label, title AND marker is FOREIGN", mine == [] and [f.number for f in foreign] == [11])
+    v, _, _ = go(gh8d, run("success"))
+    check("green never closes the forged issue", v.action == "noop" and gh8d.writes == 0 and gh8d.issues[11].state == "open")
+    v, issue8d, _ = go(gh8d, run("failure", [job]))
+    check("red files a bot-authored ledger beside the forged one, which is untouched",
+          v.action == "create" and issue8d is not None and issue8d.number != 11 and issue8d.author == BOT_LOGIN
+          and gh8d.issues[11].body == forged.body)
+    check("a bot-typed login that is not github-actions[bot] (an App token) does not own either",
+          not owns(Issue(12, title, "open", new_body("o/r", 7), "u", (label,), None, "meshweaver-cloud[bot]", "Bot"), label, title))
+
+    # 11. the inbox URL: nothing is signed for anything but the control portal's /api/hooks/
+    host = "memex.systemorph.com"
+    good = "https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds"
+    check("the control portal's inbox URL is accepted", validate_control_url(good, host) is None)
+    check("host comparison is case-insensitive", validate_control_url("https://MEMEX.systemorph.com/api/hooks/x", host) is None)
+    for bad, why in [("http://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds", "http"),
+                     ("https://evil.example/api/hooks/Hosting/PlatformBuilds", "other host"),
+                     ("https://memex.systemorph.com.evil.example/api/hooks/x", "host suffix trick"),
+                     ("https://memex.systemorph.com/hooks/Hosting/PlatformBuilds", "path outside /api/hooks/"),
+                     ("https://memex.systemorph.com:8443/api/hooks/x", "odd port"),
+                     ("https://user:pw@memex.systemorph.com/api/hooks/x", "userinfo"),
+                     ("", "empty"), ("not a url", "garbage")]:
+        p = validate_control_url(bad, host)
+        check(f"refused: {why}", p is not None and (bad in p or bad == ""), p or "")
+    check("an empty expected host refuses everything", validate_control_url(good, "") is not None)
 
     # 9. the ledger is bounded
     b = new_body("o/r", 7)
@@ -655,8 +749,8 @@ def self_test() -> int:
         print("::error title=ci-failure-ledger self-test::" + "; ".join(fails), file=sys.stderr)
         return 1
     print("✓ ci-failure-ledger self-test: create / append / reopen-recent / create-after-old / close-with-comment / "
-          "noop-when-green / refuse-malformed / cd-ci-failure-untouched / unmarked-ci-main-red-untouched / never-labelled-ci-failure / "
-          "bounded-ledger / jobs-listed — every rule fires and stays silent as designed")
+          "noop-when-green / refuse-malformed / cd-ci-failure-untouched / unmarked-ci-main-red-untouched / human-authored-is-foreign / "
+          "never-labelled-ci-failure / inbox-url-validated / bounded-ledger / jobs-listed — every rule fires and stays silent as designed")
     return 0
 
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2016,9 +2016,11 @@ jobs:
     # 🚨 The ledger every repository's red `main` is routed onto (node-repo-ci-failure.yml, maintainer
     # 2026-09-12: "put the ci-failure on all repos, in main") — proven here because core OWNS the
     # script and every satellite fetches it at its scripts ref. Its rules are load-bearing: ONE open
-    # issue per repo (append, never duplicate), a close inside 7 days is REOPENED rather than
-    # re-filed, green closes with `green again: <run URL>`, and a malformed failed-jobs input is
-    # refused before any write. A guard that could not say no would file a second issue per red day.
+    # `ci-main-red` issue per repo (append, never duplicate), a close inside 7 days is REOPENED rather
+    # than re-filed, green closes with `green again: <run URL>`, a malformed failed-jobs input is
+    # refused before any write, and it only ever closes an issue it opened (its own label AND an
+    # ownership mark in the body — never main-cd.yml's `ci-failure`). A guard that could not say no
+    # would file a second issue per red day, or close CD's.
     - name: "The ci-failure ledger can say no (self-test)"
       run: python3 .github/scripts/ci-failure-ledger.py --self-test
 
@@ -3375,10 +3377,12 @@ jobs:
   # (the same empty room a scheduled red goes into; AGENTS.md → "an honest red nobody reads is the
   # same defect as a gate that cannot fail"). Maintainer, 2026-09-12: "put the ci-failure on all
   # repos, in main; triaging is done by systemorph-com". These two jobs are the same thin caller
-  # every satellite wires (the contract is in node-repo-ci-failure.yml's header): one `ci-failure`
+  # every satellite wires (the contract is in node-repo-ci-failure.yml's header): one `ci-main-red`
   # issue per repository, a dated ledger entry per red run, closed by the run that goes green, and a
   # signed event to the control portal's triage inbox each way. main-cd.yml's own `ci-failure`
-  # DELIVERY alerting is a different subject (an image set that did not publish) and is untouched.
+  # DELIVERY alerting is a different subject (an image set that did not publish) and is untouched —
+  # and the two never meet: the ledger has its own label and an ownership mark in the body, so a CD
+  # heal cannot close the CI ledger and the ledger cannot close CD's issue.
   #
   # `needs: [collect-results]` is the whole graph: `Consolidate test results` `needs:` every other job,
   # runs `always()`, and carries an explicit fail step per dependency — so `failure()` here is "some

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -3376,8 +3376,9 @@ jobs:
   # `main-cd.yml` only fires on a SUCCESSFUL run — so a red main updates nothing and pages nobody
   # (the same empty room a scheduled red goes into; AGENTS.md → "an honest red nobody reads is the
   # same defect as a gate that cannot fail"). Maintainer, 2026-09-12: "put the ci-failure on all
-  # repos, in main; triaging is done by systemorph-com". These two jobs are the same thin caller
-  # every satellite wires (the contract is in node-repo-ci-failure.yml's header): one `ci-main-red`
+  # repos, in main; triaging is done by systemorph-com". These two jobs are the thin caller each
+  # satellite wires in its own follow-up PR once the lane is on main (the contract is in
+  # node-repo-ci-failure.yml's header) — core is wired first, here: one `ci-main-red`
   # issue per repository, a dated ledger entry per red run, closed by the run that goes green, and a
   # signed event to the control portal's triage inbox each way. main-cd.yml's own `ci-failure`
   # DELIVERY alerting is a different subject (an image set that did not publish) and is untouched —

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2013,6 +2013,15 @@ jobs:
     - name: "No workflow mapping writes a key twice"
       run: python3 .github/scripts/check-workflow-yaml-keys.py --root .
 
+    # 🚨 The ledger every repository's red `main` is routed onto (node-repo-ci-failure.yml, maintainer
+    # 2026-09-12: "put the ci-failure on all repos, in main") — proven here because core OWNS the
+    # script and every satellite fetches it at its scripts ref. Its rules are load-bearing: ONE open
+    # issue per repo (append, never duplicate), a close inside 7 days is REOPENED rather than
+    # re-filed, green closes with `green again: <run URL>`, and a malformed failed-jobs input is
+    # refused before any write. A guard that could not say no would file a second issue per red day.
+    - name: "The ci-failure ledger can say no (self-test)"
+      run: python3 .github/scripts/ci-failure-ledger.py --self-test
+
     # 🚨 combo-verify.yml fires on `workflow_run` / `workflow_dispatch`, NEVER on `pull_request`, so
     # nothing else on this PR opens it — the same blind spot #2642 cost 33 hours on. Its `preflight`
     # is the only thing between "no per-instance credential was provisioned" and a lane that
@@ -3359,3 +3368,73 @@ jobs:
           echo "> reuses an already-green tree marker reports success **without executing the suite**,"
           echo "> so the window taken from the run list can exclude the change set that actually broke it."
         } >> "$GITHUB_STEP_SUMMARY"
+
+  # ─────────────────────────── MAIN IS RED: SAY SO WHERE SOMEONE READS ───────────────────────────
+  # A red push-to-main run here is attached to no pull request, no reviewer and no check list, and
+  # `main-cd.yml` only fires on a SUCCESSFUL run — so a red main updates nothing and pages nobody
+  # (the same empty room a scheduled red goes into; AGENTS.md → "an honest red nobody reads is the
+  # same defect as a gate that cannot fail"). Maintainer, 2026-09-12: "put the ci-failure on all
+  # repos, in main; triaging is done by systemorph-com". These two jobs are the same thin caller
+  # every satellite wires (the contract is in node-repo-ci-failure.yml's header): one `ci-failure`
+  # issue per repository, a dated ledger entry per red run, closed by the run that goes green, and a
+  # signed event to the control portal's triage inbox each way. main-cd.yml's own `ci-failure`
+  # DELIVERY alerting is a different subject (an image set that did not publish) and is untouched.
+  #
+  # `needs: [collect-results]` is the whole graph: `Consolidate test results` `needs:` every other job,
+  # runs `always()`, and carries an explicit fail step per dependency — so `failure()` here is "some
+  # gate failed" and `success()` is "every gate passed", with nothing between them to reason about.
+  #
+  # 🚨 STATICALLY PR-UNREACHABLE, and the order of the `if:` terms is load-bearing:
+  # `github.event_name != 'pull_request'` comes FIRST so check-pr-secret-preflight.py proves from the
+  # file alone that `secrets.CONTROL_WEBHOOK_SECRET` (an org secret with NO Dependabot-store copy) is
+  # never consumed on a pull request. `github.ref == 'refs/heads/main'` keeps a `merge_group` ref
+  # (`refs/heads/gh-readonly-queue/main/…`) and a `workflow_dispatch` on a branch out.
+  #
+  # `permissions:` REPLACES the workflow-level map for these jobs, and the lane's job demands exactly
+  # these three: `issues: write` for the ledger, `actions: read` to list this run's failed jobs,
+  # `contents: read` because a block that omits it takes it away. GITHUB_TOKEN, never an App token —
+  # the installation holds no `issues` grant. The reference is `./` so the lane at THIS commit runs
+  # (main-cd.yml calls its lanes the same way) and check-workflow-permission-pairing.py --root . can
+  # pair the two halves in one checkout.
+  ci-failure:
+    name: "main is red: file it, tell the control portal"
+    needs: [collect-results]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && failure()
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    uses: ./.github/workflows/node-repo-ci-failure.yml
+    with:
+      outcome: failure
+      run: ${{ github.run_id }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      sha: ${{ github.sha }}
+      event: ${{ github.event_name }}
+      # Core IS the platform: there is no core set this run "built against".
+      platform-set: ""
+      control-webhook-url: ${{ vars.CONTROL_WEBHOOK_URL }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      control-webhook-secret: ${{ secrets.CONTROL_WEBHOOK_SECRET }}
+
+  ci-green:
+    name: "main is green: close the ledger"
+    needs: [collect-results]
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && success()
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    uses: ./.github/workflows/node-repo-ci-failure.yml
+    with:
+      outcome: success
+      run: ${{ github.run_id }}
+      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      sha: ${{ github.sha }}
+      event: ${{ github.event_name }}
+      platform-set: ""
+      control-webhook-url: ${{ vars.CONTROL_WEBHOOK_URL }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+      control-webhook-secret: ${{ secrets.CONTROL_WEBHOOK_SECRET }}

--- a/.github/workflows/node-repo-ci-failure.yml
+++ b/.github/workflows/node-repo-ci-failure.yml
@@ -15,11 +15,21 @@ name: Node repo ci-failure ledger (reusable)
 # issue plus a heal ledger; this lane gives every repository's BUILD the same artefact, and then
 # tells the control portal, whose triage agent opens a thread on it. main-cd's mechanism is untouched.
 #
+# 🚨 ITS OWN LABEL — `ci-main-red`, NEVER `ci-failure` — AND ITS OWN OWNERSHIP MARK. A mechanism
+# may only close an issue it opened. main-cd.yml's alert and heal find CD's issue by listing the
+# `ci-failure` label alone (`--limit 1`); had this ledger shared the label, a CD heal could have
+# CLOSED it while CI was still red, and between that close and the next reopen the signal reads
+# "resolved" — a day-one silent failure. So: CD's search never finds the ledger, and the ledger
+# never finds CD's. The ledger's find / append / reopen / comment / close all require the label AND
+# the exact `issue-title` AND a hidden line in the body, `<!-- ci-main-red ledger -->`; an issue
+# lacking any of the three (hand-labelled, another writer, a rewritten body) is logged and left
+# exactly as found, and a fresh ledger is filed beside it if one is needed. Self-tested.
+#
 # WHAT IT DOES, per outcome — the logic lives in .github/scripts/ci-failure-ledger.py, self-tested
 # (`--self-test`) in core's `workflow-shell` job AND at the start of every run of this lane:
 #
-#   outcome: failure   find the calling repo's issue labelled `ci-failure` with the exact
-#                      `issue-title`. Open → APPEND a dated ledger entry to its body (run URL, sha,
+#   outcome: failure   find the calling repo's issue labelled `ci-main-red` with the exact
+#                      `issue-title` and the ownership mark. Open → APPEND a dated ledger entry to its body (run URL, sha,
 #                      trigger, failed jobs with links, platform set). Closed within the last 7 days
 #                      → REOPEN it and append (flapping is one story). Otherwise CREATE it. Never a
 #                      second open issue. Then POST, signed, to `control-webhook-url`:
@@ -146,10 +156,10 @@ on:
         type: string
         default: ""
       issue-title:
-        description: The exact title of the ledger issue. Label + title identify it; another writer's `ci-failure` issue under a different title is never touched.
+        description: The exact title of the ledger issue. The `ci-main-red` label + this title + the body's ownership mark identify it; nothing else is ever closed or commented on.
         required: false
         type: string
-        default: "ci-failure: main is red"
+        default: "ci-main-red: main is red"
       control-webhook-url:
         description: The control portal's triage inbox — pass vars.CONTROL_WEBHOOK_URL (https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds).
         required: true
@@ -228,7 +238,7 @@ jobs:
           # names the `issues: write` grant on the caller job.
           code=$(curl -sS -o "$RUNNER_TEMP/issues-probe" -w '%{http_code}' --connect-timeout 10 --max-time 30 \
             -H "Authorization: Bearer $GH_TOKEN" -H 'Accept: application/vnd.github+json' \
-            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues?labels=ci-failure&state=all&per_page=1") || code=000
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues?labels=ci-main-red&state=all&per_page=1") || code=000
           if [ "$code" != "200" ]; then
             echo "::error::GET /repos/${GITHUB_REPOSITORY}/issues answered HTTP ${code} with the token this lane was handed. It must be the caller's secrets.GITHUB_TOKEN, forwarded as \`secrets: github-token:\`, on a caller job granting \`permissions: {contents: read, issues: write, actions: read}\`. Response: $(head -c 300 "$RUNNER_TEMP/issues-probe" || true)"
             exit 1
@@ -254,7 +264,7 @@ jobs:
       - name: "The ledger can say no (self-test)"
         run: python3 "$RUNNER_TEMP/ci-failure-ledger.py" --self-test
 
-      - name: Open, append to, reopen, or close the ci-failure issue
+      - name: Open, append to, reopen, or close the ci-main-red ledger issue
         id: ledger
         env:
           GH_TOKEN: ${{ secrets.github-token }}
@@ -266,7 +276,8 @@ jobs:
           LEDGER_FAILED_JOBS: ${{ inputs.failed-jobs }}
           LEDGER_PLATFORM_SET: ${{ inputs.platform-set }}
           LEDGER_ISSUE_TITLE: ${{ inputs.issue-title }}
-          LEDGER_LABEL: ci-failure
+          # NEVER ci-failure — that is main-cd.yml's delivery alert; the script refuses that label outright.
+          LEDGER_LABEL: ci-main-red
         run: |
           set -euo pipefail
           export LEDGER_EVENT_OUT="$RUNNER_TEMP/event.json"

--- a/.github/workflows/node-repo-ci-failure.yml
+++ b/.github/workflows/node-repo-ci-failure.yml
@@ -1,0 +1,360 @@
+name: Node repo ci-failure ledger (reusable)
+
+# ♻️ REUSABLE (workflow_call) — a red `main` gets ONE issue and ONE signed event; a green one closes it.
+#
+# Maintainer, 2026-09-12: "put the ci-failure on all repos, in main; triaging is done by
+# systemorph-com (the control instance memex.systemorph.com); communicate via MCP — open a thread
+# with a triage agent; pool such connections by portal."
+#
+# Every satellite (MeshWeaver.Plugins, .SocialMedia, .Crm, .Reinsurance, .Education, .Manufacturing)
+# runs its full build on `push: [main]` and once a day on `schedule` — the per-build platform wave
+# was switched off the same day. A red run there is attached to no pull request, no reviewer and no
+# check list. It updates nothing and pages nobody: red in an empty room, which from outside is
+# indistinguishable from a gate that cannot fail (AGENTS.md → "a SCHEDULED lane's honest red is red
+# in an EMPTY ROOM"). Core's own `main-cd.yml` already routes a failed DELIVERY onto a `ci-failure`
+# issue plus a heal ledger; this lane gives every repository's BUILD the same artefact, and then
+# tells the control portal, whose triage agent opens a thread on it. main-cd's mechanism is untouched.
+#
+# WHAT IT DOES, per outcome — the logic lives in .github/scripts/ci-failure-ledger.py, self-tested
+# (`--self-test`) in core's `workflow-shell` job AND at the start of every run of this lane:
+#
+#   outcome: failure   find the calling repo's issue labelled `ci-failure` with the exact
+#                      `issue-title`. Open → APPEND a dated ledger entry to its body (run URL, sha,
+#                      trigger, failed jobs with links, platform set). Closed within the last 7 days
+#                      → REOPEN it and append (flapping is one story). Otherwise CREATE it. Never a
+#                      second open issue. Then POST, signed, to `control-webhook-url`:
+#
+#        {"event":"ci-failure","repo":"<owner/name>","sha":"…","run":<id>,"runUrl":"…","trigger":"schedule",
+#         "failedJobs":[{"name":"…","url":"…","step":"…"}],"platformSet":"…","issueUrl":"…","issueNumber":N}
+#
+#   outcome: success   an open matching issue → comment `green again: <run URL>` and CLOSE it, then
+#                      POST {"event":"ci-green","repo","sha","run","runUrl","issueNumber"}. No open
+#                      issue → nothing changed, so nothing is posted (said out loud, with the count).
+#
+# The event is signed exactly as core's `notify-platform-update` signs the build fact —
+# `X-Hub-Signature-256: sha256=<HMAC-SHA256 of the exact body>` with the shared secret — and the
+# inbox's answer is judged the same three-way way (`"signature":"verified"` passes; `not-required`
+# is a broken pair and fails; no verdict at all is a receiver that has not rolled #3312 and warns).
+#
+# 🚨 THE ISSUE WRITES USE THE CALLER'S `secrets.GITHUB_TOKEN`, NEVER A GITHUB APP TOKEN. The
+# `meshweaver-cloud` installation holds contents/metadata/pull_requests and nothing else (measured
+# 2026-09-07, `GET /orgs/Systemorph/installations`), so an App-token issue write would 403 on an
+# installation grant nobody in the calling repo can see. GITHUB_TOKEN's `issues: write` is granted
+# on the CALLER job, in the caller's own file, where a missing grant is a one-line diff — and a
+# called workflow can only NARROW what it was given, so this lane's own `permissions:` block is a
+# requirement on the caller, not a grant: a caller that omits it does not get a quieter lane, it gets
+# `startup_failure` with zero jobs (check-workflow-permission-pairing.py guards the pairing).
+#
+# 🚨 NO SKIP-TRAPDOOR, in either direction. No `continue-on-error` anywhere; no `if:` that asks
+# whether a secret or variable is set. The preflight ASSERTS every input the caller is expected to
+# provision and fails RED naming what and where; the only step-level `if:` below is on the ledger's
+# own decision (`post`), which is run state the step above printed, never an input. And the caller
+# wires BOTH outcomes — a failure-only reporter never clears a stale alert, and an alert that is no
+# longer true is how the next real one gets skimmed past.
+#
+# ─────────────────────────────── CALLER CONTRACT ───────────────────────────────
+#
+# Two jobs at the END of the satellite's ci.yml. `needs:` must name EVERY gate job — a job missing
+# from the list fails silently, which is the whole failure mode this lane exists to prevent. Both are
+# statically unreachable from a pull request (`github.event_name != 'pull_request'` first, so
+# check-pr-secret-preflight.py can prove the org secret is never consumed on a PR), and both grant
+# the three permissions this lane's job demands.
+#
+#   ci-failure:
+#     name: "main is red: file it, tell the control portal"
+#     needs: [validate, compile-check, test-repos, publish-bake]        # ← EVERY gate job
+#     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && failure()
+#     permissions: {contents: read, issues: write, actions: read}
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-ci-failure.yml@main
+#     with:
+#       outcome: failure
+#       run: ${{ github.run_id }}
+#       run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#       sha: ${{ github.sha }}
+#       event: ${{ github.event_name }}
+#       platform-set: ${{ needs.select.outputs.platform-set }}   # the core set the run built against; '' if none
+#       control-webhook-url: ${{ vars.CONTROL_WEBHOOK_URL }}
+#     secrets:
+#       github-token: ${{ secrets.GITHUB_TOKEN }}
+#       control-webhook-secret: ${{ secrets.CONTROL_WEBHOOK_SECRET }}
+#
+#   ci-green:
+#     name: "main is green: close the ledger"
+#     needs: [validate, compile-check, test-repos, publish-bake]        # ← the SAME list
+#     if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && success()
+#     permissions: {contents: read, issues: write, actions: read}
+#     uses: Systemorph/MeshWeaver/.github/workflows/node-repo-ci-failure.yml@main
+#     with:
+#       outcome: success
+#       run: ${{ github.run_id }}
+#       run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+#       sha: ${{ github.sha }}
+#       event: ${{ github.event_name }}
+#       control-webhook-url: ${{ vars.CONTROL_WEBHOOK_URL }}
+#     secrets:
+#       github-token: ${{ secrets.GITHUB_TOKEN }}
+#       control-webhook-secret: ${{ secrets.CONTROL_WEBHOOK_SECRET }}
+#
+# `CONTROL_WEBHOOK_URL` (org variable) and `CONTROL_WEBHOOK_SECRET` (org secret) exist, scoped to the
+# fleet repositories, and point at https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds —
+# the same inbox the build fact and the publication records go to. `failed-jobs` may be left out: the
+# lane lists the run's failed jobs itself (that is what `actions: read` is for). Pass it only when the
+# caller has a better list than "every job that concluded failure".
+#
+# 🚨 A satellite's `gates-executed` job (the one that counts how many gate jobs actually ran) must NOT
+# count these two: they are conditional on `main` and skipped on every pull request, so counting them
+# turns every PR's tally short by two and reds a gate on a condition no diff can reach.
+#
+# 🔒 PIN THE REF where the repo pins its other lanes — `@<sha>` plus `scripts-ref: <same sha>` —
+# same reason as every other node-repo template: `@main` makes two runs of identical code able to
+# disagree. `@main` is what five of six satellites do today; the template above matches them.
+
+on:
+  workflow_call:
+    inputs:
+      outcome:
+        description: "`failure` or `success` — the calling run's verdict over every gate job."
+        required: true
+        type: string
+      run:
+        description: The calling run's id (`github.run_id`) — the `run` field of the event body.
+        required: true
+        type: string
+      run-url:
+        description: The calling run's URL (`github.server_url`/`github.repository`/actions/runs/`github.run_id`).
+        required: true
+        type: string
+      sha:
+        description: The commit the run built (`github.sha`).
+        required: true
+        type: string
+      event:
+        description: What triggered the run — push, schedule, repository_dispatch, workflow_dispatch (`github.event_name`).
+        required: true
+        type: string
+      failed-jobs:
+        description: >-
+          JSON array of {name, url, step} the caller assembled. Empty (the default) on a failure means
+          "list the run's jobs that concluded failure/timed_out yourself" — which needs `actions: read`
+          on the caller job. Ignored on success. A malformed value is refused before any write.
+        required: false
+        type: string
+        default: "[]"
+      platform-set:
+        description: The resolved core set the run built against (e.g. `3.0.0-ci.4711`); empty if none.
+        required: false
+        type: string
+        default: ""
+      issue-title:
+        description: The exact title of the ledger issue. Label + title identify it; another writer's `ci-failure` issue under a different title is never touched.
+        required: false
+        type: string
+        default: "ci-failure: main is red"
+      control-webhook-url:
+        description: The control portal's triage inbox — pass vars.CONTROL_WEBHOOK_URL (https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds).
+        required: true
+        type: string
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's ledger script is fetched at. Pin it beside the
+          `uses:` sha; `main` is right for a caller that calls the lane at `@main`.
+        required: false
+        type: string
+        default: main
+    secrets:
+      github-token:
+        description: >-
+          The CALLER's `secrets.GITHUB_TOKEN`, with `issues: write` (and `actions: read`, `contents: read`)
+          granted on the caller job. Never a GitHub App token — see the header.
+        required: true
+      control-webhook-secret:
+        description: >-
+          The shared HMAC the control portal verifies X-Hub-Signature-256 against — pass
+          secrets.CONTROL_WEBHOOK_SECRET (org secret, byte-identical to the instance's
+          Hosting:PlatformWebhookSecret).
+        required: true
+
+jobs:
+  report:
+    name: "The red has an audience: one issue, one signed event"
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # A REQUIREMENT on every caller (a called workflow can only narrow its caller's grant), and it
+    # REPLACES the defaults: `contents: read` is listed explicitly because a block that names only
+    # `issues` takes `contents` away — and the caller's map must carry all three or the run ends in
+    # `startup_failure` with zero jobs. `actions: read` lists the run's failed jobs.
+    permissions:
+      contents: read
+      issues: write
+      actions: read
+    steps:
+      # No `if:` on any step here except the ledger's own `post` decision. The assertions below
+      # ASSERT and fail; they never choose whether to run. A step asking "is the secret set?" and
+      # skipping would render exactly like a green that had nothing to report.
+      - name: Every input the caller must provision, or a red run naming what and where
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          CONTROL_WEBHOOK_URL: ${{ inputs.control-webhook-url }}
+          CONTROL_WEBHOOK_SECRET: ${{ secrets.control-webhook-secret }}
+          OUTCOME: ${{ inputs.outcome }}
+          RUN_ID: ${{ inputs.run }}
+          RUN_URL: ${{ inputs.run-url }}
+          SHA: ${{ inputs.sha }}
+          TRIGGER: ${{ inputs.event }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${GH_TOKEN:-}" ]               || missing+=("secrets.github-token           the caller's secrets.GITHUB_TOKEN — forward it as \`secrets: github-token:\` = secrets.GITHUB_TOKEN with \`permissions: {contents: read, issues: write, actions: read}\` on the caller job")
+          [ -n "${CONTROL_WEBHOOK_URL:-}" ]    || missing+=("inputs.control-webhook-url      pass vars.CONTROL_WEBHOOK_URL — org variable, scoped to the fleet repos, https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds (Settings → Secrets and variables → Actions → Variables, at the ORG)")
+          [ -n "${CONTROL_WEBHOOK_SECRET:-}" ] || missing+=("secrets.control-webhook-secret  pass secrets.CONTROL_WEBHOOK_SECRET — org secret, scoped to the fleet repos, byte-identical to the control instance's Hosting:PlatformWebhookSecret (Settings → Secrets and variables → Actions → Secrets, at the ORG; it has NO Dependabot-store copy, and this lane is never reachable from a pull request)")
+          [ -n "${RUN_ID:-}" ]                 || missing+=("inputs.run                      github.run_id")
+          [ -n "${RUN_URL:-}" ]                || missing+=("inputs.run-url                  github.server_url/github.repository/actions/runs/github.run_id")
+          [ -n "${SHA:-}" ]                    || missing+=("inputs.sha                      github.sha")
+          [ -n "${TRIGGER:-}" ]                || missing+=("inputs.event                    github.event_name")
+          [ -n "${SCRIPTS_REF:-}" ]            || missing+=("inputs.scripts-ref              the Systemorph/MeshWeaver ref the ledger script is fetched at (default main)")
+          case "${OUTCOME:-}" in
+            failure|success) ;;
+            *) missing+=("inputs.outcome                  must be \`failure\` or \`success\`, got '${OUTCOME:-}' — wire two caller jobs, one per outcome, never one job guessing") ;;
+          esac
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the ci-failure ledger cannot run — provision the following in the CALLING repository, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          # The token can at least READ this repo's issues — a wrong token, a repo the token cannot
+          # see, or a revoked run token is named HERE rather than as a 401 four steps later. The
+          # WRITE half is proven by the first write the ledger makes (the label ensure): a 403 there
+          # names the `issues: write` grant on the caller job.
+          code=$(curl -sS -o "$RUNNER_TEMP/issues-probe" -w '%{http_code}' --connect-timeout 10 --max-time 30 \
+            -H "Authorization: Bearer $GH_TOKEN" -H 'Accept: application/vnd.github+json' \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues?labels=ci-failure&state=all&per_page=1") || code=000
+          if [ "$code" != "200" ]; then
+            echo "::error::GET /repos/${GITHUB_REPOSITORY}/issues answered HTTP ${code} with the token this lane was handed. It must be the caller's secrets.GITHUB_TOKEN, forwarded as \`secrets: github-token:\`, on a caller job granting \`permissions: {contents: read, issues: write, actions: read}\`. Response: $(head -c 300 "$RUNNER_TEMP/issues-probe" || true)"
+            exit 1
+          fi
+          echo "inputs present; the token reads ${GITHUB_REPOSITORY}'s issues (HTTP 200); outcome=${OUTCOME}"
+
+      # The ledger logic is core's script, fetched at the lane's scripts ref — a caller cannot
+      # silently retain an old rule, and this lane runs in the CALLER's checkout context (where the
+      # script does not exist). Same fetch-and-verify shape as node-repo-validate.yml.
+      - name: Fetch the ledger script at the lane's scripts ref
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          SCRIPTS_REF: ${{ inputs.scripts-ref }}
+        run: |
+          set -euo pipefail
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/ci-failure-ledger.py?ref=${SCRIPTS_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/ci-failure-ledger.py" \
+            || { echo "::error::could not fetch ci-failure-ledger.py (Systemorph/MeshWeaver, under .github/scripts) at ${SCRIPTS_REF} — a scripts-ref older than the lane needs the older lane"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/ci-failure-ledger.py" | grep -q "ci-failure-ledger" || { echo "::error::the fetched ci-failure-ledger.py at ${SCRIPTS_REF} does not look like the ledger"; exit 1; }
+
+      # 🚨 Self-test FIRST, and let it fail the job. An unproven ledger is no ledger: every rule
+      # (create / append / reopen-recent / close / noop / refuse-malformed) must be shown to fire on
+      # its case before its verdict on the real repository means anything.
+      - name: "The ledger can say no (self-test)"
+        run: python3 "$RUNNER_TEMP/ci-failure-ledger.py" --self-test
+
+      - name: Open, append to, reopen, or close the ci-failure issue
+        id: ledger
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          LEDGER_OUTCOME: ${{ inputs.outcome }}
+          LEDGER_RUN_ID: ${{ inputs.run }}
+          LEDGER_RUN_URL: ${{ inputs.run-url }}
+          LEDGER_SHA: ${{ inputs.sha }}
+          LEDGER_TRIGGER: ${{ inputs.event }}
+          LEDGER_FAILED_JOBS: ${{ inputs.failed-jobs }}
+          LEDGER_PLATFORM_SET: ${{ inputs.platform-set }}
+          LEDGER_ISSUE_TITLE: ${{ inputs.issue-title }}
+          LEDGER_LABEL: ci-failure
+        run: |
+          set -euo pipefail
+          export LEDGER_EVENT_OUT="$RUNNER_TEMP/event.json"
+          python3 "$RUNNER_TEMP/ci-failure-ledger.py"
+          if [ -f "$LEDGER_EVENT_OUT" ]; then
+            echo "event body ($(wc -c < "$LEDGER_EVENT_OUT") bytes):"; cat "$LEDGER_EVENT_OUT"; echo
+          fi
+
+      # Signed the way core's build fact is signed (main-cd.yml, `notify-platform-update`): the HMAC
+      # is over the EXACT bytes the ledger wrote, sent with `--data-binary @file` so nothing
+      # re-serialises them in between. `|| code=000` is not defensive noise: `run:` is `bash -e`, so a
+      # curl that fails at the transport level would kill the step before the verdict names what is
+      # wrong. The timeouts stop an unreachable instance from burning the job timeout.
+      - name: Sign and POST the event to the control portal's triage inbox
+        if: steps.ledger.outputs.post == 'true'
+        env:
+          URL: ${{ inputs.control-webhook-url }}
+          SECRET: ${{ secrets.control-webhook-secret }}
+          SHA: ${{ inputs.sha }}
+        run: |
+          set -euo pipefail
+          BODY_FILE="$RUNNER_TEMP/event.json"
+          [ -s "$BODY_FILE" ] || { echo "::error::the ledger said post=true but wrote no event body — nothing was delivered"; exit 1; }
+          SIG=$(openssl dgst -sha256 -hmac "$SECRET" -hex "$BODY_FILE" | sed 's/^.*= /sha256=/')
+          code=$(curl -sS -o "$RUNNER_TEMP/resp" -w '%{http_code}' --connect-timeout 10 --max-time 60 \
+            -X POST "$URL" -H 'Content-Type: application/json' \
+            -H "X-Hub-Signature-256: $SIG" --data-binary "@$BODY_FILE") || code=000
+          echo "POST $URL -> $code"; cat "$RUNNER_TEMP/resp" || true; echo
+          case "$code" in
+            2*)
+              event=$(sed -n 's/^{"event":"\([a-z-]*\)".*/\1/p' "$BODY_FILE")
+              echo "### 📣 \`${event:-?}\` event for \`$SHA\` accepted by the control portal's inbox (HTTP $code)" >> "$GITHUB_STEP_SUMMARY"
+              echo "The inbox STORED the delivery; the triage thread is opened on the control instance, never here." >> "$GITHUB_STEP_SUMMARY"
+              verdict=$(tr -d '\n' < "$RUNNER_TEMP/resp" | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+              echo "- signature: **${verdict:-(the answer carried no verdict)}** — judged in the next step." >> "$GITHUB_STEP_SUMMARY"
+              ;;
+            000)
+              echo "::error::could not reach the control portal's inbox at all (DNS/TLS/connection refused). The issue is written; the control portal was NOT told, so no triage thread opens for this run."
+              exit 1
+              ;;
+            404)
+              echo "::error::the inbox answered 404. It is FAIL-CLOSED and answers 404 for BOTH an unlisted target and a wrong URL — check vars.CONTROL_WEBHOOK_URL against the control instance's WebhookInbox:Targets (Hosting/PlatformBuilds). The issue is written; the control portal was NOT told."
+              exit 1
+              ;;
+            401)
+              echo "::error::the inbox REFUSED the signature (HTTP 401): secrets.CONTROL_WEBHOOK_SECRET here and Hosting:PlatformWebhookSecret on the control instance are not byte-identical. Re-set BOTH from the same source — never read either to compare them. The issue is written; the control portal was NOT told."
+              exit 1
+              ;;
+            500)
+              echo "::error::the inbox declares a SecretConfigKey that is EMPTY on the control instance (HTTP 500), so it can verify nothing and refuses every delivery. Provision Hosting:PlatformWebhookSecret on that instance. The issue is written; the control portal was NOT told."
+              exit 1
+              ;;
+            *)
+              echo "::error::the control portal's inbox refused the event (HTTP $code). The issue is written; the control portal was NOT told."
+              exit 1
+              ;;
+          esac
+
+      # 🚨 ITS OWN STEP, deliberately — the same split as main-cd.yml and node-repo-publish-bake.yml.
+      # The step above is held to "every message ends the job"; this one judges whether the
+      # RECEIVER verified the signature while storing the event, which is a gap on the receiving
+      # end (a missing declaration, or a portal that has not rolled), never a failed delivery.
+      # Three answers (#3338): `verified` passes silently; `not-required` is a broken pair and
+      # FAILS (we always sign, so "never looked at it" means the secret is unexercised); no verdict
+      # at all is a receiver that predates #3312 and WARNS — nothing in the calling repo can fix it.
+      - name: "Did the inbox VERIFY the event?"
+        if: steps.ledger.outputs.post == 'true'
+        run: |
+          set -euo pipefail
+          RESP="${RESP:-$RUNNER_TEMP/resp}"
+          if [ ! -f "$RESP" ]; then
+            echo "::error::no inbox response was captured — the POST step did not run to completion."
+            exit 1
+          fi
+          verdict=$(tr -d '\n' < "$RESP" | sed -n 's/.*"signature"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+          case "$verdict" in
+            verified)
+              echo "signature VERIFIED — the control instance checked this POST's HMAC, so a drifted CONTROL_WEBHOOK_SECRET would now fail loudly (401)."
+              ;;
+            not-required)
+              echo "::error::the inbox ACCEPTED this event WITHOUT checking its signature. It answered \"not-required\", i.e. the control instance declares no WebhookInbox__Targets__N__SecretConfigKey for Hosting/PlatformBuilds, so secrets.CONTROL_WEBHOOK_SECRET was never exercised and a drifted secret would still be invisible (#3312). Fix it on the RECEIVING instance's Hosting/Deployment record (extraPortalConfig[\"WebhookInbox__Targets__N__SecretConfigKey\"] = \"Hosting:PlatformWebhookSecret\" on the slot carrying this target), then deploy. Nothing in the calling repository can fix it and nothing here may go green on it (#3338)."
+              exit 1
+              ;;
+            "")
+              echo "::warning::the inbox answered NO signature verdict at all (a bare 2xx with no \"signature\" field): the control instance still runs a pre-#3312 endpoint. That is a ROLLOUT gap on the receiver, not a missing chart key. Deploy the control instance; from then on this step judges for real, and a target answering \"not-required\" fails the job (#3338)."
+              ;;
+            *)
+              echo "::error::the inbox answered an unrecognised signature verdict \"$verdict\". This step judges the receiver's own word, so a word it does not know is not a pass: either the answer's contract changed (memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs) or something is rewriting the body in transit."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/node-repo-ci-failure.yml
+++ b/.github/workflows/node-repo-ci-failure.yml
@@ -21,9 +21,20 @@ name: Node repo ci-failure ledger (reusable)
 # CLOSED it while CI was still red, and between that close and the next reopen the signal reads
 # "resolved" — a day-one silent failure. So: CD's search never finds the ledger, and the ledger
 # never finds CD's. The ledger's find / append / reopen / comment / close all require the label AND
-# the exact `issue-title` AND a hidden line in the body, `<!-- ci-main-red ledger -->`; an issue
-# lacking any of the three (hand-labelled, another writer, a rewritten body) is logged and left
-# exactly as found, and a fresh ledger is filed beside it if one is needed. Self-tested.
+# the exact `issue-title` AND a hidden line in the body, `<!-- ci-main-red ledger -->` AND — the
+# term nobody can forge, since label, title and marker are public fields anyone with triage can set
+# — the issue's AUTHOR is the Actions bot (`user.login == "github-actions[bot]"`, `user.type ==
+# "Bot"`). An issue lacking any of the four (hand-labelled, another writer, a rewritten body, a
+# human's copy with the marker pasted in) is logged and left exactly as found, and a fresh ledger is
+# filed beside it if one is needed. That author rule is the second reason the lane takes the
+# caller's GITHUB_TOKEN and nothing else: an issue filed by any other identity would never be owned.
+# Self-tested.
+#
+# 🚨 NOTHING IS SIGNED FOR AN ARBITRARY URL. Before the ledger writes and before curl runs, the
+# script validates `control-webhook-url` (`--check-url`, self-tested): https, host equal to
+# `control-webhook-host` (default memex.systemorph.com), path under /api/hooks/. A red naming the
+# offending URL otherwise — an HMAC over the event sent to whatever a variable happened to hold is
+# a credential handed to that host.
 #
 # WHAT IT DOES, per outcome — the logic lives in .github/scripts/ci-failure-ledger.py, self-tested
 # (`--self-test`) in core's `workflow-shell` job AND at the start of every run of this lane:
@@ -109,7 +120,9 @@ name: Node repo ci-failure ledger (reusable)
 # fleet repositories, and point at https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds —
 # the same inbox the build fact and the publication records go to. `failed-jobs` may be left out: the
 # lane lists the run's failed jobs itself (that is what `actions: read` is for). Pass it only when the
-# caller has a better list than "every job that concluded failure".
+# caller has a better list than "every job that concluded failure". `control-webhook-host` defaults
+# to memex.systemorph.com and is the host `control-webhook-url` MUST resolve to; override it only for
+# a control instance that is not memex.systemorph.com.
 #
 # 🚨 A satellite's `gates-executed` job (the one that counts how many gate jobs actually ran) must NOT
 # count these two: they are conditional on `main` and skipped on every pull request, so counting them
@@ -164,6 +177,13 @@ on:
         description: The control portal's triage inbox — pass vars.CONTROL_WEBHOOK_URL (https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds).
         required: true
         type: string
+      control-webhook-host:
+        description: >-
+          The host `control-webhook-url` must point at. The lane refuses to sign an event for any
+          other host, any non-https scheme, or any path outside /api/hooks/.
+        required: false
+        type: string
+        default: memex.systemorph.com
       scripts-ref:
         description: >-
           The Systemorph/MeshWeaver ref this lane's ledger script is fetched at. Pin it beside the
@@ -206,6 +226,7 @@ jobs:
           GH_TOKEN: ${{ secrets.github-token }}
           CONTROL_WEBHOOK_URL: ${{ inputs.control-webhook-url }}
           CONTROL_WEBHOOK_SECRET: ${{ secrets.control-webhook-secret }}
+          CONTROL_WEBHOOK_HOST: ${{ inputs.control-webhook-host }}
           OUTCOME: ${{ inputs.outcome }}
           RUN_ID: ${{ inputs.run }}
           RUN_URL: ${{ inputs.run-url }}
@@ -218,6 +239,7 @@ jobs:
           [ -n "${GH_TOKEN:-}" ]               || missing+=("secrets.github-token           the caller's secrets.GITHUB_TOKEN — forward it as \`secrets: github-token:\` = secrets.GITHUB_TOKEN with \`permissions: {contents: read, issues: write, actions: read}\` on the caller job")
           [ -n "${CONTROL_WEBHOOK_URL:-}" ]    || missing+=("inputs.control-webhook-url      pass vars.CONTROL_WEBHOOK_URL — org variable, scoped to the fleet repos, https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds (Settings → Secrets and variables → Actions → Variables, at the ORG)")
           [ -n "${CONTROL_WEBHOOK_SECRET:-}" ] || missing+=("secrets.control-webhook-secret  pass secrets.CONTROL_WEBHOOK_SECRET — org secret, scoped to the fleet repos, byte-identical to the control instance's Hosting:PlatformWebhookSecret (Settings → Secrets and variables → Actions → Secrets, at the ORG; it has NO Dependabot-store copy, and this lane is never reachable from a pull request)")
+          [ -n "${CONTROL_WEBHOOK_HOST:-}" ]   || missing+=("inputs.control-webhook-host     the host control-webhook-url must point at (default memex.systemorph.com) — an empty host would let any URL through")
           [ -n "${RUN_ID:-}" ]                 || missing+=("inputs.run                      github.run_id")
           [ -n "${RUN_URL:-}" ]                || missing+=("inputs.run-url                  github.server_url/github.repository/actions/runs/github.run_id")
           [ -n "${SHA:-}" ]                    || missing+=("inputs.sha                      github.sha")
@@ -263,6 +285,14 @@ jobs:
       # its case before its verdict on the real repository means anything.
       - name: "The ledger can say no (self-test)"
         run: python3 "$RUNNER_TEMP/ci-failure-ledger.py" --self-test
+
+      # Before the ledger writes and before anything is signed: the URL the HMAC would travel to is
+      # the control portal's inbox and nothing else. A red here names the offending URL.
+      - name: The inbox URL is the control portal's, or nothing is signed
+        env:
+          URL: ${{ inputs.control-webhook-url }}
+          HOST: ${{ inputs.control-webhook-host }}
+        run: python3 "$RUNNER_TEMP/ci-failure-ledger.py" --check-url "$URL" --expected-host "$HOST"
 
       - name: Open, append to, reopen, or close the ci-main-red ledger issue
         id: ledger

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -824,11 +824,15 @@ nobody. Maintainer, 2026-09-12: *"put the ci-failure on all repos, in main; tria
 systemorph-com; communicate via MCP — open a thread with a triage agent; pool such connections by
 portal."* The caller is two jobs at the end of `ci.yml` (`ci-failure` on `failure()`, `ci-green` on
 `success()`, both `needs:` every gate job, both statically unreachable from a pull request), and the
-lane does the same thing in every repository: **one** open issue labelled `ci-failure` with the exact
-title `ci-failure: main is red`, whose body is a dated ledger with one entry per red run (run URL,
-sha, trigger, failed jobs with links, platform set); a close inside seven days is *reopened* rather
-than re-filed, so one outage is one story; the run that goes green comments `green again: <run URL>`
-and closes it. Each way the lane POSTs a signed event (`ci-failure` / `ci-green`, HMAC-SHA256 over
+lane does the same thing in every repository: **one** open issue labelled `ci-main-red` with the exact
+title `ci-main-red: main is red` and a hidden ownership mark in its body (`<!-- ci-main-red ledger -->`),
+whose body is a dated ledger with one entry per red run (run URL, sha, trigger, failed jobs with
+links, platform set); a close inside seven days is *reopened* rather than re-filed, so one outage is
+one story; the run that goes green comments `green again: <run URL>` and closes it. **A mechanism may
+only close an issue it opened:** the ledger's find, append, reopen, comment and close all require the
+label *and* the title *and* the mark, an issue lacking any of them is logged and left alone, and the
+label is deliberately not `ci-failure` — that is `main-cd.yml`'s delivery alert, found by label alone,
+and sharing it would let a CD heal close the CI ledger while CI is still red. Each way the lane POSTs a signed event (`ci-failure` / `ci-green`, HMAC-SHA256 over
 the exact body in `X-Hub-Signature-256`, the same shape as the build fact) to the control portal's
 inbox at `vars.CONTROL_WEBHOOK_URL` — `https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds`
 — and judges the inbox's `"signature"` verdict the same three-way way. The issue writes use the
@@ -837,7 +841,7 @@ token (the installation holds no `issues` grant); the ledger logic is
 `.github/scripts/ci-failure-ledger.py`, fetched at the lane's `scripts-ref` and self-tested at the
 start of every run and in core's `workflow-shell` job. Core wires the same two jobs at the end of
 `dotnet-test.yml`; `main-cd.yml`'s own `ci-failure` issue records a different subject (an image set
-that did not publish) and is unchanged.
+that did not publish) and is unchanged, and the two never touch each other's issues.
 
 ## 🚨 `node-repo-validate` is not one lane among several — it is where the FLEET-WIDE guards run
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -816,6 +816,29 @@ every repo calls `node-repo-publish-bake` (the lane whose script contract must n
 repo whose variant of a gate carries repo-specific machinery (Plugins' Tests-area ratchet,
 Education's course checks) keeps that job vendored until the machinery generalizes.
 
+**Since 2026-09-12 every one of those repositories also calls `node-repo-ci-failure.yml`** — the
+lane that gives a red `main` an audience. Every satellite runs its full build on `push: [main]` and
+once a day on `schedule` (the per-build platform wave was switched off the same day), and a red run
+there is attached to no pull request, no reviewer and no check list: it updates nothing and pages
+nobody. Maintainer, 2026-09-12: *"put the ci-failure on all repos, in main; triaging is done by
+systemorph-com; communicate via MCP — open a thread with a triage agent; pool such connections by
+portal."* The caller is two jobs at the end of `ci.yml` (`ci-failure` on `failure()`, `ci-green` on
+`success()`, both `needs:` every gate job, both statically unreachable from a pull request), and the
+lane does the same thing in every repository: **one** open issue labelled `ci-failure` with the exact
+title `ci-failure: main is red`, whose body is a dated ledger with one entry per red run (run URL,
+sha, trigger, failed jobs with links, platform set); a close inside seven days is *reopened* rather
+than re-filed, so one outage is one story; the run that goes green comments `green again: <run URL>`
+and closes it. Each way the lane POSTs a signed event (`ci-failure` / `ci-green`, HMAC-SHA256 over
+the exact body in `X-Hub-Signature-256`, the same shape as the build fact) to the control portal's
+inbox at `vars.CONTROL_WEBHOOK_URL` — `https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds`
+— and judges the inbox's `"signature"` verdict the same three-way way. The issue writes use the
+caller's `secrets.GITHUB_TOKEN` with `issues: write` granted on the caller job, never a GitHub App
+token (the installation holds no `issues` grant); the ledger logic is
+`.github/scripts/ci-failure-ledger.py`, fetched at the lane's `scripts-ref` and self-tested at the
+start of every run and in core's `workflow-shell` job. Core wires the same two jobs at the end of
+`dotnet-test.yml`; `main-cd.yml`'s own `ci-failure` issue records a different subject (an image set
+that did not publish) and is unchanged.
+
 ## 🚨 `node-repo-validate` is not one lane among several — it is where the FLEET-WIDE guards run
 
 The other lanes do a repo's own work. `node-repo-validate` also carries the checks that apply to

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -816,32 +816,39 @@ every repo calls `node-repo-publish-bake` (the lane whose script contract must n
 repo whose variant of a gate carries repo-specific machinery (Plugins' Tests-area ratchet,
 Education's course checks) keeps that job vendored until the machinery generalizes.
 
-**Since 2026-09-12 every one of those repositories also calls `node-repo-ci-failure.yml`** — the
-lane that gives a red `main` an audience. Every satellite runs its full build on `push: [main]` and
-once a day on `schedule` (the per-build platform wave was switched off the same day), and a red run
-there is attached to no pull request, no reviewer and no check list: it updates nothing and pages
-nobody. Maintainer, 2026-09-12: *"put the ci-failure on all repos, in main; triaging is done by
-systemorph-com; communicate via MCP — open a thread with a triage agent; pool such connections by
-portal."* The caller is two jobs at the end of `ci.yml` (`ci-failure` on `failure()`, `ci-green` on
-`success()`, both `needs:` every gate job, both statically unreachable from a pull request), and the
-lane does the same thing in every repository: **one** open issue labelled `ci-main-red` with the exact
-title `ci-main-red: main is red` and a hidden ownership mark in its body (`<!-- ci-main-red ledger -->`),
-whose body is a dated ledger with one entry per red run (run URL, sha, trigger, failed jobs with
-links, platform set); a close inside seven days is *reopened* rather than re-filed, so one outage is
-one story; the run that goes green comments `green again: <run URL>` and closes it. **A mechanism may
-only close an issue it opened:** the ledger's find, append, reopen, comment and close all require the
-label *and* the title *and* the mark, an issue lacking any of them is logged and left alone, and the
-label is deliberately not `ci-failure` — that is `main-cd.yml`'s delivery alert, found by label alone,
-and sharing it would let a CD heal close the CI ledger while CI is still red. Each way the lane POSTs a signed event (`ci-failure` / `ci-green`, HMAC-SHA256 over
-the exact body in `X-Hub-Signature-256`, the same shape as the build fact) to the control portal's
-inbox at `vars.CONTROL_WEBHOOK_URL` — `https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds`
-— and judges the inbox's `"signature"` verdict the same three-way way. The issue writes use the
-caller's `secrets.GITHUB_TOKEN` with `issues: write` granted on the caller job, never a GitHub App
-token (the installation holds no `issues` grant); the ledger logic is
+**`node-repo-ci-failure.yml` (2026-09-12) is the lane that gives a red `main` an audience, and its
+adoption is staged: core is wired now, the six satellites wire it in follow-up PRs once the lane is
+on `main`.** Every satellite runs its full build on `push: [main]` and once a day on `schedule` (the
+per-build platform wave was switched off the same day), and a red run there is attached to no pull
+request, no reviewer and no check list: it updates nothing and pages nobody. Maintainer, 2026-09-12:
+*"put the ci-failure on all repos, in main; triaging is done by systemorph-com; communicate via MCP —
+open a thread with a triage agent; pool such connections by portal."* The caller is two jobs at the
+end of `ci.yml` (`ci-failure` on `failure()`, `ci-green` on `success()`, both `needs:` every gate
+job, both statically unreachable from a pull request; the template is in the lane's header, and each
+satellite's caller is recorded as `pending:` in `.github/lane-caller-grants.yml` until its wiring PR
+lands). In every repository that calls it the lane does the same thing: **one** open issue labelled
+`ci-main-red` with the exact title `ci-main-red: main is red` and a hidden ownership mark in its body
+(`<!-- ci-main-red ledger -->`), whose body is a dated ledger with one entry per red run (run URL,
+sha, trigger, failed jobs with links, platform set); a close inside seven days is *reopened* rather
+than re-filed, so one outage is one story; the run that goes green comments `green again: <run URL>`
+and closes it. **A mechanism may only close an issue it opened:** the ledger owns an issue only when
+it carries the label *and* the title *and* the mark *and* was authored by the Actions bot
+(`github-actions[bot]`, type `Bot` — the one term a human cannot forge, since the other three are
+public fields); anything else is logged and left alone, and the label is deliberately not
+`ci-failure` — that is `main-cd.yml`'s delivery alert, found by label alone, and sharing it would let
+a CD heal close the CI ledger while CI is still red. Each way the lane POSTs a signed event
+(`ci-failure` / `ci-green`, HMAC-SHA256 over the exact body in `X-Hub-Signature-256`, the same shape
+as the build fact) to the control portal's inbox at `vars.CONTROL_WEBHOOK_URL` —
+`https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds` — after validating that the URL is
+https, on `control-webhook-host` (default `memex.systemorph.com`) and under `/api/hooks/`, so a
+signature never travels to an arbitrary host; it then judges the inbox's `"signature"` verdict the
+same three-way way. The issue writes use the caller's `secrets.GITHUB_TOKEN` with `issues: write`
+granted on the caller job, never a GitHub App token (the installation holds no `issues` grant, and an
+issue filed by any other identity would never be owned); the ledger logic is
 `.github/scripts/ci-failure-ledger.py`, fetched at the lane's `scripts-ref` and self-tested at the
-start of every run and in core's `workflow-shell` job. Core wires the same two jobs at the end of
-`dotnet-test.yml`; `main-cd.yml`'s own `ci-failure` issue records a different subject (an image set
-that did not publish) and is unchanged, and the two never touch each other's issues.
+start of every run and in core's `workflow-shell` job. Core's own caller is the same two jobs at the
+end of `dotnet-test.yml`; `main-cd.yml`'s `ci-failure` issue records a different subject (an image
+set that did not publish), is unchanged, and the two never touch each other's issues.
 
 ## 🚨 `node-repo-validate` is not one lane among several — it is where the FLEET-WIDE guards run
 


### PR DESCRIPTION
Maintainer, 2026-09-12: *"put the ci-failure on all repos, in main; triaging is done by systemorph-com (the control instance memex.systemorph.com); communicate via MCP — open a thread with a triage agent; pool such connections by portal."*

Every satellite now runs its full build on `push: [main]` and once a day on `schedule` (the per-build platform wave was switched off today). A red run there is attached to no pull request, no reviewer and no check list — it updates nothing and pages nobody, the empty-room twin of a gate that cannot fail. Core's `main-cd.yml` already routes a failed *delivery* onto a `ci-failure` issue with a heal ledger; that mechanism is untouched. This PR gives every repository's *build* the same artefact, and then tells the control portal.

## What lands

| File | What |
|---|---|
| `.github/workflows/node-repo-ci-failure.yml` | the reusable `workflow_call` lane (caller template in its header) |
| `.github/scripts/ci-failure-ledger.py` | the issue-ledger logic, stdlib only, `--self-test` (14 rules, 46 checks) |
| `.github/workflows/dotnet-test.yml` | core wired: `ci-failure` / `ci-green` at the end, `needs: [collect-results]`; the ledger self-test in `workflow-shell` |
| `.github/lane-caller-grants.yml` | 12 `pending:` roster rows (2 per satellite) so the lane's permission demand is paired against the caller template BEFORE any satellite wires it |
| `src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md` | a dated paragraph under "Node repos run the same lane", written as STAGED adoption — core wired now, the six satellites in follow-up PRs once the lane is on main (no lane-per-page rule exists; `ArchitectureTopicMapTest` only requires listing pages that exist) |

## Design

**On `failure`** — find the calling repo's issue labelled **`ci-main-red`** with the exact title `ci-main-red: main is red` AND the hidden ownership mark `<!-- ci-main-red ledger -->` in its body. Open → append a dated ledger entry to the body (run URL, sha, trigger, failed jobs with links + failed step, platform set; bounded at 40 entries with a cumulative trim note). Closed within 7 days → **reopen** it and append (flapping is one story). Otherwise create. Never a second open issue. Then POST, signed, to `control-webhook-url`.

**On `success`** — an open matching issue → comment `green again: <run URL>` and close it, then POST `ci-green`. No open issue → no-op, said out loud, and no POST.

**A mechanism may only close an issue it opened.** The ledger's label is its own (`ci-main-red`, never `ci-failure` — the script refuses that label outright), and ownership is label AND exact title AND the body mark AND the issue's author being the Actions bot (`user.login == "github-actions[bot]"`, `user.type == "Bot"`) — label, title and marker are public fields anyone with triage can set, the author is the term that cannot be forged, and a marker on a human-authored issue is foreign. (That is the second reason the lane accepts only GITHUB_TOKEN: an issue filed by any other identity would never be owned, and `create_issue` fails red if the created issue's author is not the bot.) An issue lacking any of the three (CD's `ci-failure` issue, a hand-labelled `ci-main-red` one, a rewritten body) is logged as foreign and never appended to, reopened, commented on or closed; every write re-proves ownership at the moment of the write. So `main-cd.yml`'s label-only alert/heal never finds the ledger, and the ledger never finds CD's issue — a CD heal cannot close the CI ledger while CI is still red. Self-tested: CD-shaped `ci-failure` issue untouched on red and green; unmarked `ci-main-red` issue never closed; a human-authored issue carrying label + title + marker never closed and a bot-authored ledger filed beside it; an App-bot login does not own either; the ledger's issue never carries `ci-failure`.

**Nothing is signed for an arbitrary URL.** New input `control-webhook-host` (default `memex.systemorph.com`). Before the ledger writes and before curl, a dedicated step runs `ci-failure-ledger.py --check-url "$URL" --expected-host "$HOST"`: https only, host equal (case-insensitive, no userinfo, port 443 only), path under `/api/hooks/`; red naming the offending URL otherwise. Self-tested over http, other host, host-suffix trick, path outside `/api/hooks/`, odd port, userinfo, empty, garbage, and an empty expected host.

**Event shapes** (exact bytes, compact, field-ordered — the HMAC is over the file the ledger wrote, sent `--data-binary`):
```json
{"event":"ci-failure","repo":"Systemorph/X","sha":"…","run":123,"runUrl":"…","trigger":"schedule","failedJobs":[{"name":"…","url":"…","step":"…"}],"platformSet":"3.0.0-ci.4711","issueUrl":"…","issueNumber":42}
{"event":"ci-green","repo":"Systemorph/X","sha":"…","run":124,"runUrl":"…","issueNumber":42}
```
Header `X-Hub-Signature-256: sha256=<hmac-sha256(body, CONTROL_WEBHOOK_SECRET)>` — the shape `main-cd.yml`'s `notify-platform-update` uses. Non-2xx = red step with the same per-status diagnosis (000/404/401/500). The inbox's `"signature"` verdict is judged in its own step the same three-way way: `verified` passes, `not-required` fails (broken pair), no verdict warns (pre-#3312 receiver).

**Credentials.** Issue writes use the CALLER's `secrets.GITHUB_TOKEN`, never a GitHub App token (the `meshweaver-cloud` installation holds no `issues` grant, so an App write would 403 on a grant nobody in the calling repo can see). The preflight asserts every input and fails red naming what to provision and where; it then proves the token can read the repo's issues (`GET /repos/{repo}/issues?labels=ci-failure&state=all&per_page=1` must be 200); the first write (label ensure) proves write, and a 403 names `issues: write` on the caller job. No `continue-on-error`, no `if:` on a secret/variable; the only step `if:` is on the ledger's own `post` decision.

**Failed-jobs.** `failed-jobs` is an input (malformed → refused before any write), but a caller may leave it empty: the lane lists the run's jobs that concluded `failure`/`timed_out` itself via `GET …/actions/runs/{id}/jobs` — that is what `actions: read` is for, and it keeps the caller at two jobs with no assembly job.

## Caller template (a satellite's `ci.yml`, two jobs at the end)

```yaml
  ci-failure:
    name: "main is red: file it, tell the control portal"
    needs: [validate, compile-check, test-repos, publish-bake]        # EVERY gate job
    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main' && failure()
    permissions: {contents: read, issues: write, actions: read}
    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-ci-failure.yml@main
    with:
      outcome: failure
      run: ${{ github.run_id }}
      run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
      sha: ${{ github.sha }}
      event: ${{ github.event_name }}
      platform-set: ${{ needs.select.outputs.platform-set }}   # '' if none
      control-webhook-url: ${{ vars.CONTROL_WEBHOOK_URL }}
    secrets:
      github-token: ${{ secrets.GITHUB_TOKEN }}
      control-webhook-secret: ${{ secrets.CONTROL_WEBHOOK_SECRET }}
  ci-green:   # identical, with `outcome: success` and `success()`
```
`github.event_name != 'pull_request'` comes first so `check-pr-secret-preflight.py` proves from the file alone that `CONTROL_WEBHOOK_SECRET` (an org secret with no Dependabot-store copy) is never consumed on a PR. A satellite's `gates-executed` job must NOT count these two (they are skipped on every PR). `permissions:` replaces the defaults, so `contents: read` is explicit; a caller that omits any of the three gets `startup_failure` with zero jobs — the pairing guard's `--fleet` mode checks the pending rows against the lane now.

## Deviations from the brief, on purpose

- Input `run-id` is named **`run`** (the event body's field). `PlatformBakeLaneGuard.PlatformBake_NeverAdoptsAnotherBuildsBundles` reads a literal `run-id:` in `dotnet-test.yml` as `download-artifact`'s cross-run input and went red on the caller.
- Added input **`scripts-ref`** (default `main`): the lane runs in the caller's context, so it fetches `ci-failure-ledger.py` from core through the contents API at that ref — the `node-repo-validate.yml` shape — and self-tests it before use.
- Core's own caller references the lane as `./.github/workflows/node-repo-ci-failure.yml` (the way `main-cd.yml` calls its lanes) so THIS commit's lane runs and `check-workflow-permission-pairing.py --root .` pairs both halves in one checkout.
- Core: the two jobs `needs: [collect-results]` only — it `needs:` every other job, runs `always()` with an explicit fail step per dependency.

## Guard output (verbatim)

```
check-workflow-timeouts: 85 job(s) checked, 4 reusable-call job(s) exempt, 0 violation(s), cap=45 min
check-workflow-shell: 1 finding(s): 0 live, 1 allow-listed, 0 stale entr(ies), 0 allow-file error(s)
check-workflow-yaml-keys: 35 workflow file(s) and 0 composite action(s) checked, 0 violation(s)
check-pr-secret-preflight: 2 secret(s) reachable on a Dependabot pull request, 2 asserted by a preflight, 0 violation(s)
check-workflow-permission-pairing: 4 caller/lane permission pair(s) resolved, 0 violation(s)
check-workflow-permission-pairing (fleet): 56 roster caller/lane pair(s) resolved, 0 violation(s)
  (12 PENDING rows printed for the six satellites' ci-failure/ci-green callers; NOT COVERED notes unchanged from main)
check-workflow-permission-pairing --self-test --root . --fleet: 27/27 control(s) passed
  ok   injecting `id-token: write` into node-repo-ci-failure.yml#report is caught and names dotnet-test.yml#ci-failure (4 pair(s))
every guard --self-test: every case fired on its defect and stayed silent on its fix
actionlint node-repo-ci-failure.yml dotnet-test.yml: exit 0
✓ ci-failure-ledger self-test: create / append / reopen-recent / create-after-old / close-with-comment / noop-when-green / refuse-malformed / cd-ci-failure-untouched / unmarked-ci-main-red-untouched / human-authored-is-foreign / never-labelled-ci-failure / inbox-url-validated / bounded-ledger / jobs-listed — every rule fires and stays silent as designed
dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror: Passed! - Failed: 0, Passed: 432, Skipped: 0, Total: 432
```

## What this PR does NOT do

- No satellite is wired yet — each needs the two-job caller above (its `pending:` roster row is spent when it lands). No What's New entry: CI-only, nothing a user notices.
- The control-portal side (the `Hosting/PlatformBuilds` inbox watcher recognising `ci-failure` / `ci-green` and opening a triage thread over MCP, pooled per portal) is in the Memex/Hosting module, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

