### PR TITLE
cd: satellite-compat — every core build compile-checks every satellite's NodeTypes against the new set (phase 2a)

### DIFF
--- a/.github/scripts/compat-verdict.py
+++ b/.github/scripts/compat-verdict.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""compat-verdict.py — did THIS core build break a satellite, or was the satellite already broken?
+
+(The name on this first line is load-bearing, like every script the reusable lanes fetch at a
+platform ref and verify by their first bytes.)
+
+WHY THIS EXISTS (maintainer pushback on MeshWeaver#4088, 2026-09-12: "why fail compatibility?")
+--------------------------------------------------------------------------------------------
+`satellite-compat` compiles every satellite's NodeTypes against the set a core build just
+promoted. A red compile alone cannot say WHICH side moved: core changed a surface incompatibly
+(core's fault — the red is right), or the satellite merged content that never compiled (core
+reddened by a repository it should not know about — precisely the hazard commit c88cd5d5c's
+guard exists to keep out of core). One compile is a measurement with no control.
+
+The control is a SECOND compile of the same content against the PREVIOUS image — the set the
+fleet is currently on, recorded by `gate` BEFORE this run's promote moved the pointer — with the
+module bundles that shipped with it. Two readings, one verdict per NodeType, one verdict per leg:
+
+    previous ok   + new FAIL  → BROKE            core broke it — the leg is RED (the only red)
+    previous fail + new fail  → ALREADY-BROKEN   satellite side — GREEN with an advisory line;
+                                                 its own daily run / ci-main-red issue own it
+    previous ok   + new ok    → COMPATIBLE       green
+    no previous image         → NO-BASELINE      a REFUSAL to judge — GREEN with an advisory
+                                                 naming why; an unestablished baseline must
+                                                 never read as "core broke it" (nor as "fine")
+
+A type that fails on the new image and did not EXIST at the baseline is satellite side too
+(nothing core did can have broken content that was never compiled against the fleet's set): it
+is listed as already-broken with baseline "absent". A type the new-image ratchet calls "compiles
+now — remove it from the allow file" (stale allow) is an advisory in every verdict, never red.
+
+USAGE
+  compat-verdict.py --new new.json [--baseline baseline.json] [--baseline-reason TEXT]
+                    --new-digest D [--baseline-digest D] --out verdict.json
+  compat-verdict.py --self-test
+
+Reads the JSON `compile-check.py --report` writes. Exit 1 iff the verdict is BROKE.
+"""
+from __future__ import annotations
+import argparse
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+VERDICTS = ("broke", "already-broken", "compatible", "no-baseline")
+
+
+def _failing(report: dict) -> dict:
+    """type -> first error, for every type that FAILED to compile in a report (gating or allowlisted)."""
+    out = {}
+    for key in ("new_breaks", "fp_drift", "known_debt"):
+        for row in report.get(key, []) or []:
+            out.setdefault(row["type"], row.get("error", ""))
+    return out
+
+
+def judge(new: dict, baseline: dict | None, baseline_reason: str = "") -> dict:
+    """Pure function: (new report, baseline report or None) -> the classified verdict.
+
+    Only the NEW image's GATING failures (new_breaks + fp_drift) can red anything: known debt
+    is allowlisted by the satellite and is its own ratchet's business. The baseline side counts
+    ANY compile failure (allowlisted or not) — the question there is only "did it compile?"."""
+    new_gating = {}
+    for key in ("new_breaks", "fp_drift"):
+        for row in new.get(key, []) or []:
+            new_gating.setdefault(row["type"], row.get("error", ""))
+    stale_allow = list(new.get("stale_allow", []) or [])
+
+    if baseline is None:
+        return {
+            "verdict": "no-baseline",
+            "gate_fail": False,
+            "broke": [],
+            "already_broken": [],
+            "unjudged": [{"type": t, "error": e} for t, e in sorted(new_gating.items())],
+            "stale_allow": stale_allow,
+            "baseline_reason": baseline_reason or "no baseline report",
+        }
+
+    base_ok = set(baseline.get("ok", []) or [])
+    base_fail = _failing(baseline)
+    broke, already = [], []
+    for t, e in sorted(new_gating.items()):
+        if t in base_ok:
+            broke.append({"type": t, "error": e})
+        elif t in base_fail:
+            already.append({"type": t, "error": e, "baseline": "failed", "baseline_error": base_fail[t]})
+        else:
+            already.append({"type": t, "error": e, "baseline": "absent"})
+    verdict = "broke" if broke else ("already-broken" if already else "compatible")
+    return {
+        "verdict": verdict,
+        "gate_fail": bool(broke),
+        "broke": broke,
+        "already_broken": already,
+        "unjudged": [],
+        "stale_allow": stale_allow,
+        "baseline_reason": "",
+    }
+
+
+def _load(path: str | None) -> dict | None:
+    if not path:
+        return None
+    p = Path(path)
+    if not p.is_file():
+        return None
+    return json.loads(p.read_text(encoding="utf-8"))
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--new", help="compile-check --report of the NEW image")
+    ap.add_argument("--baseline", help="compile-check --report of the PREVIOUS image (may be absent)")
+    ap.add_argument("--baseline-reason", default="", help="why there is no baseline, when there is none")
+    ap.add_argument("--new-digest", default="")
+    ap.add_argument("--baseline-digest", default="")
+    ap.add_argument("--out", help="where to write the verdict JSON")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        return _self_test()
+    if not args.new or not args.out:
+        print("error: --new and --out are required (or --self-test)")
+        return 2
+
+    new = _load(args.new)
+    if new is None:
+        print(f"::error::the new-image compile produced no report at {args.new} — the gate died before "
+              "judging anything; that is a red run, not a verdict")
+        return 2
+    baseline = _load(args.baseline)
+    reason = args.baseline_reason
+    if baseline is None and args.baseline and not reason:
+        reason = f"the baseline compile produced no report ({args.baseline} is absent)"
+    if baseline is None and not args.baseline and not reason:
+        reason = "no baseline image was supplied"
+
+    v = judge(new, baseline, reason)
+    out = {
+        "schema": "satellite-compat/1",
+        "content": new.get("content", {}),
+        "images": {"new": args.new_digest, "baseline": args.baseline_digest if baseline is not None else "",
+                   "baseline_reason": v["baseline_reason"]},
+        "types": new.get("types", 0),
+        "clean": new.get("clean", 0),
+        "known_debt": new.get("known_debt", []),
+        **v,
+    }
+    Path(args.out).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.out).write_text(json.dumps(out, indent=2) + "\n", encoding="utf-8")
+
+    sat = out["content"].get("repository") or "this content"
+    label = {
+        "broke": f"🔴 BROKE — this core build broke {sat}: {len(v['broke'])} NodeType(s) compiled against the "
+                 f"previous image ({args.baseline_digest[:19]}) and do not against the new one ({args.new_digest[:19]})",
+        "already-broken": f"🟡 ALREADY BROKEN — {len(v['already_broken'])} NodeType(s) of {sat} fail on the new image "
+                          f"AND on the previous one (or did not exist there): satellite side, not this build's",
+        "compatible": f"✅ COMPATIBLE — every NodeType of {sat} compiles against the new image "
+                      f"({len(v['already_broken'])} advisory)",
+        "no-baseline": f"⚪ NO BASELINE — refusing to judge {sat}: {v['baseline_reason']}. "
+                       f"{len(v['unjudged'])} new-image failure(s) are listed UNJUDGED, not attributed",
+    }[v["verdict"]]
+    print(label)
+    for row in v["broke"]:
+        print(f"  BROKE            {row['type']}: {row['error']}")
+    for row in v["already_broken"]:
+        print(f"  already-broken   {row['type']} (baseline: {row['baseline']}): {row['error']}")
+    for row in v["unjudged"]:
+        print(f"  unjudged         {row['type']}: {row['error']}")
+    for t in v["stale_allow"]:
+        print(f"  advisory         {t}: compiles now — remove it from scripts/compile-check.allow")
+    if v["gate_fail"]:
+        print(f"::error::{label}")
+        return 1
+    if v["verdict"] != "compatible":
+        print(f"::warning::{label}")
+    return 0
+
+
+def _self_test() -> int:
+    """Every row of the truth table, both directions, plus the two edge rows."""
+    failures = []
+    def rep(ok=(), breaks=(), drift=(), debt=(), stale=()):
+        return {"ok": list(ok),
+                "new_breaks": [{"type": t, "error": f"CS0246: {t}"} for t in breaks],
+                "fp_drift": [{"type": t, "error": f"CS0103: {t}"} for t in drift],
+                "known_debt": [{"type": t, "error": f"CS1061: {t}"} for t in debt],
+                "stale_allow": list(stale), "types": 3, "clean": len(ok)}
+    # row 1: previous ok + new FAIL → BROKE, red
+    v = judge(rep(breaks=["P/A"], ok=["P/B"]), rep(ok=["P/A", "P/B"]))
+    if v["verdict"] != "broke" or not v["gate_fail"] or [r["type"] for r in v["broke"]] != ["P/A"]:
+        failures.append(f"row1 broke: {v!r}")
+    # row 2: previous fail + new fail → ALREADY-BROKEN, green
+    v = judge(rep(breaks=["P/A"], ok=["P/B"]), rep(ok=["P/B"], breaks=["P/A"]))
+    if v["verdict"] != "already-broken" or v["gate_fail"] or v["broke"] or v["already_broken"][0]["baseline"] != "failed":
+        failures.append(f"row2 already-broken: {v!r}")
+    # row 2b: the baseline failure was ALLOWLISTED debt there — still "did not compile" → already-broken
+    v = judge(rep(breaks=["P/A"]), rep(debt=["P/A"]))
+    if v["verdict"] != "already-broken" or v["gate_fail"]:
+        failures.append(f"row2b debt-at-baseline: {v!r}")
+    # row 3: ok + ok → COMPATIBLE
+    v = judge(rep(ok=["P/A", "P/B"]), rep(ok=["P/A", "P/B"]))
+    if v["verdict"] != "compatible" or v["gate_fail"] or v["broke"] or v["already_broken"]:
+        failures.append(f"row3 compatible: {v!r}")
+    # row 4: no baseline → NO-BASELINE, green, failures UNJUDGED (never attributed)
+    v = judge(rep(breaks=["P/A"]), None, "could not resolve the previous image")
+    if v["verdict"] != "no-baseline" or v["gate_fail"] or v["broke"] or [r["type"] for r in v["unjudged"]] != ["P/A"] \
+       or "previous image" not in v["baseline_reason"]:
+        failures.append(f"row4 no-baseline: {v!r}")
+    # edge: the type did not exist at the baseline → satellite side, never BROKE
+    v = judge(rep(breaks=["P/New"], ok=["P/A"]), rep(ok=["P/A"]))
+    if v["verdict"] != "already-broken" or v["gate_fail"] or v["already_broken"][0]["baseline"] != "absent":
+        failures.append(f"edge absent-at-baseline: {v!r}")
+    # edge: fingerprint drift on the new image counts as a new-image failure; stale allow is advisory only
+    v = judge(rep(drift=["P/A"], stale=["P/S"], ok=["P/B", "P/S"]), rep(ok=["P/A", "P/B", "P/S"]))
+    if v["verdict"] != "broke" or [r["type"] for r in v["broke"]] != ["P/A"] or v["stale_allow"] != ["P/S"]:
+        failures.append(f"edge drift+stale: {v!r}")
+    v = judge(rep(stale=["P/S"], ok=["P/S"]), rep(ok=["P/S"]))
+    if v["verdict"] != "compatible" or v["gate_fail"]:
+        failures.append(f"edge stale-only must be compatible: {v!r}")
+    # edge: known debt on the NEW image alone never reds (it is the satellite's ratchet)
+    v = judge(rep(debt=["P/D"], ok=["P/A"]), rep(ok=["P/A", "P/D"]))
+    if v["verdict"] != "compatible" or v["gate_fail"]:
+        failures.append(f"edge known-debt-new: {v!r}")
+    # the CLI end to end: exit codes and the written file
+    import subprocess
+    with tempfile.TemporaryDirectory() as tmp:
+        t = Path(tmp)
+        (t / "new.json").write_text(json.dumps(rep(breaks=["P/A"], ok=["P/B"]) | {"content": {"repository": "Systemorph/X", "sha": "abc"}}))
+        (t / "base.json").write_text(json.dumps(rep(ok=["P/A", "P/B"])))
+        rc = subprocess.run([sys.executable, __file__, "--new", str(t / "new.json"), "--baseline", str(t / "base.json"),
+                             "--new-digest", "sha256:n", "--baseline-digest", "sha256:b", "--out", str(t / "v.json")],
+                            capture_output=True, text=True).returncode
+        got = json.loads((t / "v.json").read_text())
+        if rc != 1 or got["verdict"] != "broke" or got["images"] != {"new": "sha256:n", "baseline": "sha256:b", "baseline_reason": ""} \
+           or got["content"]["sha"] != "abc":
+            failures.append(f"cli broke: rc={rc} {got!r}")
+        rc = subprocess.run([sys.executable, __file__, "--new", str(t / "new.json"), "--baseline", str(t / "missing.json"),
+                             "--new-digest", "sha256:n", "--out", str(t / "v2.json")], capture_output=True, text=True).returncode
+        got = json.loads((t / "v2.json").read_text())
+        if rc != 0 or got["verdict"] != "no-baseline" or got["images"]["baseline"] != "" or "absent" not in got["images"]["baseline_reason"]:
+            failures.append(f"cli no-baseline: rc={rc} {got!r}")
+        rc = subprocess.run([sys.executable, __file__, "--new", str(t / "nope.json"), "--out", str(t / "v3.json")],
+                            capture_output=True, text=True).returncode
+        if rc != 2:
+            failures.append(f"cli missing new report must be rc=2, got {rc}")
+    if failures:
+        print("✗ compat-verdict self-test FAILED:\n  " + "\n  ".join(failures))
+        return 1
+    print("✓ compat-verdict: broke (red) · already-broken (green, advisory) · compatible · no-baseline (green, "
+          "unjudged) — all four rows, both directions, absent-at-baseline, drift, stale-allow and known-debt edges, CLI exit codes")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/compat-verdict.py
+++ b/.github/scripts/compat-verdict.py
@@ -23,10 +23,15 @@ module bundles that shipped with it. Two readings, one verdict per NodeType, one
     no previous image         → NO-BASELINE      a REFUSAL to judge — GREEN with an advisory
                                                  naming why; an unestablished baseline must
                                                  never read as "core broke it" (nor as "fine")
+    type ABSENT at previous   → UNJUDGED         no per-type baseline: the type is newer than
+      + new fail                                 the set the fleet is on, so NOTHING licenses
+                                                 the word "broke" — and nothing licenses
+                                                 "already broken" either. Its own row, GREEN,
+                                                 advisory; never folded into either verdict.
 
-A type that fails on the new image and did not EXIST at the baseline is satellite side too
-(nothing core did can have broken content that was never compiled against the fleet's set): it
-is listed as already-broken with baseline "absent". A type the new-image ratchet calls "compiles
+Every reading is PER TYPE: "compiled at the baseline" is the type's own name in the baseline
+report's `ok` list, never an inference from the satellite's overall colour. Only
+previous-compiled-ok → new-fails licenses "broke". A type the new-image ratchet calls "compiles
 now — remove it from the allow file" (stale allow) is an advisory in every verdict, never red.
 
 USAGE
@@ -43,7 +48,8 @@ import sys
 import tempfile
 from pathlib import Path
 
-VERDICTS = ("broke", "already-broken", "compatible", "no-baseline")
+VERDICTS = ("broke", "already-broken", "unjudged", "compatible", "no-baseline")
+ABSENT_REASON = "no per-type baseline: the type is absent from the previous report (newer than the set the fleet is on)"
 
 
 def _failing(report: dict) -> dict:
@@ -73,28 +79,33 @@ def judge(new: dict, baseline: dict | None, baseline_reason: str = "") -> dict:
             "gate_fail": False,
             "broke": [],
             "already_broken": [],
-            "unjudged": [{"type": t, "error": e} for t, e in sorted(new_gating.items())],
+            "unjudged": [{"type": t, "error": e, "reason": baseline_reason or "no baseline report"}
+                         for t, e in sorted(new_gating.items())],
             "stale_allow": stale_allow,
             "baseline_reason": baseline_reason or "no baseline report",
         }
 
     base_ok = set(baseline.get("ok", []) or [])
     base_fail = _failing(baseline)
-    broke, already = [], []
+    broke, already, unjudged = [], [], []
     for t, e in sorted(new_gating.items()):
         if t in base_ok:
             broke.append({"type": t, "error": e})
         elif t in base_fail:
             already.append({"type": t, "error": e, "baseline": "failed", "baseline_error": base_fail[t]})
         else:
-            already.append({"type": t, "error": e, "baseline": "absent"})
-    verdict = "broke" if broke else ("already-broken" if already else "compatible")
+            # Neither compiled nor failed at the baseline — it was not THERE. Its own row: nothing
+            # licenses "broke" (it never compiled against the fleet's set) and nothing licenses
+            # "already broken" (it never failed against it either).
+            unjudged.append({"type": t, "error": e, "reason": ABSENT_REASON})
+    verdict = ("broke" if broke else "already-broken" if already
+               else "unjudged" if unjudged else "compatible")
     return {
         "verdict": verdict,
         "gate_fail": bool(broke),
         "broke": broke,
         "already_broken": already,
-        "unjudged": [],
+        "unjudged": unjudged,
         "stale_allow": stale_allow,
         "baseline_reason": "",
     }
@@ -156,7 +167,11 @@ def main() -> int:
         "broke": f"🔴 BROKE — this core build broke {sat}: {len(v['broke'])} NodeType(s) compiled against the "
                  f"previous image ({args.baseline_digest[:19]}) and do not against the new one ({args.new_digest[:19]})",
         "already-broken": f"🟡 ALREADY BROKEN — {len(v['already_broken'])} NodeType(s) of {sat} fail on the new image "
-                          f"AND on the previous one (or did not exist there): satellite side, not this build's",
+                          f"AND on the previous one: satellite side, not this build's"
+                          + (f" (+{len(v['unjudged'])} unjudged: no per-type baseline)" if v["unjudged"] else ""),
+        "unjudged": f"🟡 UNJUDGED — {len(v['unjudged'])} NodeType(s) of {sat} fail on the new image and are ABSENT "
+                    f"from the previous report (newer than the set the fleet is on): no per-type baseline, so "
+                    f"neither 'broke' nor 'already broken' is licensed",
         "compatible": f"✅ COMPATIBLE — every NodeType of {sat} compiles against the new image "
                       f"({len(v['already_broken'])} advisory)",
         "no-baseline": f"⚪ NO BASELINE — refusing to judge {sat}: {v['baseline_reason']}. "
@@ -168,7 +183,7 @@ def main() -> int:
     for row in v["already_broken"]:
         print(f"  already-broken   {row['type']} (baseline: {row['baseline']}): {row['error']}")
     for row in v["unjudged"]:
-        print(f"  unjudged         {row['type']}: {row['error']}")
+        print(f"  unjudged         {row['type']} ({row.get('reason', '')}): {row['error']}")
     for t in v["stale_allow"]:
         print(f"  advisory         {t}: compiles now — remove it from scripts/compile-check.allow")
     if v["gate_fail"]:
@@ -209,10 +224,28 @@ def _self_test() -> int:
     if v["verdict"] != "no-baseline" or v["gate_fail"] or v["broke"] or [r["type"] for r in v["unjudged"]] != ["P/A"] \
        or "previous image" not in v["baseline_reason"]:
         failures.append(f"row4 no-baseline: {v!r}")
-    # edge: the type did not exist at the baseline → satellite side, never BROKE
+    # row 5: type ABSENT from the baseline report, fails on new ⇒ UNJUDGED — its own row, green,
+    # never BROKE and never folded into already-broken
     v = judge(rep(breaks=["P/New"], ok=["P/A"]), rep(ok=["P/A"]))
-    if v["verdict"] != "already-broken" or v["gate_fail"] or v["already_broken"][0]["baseline"] != "absent":
-        failures.append(f"edge absent-at-baseline: {v!r}")
+    if v["verdict"] != "unjudged" or v["gate_fail"] or v["broke"] or v["already_broken"] \
+       or [r["type"] for r in v["unjudged"]] != ["P/New"] or "absent" not in v["unjudged"][0]["reason"]:
+        failures.append(f"row5 absent-at-baseline must be unjudged: {v!r}")
+    # …and it stays its own row beside a genuine already-broken type (verdict word = already-broken,
+    # the absent type is NOT in already_broken)
+    v = judge(rep(breaks=["P/New", "P/Old"], ok=["P/A"]), rep(ok=["P/A"], breaks=["P/Old"]))
+    if v["verdict"] != "already-broken" or v["gate_fail"] or [r["type"] for r in v["already_broken"]] != ["P/Old"] \
+       or [r["type"] for r in v["unjudged"]] != ["P/New"]:
+        failures.append(f"row5b absent beside already-broken: {v!r}")
+    # …and beside a genuine BROKE type the leg is still red for THAT type only
+    v = judge(rep(breaks=["P/New", "P/A"], ok=["P/B"]), rep(ok=["P/A", "P/B"]))
+    if v["verdict"] != "broke" or not v["gate_fail"] or [r["type"] for r in v["broke"]] != ["P/A"] \
+       or [r["type"] for r in v["unjudged"]] != ["P/New"]:
+        failures.append(f"row5c absent beside broke: {v!r}")
+    # per-TYPE, never per-satellite: a satellite whose baseline report is all-red still yields BROKE
+    # for the one type that compiled there
+    v = judge(rep(breaks=["P/A", "P/B"]), rep(ok=["P/A"], breaks=["P/B"]))
+    if v["verdict"] != "broke" or [r["type"] for r in v["broke"]] != ["P/A"] or [r["type"] for r in v["already_broken"]] != ["P/B"]:
+        failures.append(f"per-type granularity: {v!r}")
     # edge: fingerprint drift on the new image counts as a new-image failure; stale allow is advisory only
     v = judge(rep(drift=["P/A"], stale=["P/S"], ok=["P/B", "P/S"]), rep(ok=["P/A", "P/B", "P/S"]))
     if v["verdict"] != "broke" or [r["type"] for r in v["broke"]] != ["P/A"] or v["stale_allow"] != ["P/S"]:
@@ -250,7 +283,8 @@ def _self_test() -> int:
         print("✗ compat-verdict self-test FAILED:\n  " + "\n  ".join(failures))
         return 1
     print("✓ compat-verdict: broke (red) · already-broken (green, advisory) · compatible · no-baseline (green, "
-          "unjudged) — all four rows, both directions, absent-at-baseline, drift, stale-allow and known-debt edges, CLI exit codes")
+          "unjudged) · type-absent-from-baseline ⇒ unjudged, never BROKE (row 5) — all rows both directions, per-type "
+          "granularity, drift, stale-allow and known-debt edges, CLI exit codes")
     return 0
 
 

--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -246,6 +246,9 @@ def write_report(path: Path, verdict: dict, result: dict, *, gate_fail: bool, sc
         "types": len(result),
         "elapsed_seconds": round(elapsed, 1),
         "clean": len(verdict["clean"]),
+        # By NAME as well as by count: compat-verdict.py asks "did this type compile against the
+        # PREVIOUS image?", and a count cannot answer for one type.
+        "ok": list(verdict["clean"]),
         "known_debt": [{"type": n, "error": first(n)} for n in verdict["known_debt"]],
         "new_breaks": [{"type": n, "error": first(n)} for n in verdict["new_breaks"]],
         "fp_drift": [{"type": n, "expected": e, "actual": a, "error": first(n)} for n, e, a in verdict["fp_drift"]],
@@ -1093,6 +1096,8 @@ def _self_test() -> int:
             failures.append("  report: a break must carry its FIRST error line")
         if [d.get("type") for d in got.get("known_debt", [])] != ["Pkg/Debt"] or got.get("clean") != 1:
             failures.append(f"  report: known_debt/clean counts wrong: {got!r}")
+        if got.get("ok") != ["Pkg/Fine"]:
+            failures.append(f"  report: the clean types must be listed by NAME, got {got.get('ok')!r}")
         if got.get("scope") != "full" or got.get("types") != 3:
             failures.append(f"  report: scope/types wrong: {got.get('scope')!r}/{got.get('types')!r}")
         os.environ["MW_CONTENT_REPOSITORY"] = "Systemorph/Fixture"; os.environ["MW_CONTENT_SHA"] = "abc1234"

--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -222,6 +222,37 @@ def evaluate_gate(result: dict, allow: dict, node_set: dict) -> dict:
             "stale_allow": stale_allow, "ghosts": ghosts}
 
 
+def write_report(path: Path, verdict: dict, result: dict, *, gate_fail: bool, scope, elapsed: float) -> None:
+    """The verdict as MACHINE-READABLE JSON — for a caller that has to relay it, not read it.
+
+    core's `satellite-compat` lane (MeshWeaver, 2026-09-12) runs this gate once per satellite on
+    every platform build, inside a matrix of reusable-workflow calls. A matrix `uses:` job has no
+    steps of its own and its outputs overwrite each other leg by leg, so the ONLY way the run's
+    verdict and the `ci-failure` issue can name WHICH satellite broke and on WHICH NodeTypes is a
+    per-leg artifact — and an artifact is worth exactly what the file inside it says. So the file
+    carries the same verdict the console prints, keyed the same way, with the FIRST error line of
+    every failing type: enough for a triage line, never a second judgement. Written before the
+    exit code is decided so a red run has a report too; a run that dies before this point leaves
+    no file, and the consumer treats "no report" as "not measured" rather than as clean."""
+    first = lambda n: (result.get(n, (None, []))[1] or ["(no CS error captured)"])[0]
+    payload = {
+        "gate_fail": bool(gate_fail),
+        "scope": "full" if scope is None else list(scope),
+        "types": len(result),
+        "elapsed_seconds": round(elapsed, 1),
+        "clean": len(verdict["clean"]),
+        "known_debt": [{"type": n, "error": first(n)} for n in verdict["known_debt"]],
+        "new_breaks": [{"type": n, "error": first(n)} for n in verdict["new_breaks"]],
+        "fp_drift": [{"type": n, "expected": e, "actual": a, "error": first(n)} for n, e, a in verdict["fp_drift"]],
+        "stale_allow": list(verdict["stale_allow"]),
+        "unverifiable": list(verdict["unverifiable"]),
+        "ghosts": list(verdict["ghosts"]),
+    }
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
 # ── source resolution (mirror the mesh's three source queries) ─────────────────────────────────────
 
 def resolve_spec(spec: str, nd: Path, root: Path):
@@ -1037,6 +1068,35 @@ def _self_test() -> int:
             ROOT = saved_root
     failures.extend(scope_failures)
 
+    # 🚨 THE REPORT MUST CARRY THE VERDICT, IN BOTH COLOURS. A relayed verdict is read by a job
+    # that cannot see this console (core's satellite-compat lane names the failing satellite and
+    # its types from the file alone), so a report that says "green" for a red gate — or names no
+    # type — would make that lane certify compatibility it never measured.
+    with tempfile.TemporaryDirectory() as tmp:
+        rep = Path(tmp) / "nested" / "verdict.json"
+        result = {"Pkg/Broken": ("fail", ["CS0246: 'Gone' could not be found", "CS0103: second"]),
+                  "Pkg/Fine": ("ok", []), "Pkg/Debt": ("fail", ["CS0246: x"])}
+        allow = {"Pkg/Debt": failure_fingerprint(["CS0246: x"])}
+        v = evaluate_gate(result, allow, {n: frozenset() for n in result})
+        write_report(rep, v, result, gate_fail=bool(v["new_breaks"]), scope=None, elapsed=12.34)
+        got = json.loads(rep.read_text(encoding="utf-8"))
+        if got.get("gate_fail") is not True:
+            failures.append(f"  report: a NEW break must read gate_fail=true, got {got.get('gate_fail')!r}")
+        if [b.get("type") for b in got.get("new_breaks", [])] != ["Pkg/Broken"]:
+            failures.append(f"  report: new_breaks must name Pkg/Broken, got {got.get('new_breaks')!r}")
+        if got.get("new_breaks", [{}])[0].get("error") != "CS0246: 'Gone' could not be found":
+            failures.append("  report: a break must carry its FIRST error line")
+        if [d.get("type") for d in got.get("known_debt", [])] != ["Pkg/Debt"] or got.get("clean") != 1:
+            failures.append(f"  report: known_debt/clean counts wrong: {got!r}")
+        if got.get("scope") != "full" or got.get("types") != 3:
+            failures.append(f"  report: scope/types wrong: {got.get('scope')!r}/{got.get('types')!r}")
+        green = {"Pkg/Fine": ("ok", [])}
+        write_report(rep, evaluate_gate(green, {}, {"Pkg/Fine": frozenset()}), green,
+                     gate_fail=False, scope=["Pkg"], elapsed=1)
+        got = json.loads(rep.read_text(encoding="utf-8"))
+        if got.get("gate_fail") is not False or got.get("new_breaks") or got.get("scope") != ["Pkg"]:
+            failures.append(f"  report: a clean gate must read gate_fail=false with no breaks, got {got!r}")
+
     if failures:
         print("✗ using-directive parser self-test FAILED:")
         print("\n".join(failures))
@@ -1046,6 +1106,8 @@ def _self_test() -> int:
           f"{len(MODULE_REFS_NOT_IN_IMAGE)} registry-served assemblies, absolutized")
     print("✓ --modules scope: a subset selects only its packages, an unknown id and an empty list "
           "are refused, the ratchet judges the unit's allow entries only")
+    print("✓ --report: the JSON verdict carries gate_fail in both colours, every new break with its "
+          "first error, the known-debt list and the scope")
     return 0
 
 
@@ -1064,6 +1126,10 @@ def main() -> int:
                     help="compile ONLY the NodeTypes of these packages (top-level folders) — the "
                          "atomic unit the caller selected; the allow-file ratchet is judged over "
                          "them alone. An unknown id or an empty list is RED. Omit for a full run.")
+    ap.add_argument("--report", metavar="PATH",
+                    help="also write the verdict as JSON to PATH (see write_report) — what a caller "
+                         "that has to RELAY the result reads, e.g. core's per-satellite compat lane. "
+                         "Never changes the exit code.")
     args = ap.parse_args()
 
     if args.self_test:
@@ -1333,6 +1399,9 @@ def main() -> int:
         unit = "full tree" if selected is None else f"unit {', '.join(selected)}"
         print(f"\n✓ compile gate GREEN ({unit}): {len(clean)} clean, {len(known_debt)} known-debt "
               f"(shrinking), no new breaks.")
+    if args.report:
+        write_report(Path(args.report), verdict, result, gate_fail=gate_fail, scope=selected, elapsed=elapsed)
+        print(f"verdict written to {args.report}")
     return 1 if gate_fail else 0
 
 

--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -236,6 +236,11 @@ def write_report(path: Path, verdict: dict, result: dict, *, gate_fail: bool, sc
     no file, and the consumer treats "no report" as "not measured" rather than as clean."""
     first = lambda n: (result.get(n, (None, []))[1] or ["(no CS error captured)"])[0]
     payload = {
+        # WHAT was judged, so the verdict is a fact about one tree and not "the satellite":
+        # the lane sets these to the checked-out repository and the commit it resolved. A ref
+        # like `main` moves; the sha in the report is what the verdict is about.
+        "content": {"repository": os.environ.get("MW_CONTENT_REPOSITORY", ""),
+                    "sha": os.environ.get("MW_CONTENT_SHA", "")},
         "gate_fail": bool(gate_fail),
         "scope": "full" if scope is None else list(scope),
         "types": len(result),
@@ -1090,6 +1095,14 @@ def _self_test() -> int:
             failures.append(f"  report: known_debt/clean counts wrong: {got!r}")
         if got.get("scope") != "full" or got.get("types") != 3:
             failures.append(f"  report: scope/types wrong: {got.get('scope')!r}/{got.get('types')!r}")
+        os.environ["MW_CONTENT_REPOSITORY"] = "Systemorph/Fixture"; os.environ["MW_CONTENT_SHA"] = "abc1234"
+        try:
+            write_report(rep, v, result, gate_fail=True, scope=None, elapsed=1)
+            got = json.loads(rep.read_text(encoding="utf-8"))
+            if got.get("content") != {"repository": "Systemorph/Fixture", "sha": "abc1234"}:
+                failures.append(f"  report: content repository/sha not recorded: {got.get('content')!r}")
+        finally:
+            del os.environ["MW_CONTENT_REPOSITORY"]; del os.environ["MW_CONTENT_SHA"]
         green = {"Pkg/Fine": ("ok", [])}
         write_report(rep, evaluate_gate(green, {}, {"Pkg/Fine": frozenset()}), green,
                      gate_fail=False, scope=["Pkg"], elapsed=1)
@@ -1107,7 +1120,7 @@ def _self_test() -> int:
     print("✓ --modules scope: a subset selects only its packages, an unknown id and an empty list "
           "are refused, the ratchet judges the unit's allow entries only")
     print("✓ --report: the JSON verdict carries gate_fail in both colours, every new break with its "
-          "first error, the known-debt list and the scope")
+          "first error, the known-debt list, the scope, and the content repository + sha it judged")
     return 0
 
 

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2621,11 +2621,22 @@ jobs:
   #     against the set the fleet is ON (`gate` records mw-plugin-test:main's digest and version
   #     pre-promote; satellite-compat-image verifies GHCR holds it and re-uploads the four module
   #     bundles the run that built it packed). compat-verdict.py then classifies per NodeType:
-  #     compiled at the baseline, not now → BROKE (the only red); failed at the baseline too, or
-  #     absent there → already broken, satellite side (green, advisory — its own daily run and
-  #     ci-main-red issue own it); no baseline → a refusal to judge (green, advisory, new-image
-  #     failures listed UNJUDGED). So the c88cd5d5c hazard — core reddened by a satellite's own
+  #     compiled at the baseline, not now → BROKE (the only red); failed at the baseline too →
+  #     already broken, satellite side (green, advisory — its own daily run and ci-main-red issue
+  #     own it); ABSENT at the baseline (newer than the set the fleet is on) → UNJUDGED, its own
+  #     row (green, advisory: nothing licenses "broke" and nothing licenses "already broken"); no
+  #     baseline → a refusal to judge (green, advisory, new-image failures listed UNJUDGED). Per
+  #     TYPE, never per satellite. So the c88cd5d5c hazard — core reddened by a satellite's own
   #     broken commit — is classified out, not tolerated. Both digests are in every verdict.
+  #   * 🚨 THE BASELINE COMPILES AGAINST THE BASELINE RUN'S MODULE BUNDLES (located by the run
+  #     number in the baseline's 3.0.0-ci.<run> tag), NOT THIS RUN'S — even though this run's are
+  #     already at hand. The four modules (AI, Markdown.Collaboration, Maps, Payments.Stripe) are
+  #     Plugins content packed per build; a Plugins-side move between the two sets (a type renamed
+  #     in MeshWeaver.AI, say) would, with this run's bundles under the OLD image, fail the baseline
+  #     reading too and be filed as "already broken" — misattributing a Plugins move as satellite
+  #     debt, or, with new bundles that need new core surface, as a false baseline failure. "We
+  #     already have this run's bundles, why download the old ones" is the optimisation this
+  #     paragraph exists to refuse: it would break the attribution the whole control is for.
   #
   # Budget: ubuntu-latest in a public repository — unbilled. Five parallel legs of ~2 min per
   # compile, two compiles each (~4–5 min a leg), add ≤ ~5 min of wall time beside `plugins-bake`
@@ -3268,15 +3279,23 @@ jobs:
               broke)
                 red=$((red + 1)); redlist="${redlist:+$redlist, }$sat"
                 list=$(jq -r --arg bt '`' '[.broke[].type] | map($bt + . + $bt) | join(", ")' "$f")
-                echo "| $sat | \`${csha:-?}\` | 🔴 **THIS BUILD BROKE IT** | $types | ${list:-?} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                absent=$(jq -r --arg bt '`' '[.unjudged[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | 🔴 **THIS BUILD BROKE IT** | $types | ${list:-?}${absent:+; unjudged (no per-type baseline): $absent} | $images |" >> "$GITHUB_STEP_SUMMARY"
                 echo "compatibility: $sat@${csha:-?} — BROKEN BY THIS BUILD ($VERSION): ${list:-?}"
                 jq -r '.broke[] | "    \(.type): \(.error)"' "$f" ;;
               already-broken)
                 advisory="${advisory:+$advisory; }$sat"
                 list=$(jq -r --arg bt '`' '[.already_broken[].type] | map($bt + . + $bt) | join(", ")' "$f")
-                echo "| $sat | \`${csha:-?}\` | 🟡 already broken (satellite side, advisory) | $types | ${list:-?} | $images |" >> "$GITHUB_STEP_SUMMARY"
-                echo "compatibility: $sat@${csha:-?} — ALREADY BROKEN on the baseline too (satellite side; its own daily run / ci-main-red issue own it): ${list:-?}"
+                absent=$(jq -r --arg bt '`' '[.unjudged[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | 🟡 already broken (satellite side, advisory) | $types | ${list:-?}${absent:+; unjudged (no per-type baseline): $absent} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — ALREADY BROKEN on the baseline too (satellite side; its own daily run / ci-main-red issue own it): ${list:-?}${absent:+; unjudged, no per-type baseline: $absent}"
                 jq -r '.already_broken[] | "    \(.type) (baseline: \(.baseline)): \(.error)"' "$f" ;;
+              unjudged)
+                advisory="${advisory:+$advisory; }$sat (unjudged types)"
+                list=$(jq -r --arg bt '`' '[.unjudged[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | 🟡 unjudged (no per-type baseline — newer than the set the fleet is on) | $types | ${list:-?} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — UNJUDGED: these types fail on the new image and are absent from the baseline report, so neither 'broke' nor 'already broken' is licensed: ${list:-?}"
+                jq -r '.unjudged[] | "    \(.type): \(.error)"' "$f" ;;
               no-baseline)
                 advisory="${advisory:+$advisory; }$sat (no baseline)"
                 reason=$(jq -r '.images.baseline_reason // .baseline_reason // "?"' "$f")

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -308,6 +308,8 @@ jobs:
           DEPENDENT_DISPATCH_APP_ID: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
           DEPENDENT_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
           BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
+          FLEET_READER_APP_ID: ${{ secrets.FLEET_READER_APP_ID }}
+          FLEET_READER_APP_PRIVATE_KEY: ${{ secrets.FLEET_READER_APP_PRIVATE_KEY }}
         run: |
           missing=()
           [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID           OIDC app registration for azure/login")
@@ -318,6 +320,13 @@ jobs:
           [ -n "$DEPENDENT_DISPATCH_APP_ID" ]          || missing+=("secrets.DEPENDENT_DISPATCH_APP_ID          GitHub App whose installation token reads the Plugins content tree for plugins-modules / plugins-bake (content-app-id) — NOT a dispatch credential: core dispatches to no repository")
           [ -n "$DEPENDENT_DISPATCH_APP_PRIVATE_KEY" ] || missing+=("secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY that App's private key, PEM")
           [ -n "$BAKE_PUBLISH_TARGETS" ]               || missing+=("vars.BAKE_PUBLISH_TARGETS                  the portals' storage shares the Plugins publication is sealed to (<account>/<share>…)")
+          # The READ-ONLY fleet-reader App is what `satellite-compat` checks each satellite's main out
+          # with (content-app-id on node-repo-compile-check.yml). Asserted here, on every tick, so a
+          # missing credential is a red preflight naming it — never a leg that mints nothing and is
+          # painted grey. Measured 2026-09-12: the App (`meshweaver-reader`, installation 161095771)
+          # is installed org-wide (repository_selection: all), MeshWeaver.Crm included.
+          [ -n "$FLEET_READER_APP_ID" ]          || missing+=("secrets.FLEET_READER_APP_ID          app id of the org's READ-ONLY fleet-reader GitHub App (Contents, Metadata, Pull requests: read), whose installation token checks out each satellite's main for satellite-compat — set it in BOTH the Actions and the Dependabot secret stores (gh secret set NAME --repo Systemorph/MeshWeaver, then again with --app dependabot)")
+          [ -n "$FLEET_READER_APP_PRIVATE_KEY" ] || missing+=("secrets.FLEET_READER_APP_PRIVATE_KEY  that App's private key (PEM), in BOTH stores like the id. NOT meshweaver-cloud's key: that App holds write")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::CD cannot deliver a release event — provision the following, then re-run:"
             for m in "${missing[@]}"; do echo "  • $m"; done
@@ -2533,6 +2542,141 @@ jobs:
       # asserts it and why it must actually reach this lane.
       webhook-secret: ${{ secrets.PLATFORM_WEBHOOK_SECRET }}
 
+  # ────────── SATELLITE COMPATIBILITY: every satellite's NodeTypes against THIS set ──────────
+  # 🚨 The per-build counterweight to the DAILY rebuild (maintainer decision, 2026-09-12). The fleet
+  # assumes the platform is backwards compatible within a MAJOR, so the satellites (SocialMedia,
+  # Crm, Reinsurance, Education, Manufacturing; Plugins is built inside this run) rebuild ONCE A
+  # DAY, not per platform build. That removes the per-build wave's cost — and with it the only
+  # per-build evidence that a core merge did not break them. Without something here a break is
+  # found at 03:00 by the daily run, or on a portal at self-update, hours after the merge that
+  # caused it and by someone else.
+  #
+  # So every core build still MEASURES compatibility, cheaply: one leg per satellite, in parallel,
+  # each compiling every NodeType of that satellite's `main` against the tester THIS run promoted
+  # plus the module bundles THIS run packed (`plugins-modules` — the same bytes `plugins-bake`
+  # seals, so a verdict here is a verdict about the publication the satellites will consume). It
+  # is the reusable compile gate the satellites run on their own pull requests, pointed at their
+  # content from here; `compile-check.py` is fetched at THIS run's core sha. Measured on the same
+  # lane (MeshWeaver.Crm run 34686027657, 2026-09-12): 1 min 50 s per leg.
+  #
+  # 🚨 RED, BUT NOT BLOCKING — and both halves are deliberate.
+  #   * NOT blocking: it runs AFTER `promote` (the set is already armed), and neither
+  #     `notify-platform-update` nor `plugins-bake` waits for it. The set is published; each
+  #     instance gates ITSELF (Admin/UpdatePolicy, its own bake health). Blocking the publish on a
+  #     satellite's compile would hand every satellite a veto over the platform's delivery — the
+  #     dependency direction this repository forbids (PlatformNeverDependsOnPluginsGuard).
+  #   * RED: a failing leg fails THIS job, the run is red, `alert-on-failure` files it on the
+  #     `ci-failure` issue naming the satellite, the set and the first failing types, and
+  #     `delivery-verdict` lists every leg under "Compatibility". Never `continue-on-error`, never
+  #     an `if:` on a credential: `preflight` asserts the fleet-reader App RED, and a leg that
+  #     cannot mint, pull or compile is a red leg. `fail-fast: false`, so one satellite's red does
+  #     not cancel the others' measurement — the verdict is per satellite or it is not a verdict.
+  #
+  # Budget: ubuntu-latest in a public repository — unbilled. Five parallel legs of ~2 min add
+  # ≤ ~3 min of wall time beside `plugins-bake` (which they do not wait for), and five concurrent
+  # jobs per build against the org's job ceiling. Narrowing the matrix to the satellites whose
+  # NodeTypes reference the changed surface is the honest lever if that concurrency ever matters;
+  # it is NOT done here — nothing in this run knows which satellite binds which surface, and a
+  # matrix that guessed would skip exactly the leg it should have run.
+  #
+  # 🚨 Why the GHCR mirror and not ACR: the lane authenticates to its registry with a username and
+  # a password (the satellites' ACR credential). Core holds no ACR password — it pushes by OIDC —
+  # and OIDC inside the lane would demand `id-token: write` of every satellite caller, the #3933
+  # startup-failure shape. `promote`'s phase B mirrors the tester to GHCR by digest (imagetools
+  # copies the index), so the job below resolves the GHCR tag and ASSERTS it is the digest
+  # `plugins-bake-image` resolved on ACR; the legs then pull `ghcr.io/…@<that digest>` with
+  # GITHUB_TOKEN. One set, one digest, two registries — verified, not assumed.
+  satellite-compat-image:
+    name: "Compatibility: the tester on GHCR is this run's digest"
+    needs: [preflight, gate, plugin-test-image, promote, plugins-bake-image]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      image: ${{ steps.mirror.outputs.image }}
+      digest: ${{ steps.mirror.outputs.digest }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Resolve the mirrored tester and assert it is the promoted digest
+        id: mirror
+        env:
+          VERSION: ${{ needs.plugin-test-image.outputs.version }}
+          ACR_DIGEST: ${{ needs.plugins-bake-image.outputs.digest }}
+          OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+          [ -n "${VERSION:-}" ] || { echo "::error::plugin-test-image produced no version — cannot name the tester the satellites are checked against"; exit 1; }
+          case "$ACR_DIGEST" in sha256:*) ;; *) echo "::error::plugins-bake-image resolved no digest for the tester (got '$ACR_DIGEST') — nothing to assert the mirror against"; exit 1 ;; esac
+          ns=$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')
+          ref="ghcr.io/$ns/mw-plugin-test:$VERSION"
+          digest=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          case "$digest" in sha256:*) ;; *) echo "::error::could not resolve a digest for $ref (got '$digest') — promote's phase B mirrors the tester to GHCR; if it is not there, the set is not what promote said it was"; exit 1 ;; esac
+          [ "$digest" = "$ACR_DIGEST" ] || { echo "::error::the GHCR mirror of mw-plugin-test:$VERSION is $digest but ACR's is $ACR_DIGEST — the two registries do not hold ONE image for this set, so a compatibility verdict against the mirror would be a verdict about a different tester. Read promote's phase B."; exit 1; }
+          echo "image=ghcr.io/$ns/mw-plugin-test" >> "$GITHUB_OUTPUT"
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "satellite-compat tester: $ref = $digest (equal to ACR's)"
+
+  satellite-compat:
+    name: "Compatibility: ${{ matrix.satellite }}'s NodeTypes compile against this set"
+    needs: [preflight, gate, plugin-test-image, promote, plugins-bake-image, plugins-modules, satellite-compat-image]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    strategy:
+      # 🚨 One red satellite must not cancel the other four's measurement.
+      fail-fast: false
+      matrix:
+        # The satellite register of this gate. `repository:` is spelled out per entry rather than
+        # composed from `satellite` so the guards that inventory every cross-repository reach in
+        # this file (PlatformBakeLaneGuard, PlatformNeverDependsOnPluginsGuard) SEE each one by
+        # name — a detector that cannot see its subject reports a clean tree forever.
+        include:
+          - satellite: MeshWeaver.SocialMedia
+            repository: Systemorph/MeshWeaver.SocialMedia
+          - satellite: MeshWeaver.Crm
+            repository: Systemorph/MeshWeaver.Crm
+          - satellite: MeshWeaver.Reinsurance
+            repository: Systemorph/MeshWeaver.Reinsurance
+          - satellite: MeshWeaver.Education
+            repository: Systemorph/MeshWeaver.Education
+          - satellite: MeshWeaver.Manufacturing
+            repository: Systemorph/MeshWeaver.Manufacturing
+    permissions:
+      contents: read
+      packages: read
+    uses: ./.github/workflows/node-repo-compile-check.yml
+    with:
+      content-repository: ${{ matrix.repository }}
+      # The satellite's own default branch — what its daily run would bake. Deliberately NOT a sha
+      # this run resolved: the satellites are not part of the image set, so there is no set identity
+      # to keep consistent (contrast the Plugins checkouts, pinned to gate's plugins_sha), and each
+      # leg checks out exactly once.
+      content-ref: main
+      platform-ref: ${{ needs.gate.outputs.sha }}
+      test-image: ${{ needs.satellite-compat-image.outputs.image }}:${{ needs.plugin-test-image.outputs.version }}
+      image-digest: ${{ needs.satellite-compat-image.outputs.digest }}
+      # THIS run's module bundles — the set `plugins-bake` seals (same pattern, same artifacts), and
+      # the four modules every satellite declares as `registry-modules: AI Essentials Stripe Maps`
+      # with `upstream-seed: plugins` on its own gate. From the artifacts, not the seal: the seal is
+      # being written by `plugins-bake` in parallel, and the bytes are the same by construction.
+      module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration,Maps,Payments.Stripe}
+      verdict-artifact: satellite-compat-${{ matrix.satellite }}
+    secrets:
+      # GHCR takes any username with a token that can read the package; GITHUB_TOKEN can, because
+      # promote pushed the mirror under it and the lane's job holds `packages: read`.
+      acr-username: ${{ github.actor }}
+      acr-password: ${{ secrets.GITHUB_TOKEN }}
+      # The satellites are PRIVATE: this run's GITHUB_TOKEN cannot check them out. The READ-ONLY
+      # fleet-reader App is installed on every one of them; preflight asserts it.
+      content-app-id: ${{ secrets.FLEET_READER_APP_ID }}
+      content-app-private-key: ${{ secrets.FLEET_READER_APP_PRIVATE_KEY }}
+
   verify-images:
     name: "Verify every image shipped"
     needs: [gate, portal-image, migration-image, plugin-test-image, promote]
@@ -2692,7 +2836,8 @@ jobs:
     # publish actually happened while it can only see two of the nine jobs that make it happen.
     needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote,
             publish-bake, notify-platform-update, verify-images,
-            plugins-modules, plugins-bake-image, plugins-bake]
+            plugins-modules, plugins-bake-image, plugins-bake,
+            satellite-compat-image, satellite-compat]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2940,6 +3085,81 @@ jobs:
           fi
           echo "every delivery leg ran and succeeded: $LEGS"
 
+      # ─────────── Compatibility: every satellite's NodeTypes against this set ───────────
+      # The legs are `satellite-compat`'s (see that job): RED on a break, NOT blocking. This step
+      # RELAYS them — one table on the run page, one line per satellite in the log — and holds the
+      # one thing the legs' own colour cannot: that the gate RAN. A publishing run on which the
+      # compatibility job was skipped or cancelled certified nothing, and GitHub paints that grey
+      # like a pass; here it is red, naming the job's result. A leg that ran and FAILED is listed
+      # with its failing types and does NOT fail this step twice — its own red already carries the
+      # run, and `alert-on-failure` files it.
+      # `always()`: the table renders even when a verdict step above went red — a run that is
+      # already red for delivery still owes the reader the compatibility reading it took.
+      - name: Collect the satellite verdicts
+        if: ${{ always() && needs.gate.outputs.publish == 'true' }}
+        uses: actions/download-artifact@v8
+        with:
+          pattern: satellite-compat-*
+          path: ${{ runner.temp }}/satellite-compat
+      - name: "Compatibility: every satellite's NodeTypes compile against this set"
+        if: ${{ always() && needs.gate.outputs.publish == 'true' }}
+        env:
+          COMPAT_RESULT: ${{ needs.satellite-compat.result }}
+          COMPAT_IMAGE_RESULT: ${{ needs.satellite-compat-image.result }}
+          # The same register as the job's matrix. A satellite named here with no verdict artifact
+          # is reported NOT MEASURED, never folded into a green.
+          SATELLITES: MeshWeaver.SocialMedia MeshWeaver.Crm MeshWeaver.Reinsurance MeshWeaver.Education MeshWeaver.Manufacturing
+          VERSION: ${{ needs.portal-image.outputs.version }}
+          VERDICTS: ${{ runner.temp }}/satellite-compat
+        run: |
+          set -euo pipefail
+          {
+            echo "### 🧩 Compatibility — every satellite's NodeTypes against \`${VERSION}\` (satellite-compat=${COMPAT_RESULT})"
+            echo ""
+            echo "| Satellite | Verdict | NodeTypes | Breaks | Known debt |"
+            echo "|---|---|---:|---|---:|"
+          } >> "$GITHUB_STEP_SUMMARY"
+          red=0; unmeasured=0
+          for sat in $SATELLITES; do
+            f="$VERDICTS/satellite-compat-$sat/compile-check-verdict.json"
+            if [ ! -f "$f" ]; then
+              unmeasured=$((unmeasured + 1))
+              echo "| $sat | ⚪ NOT MEASURED — no verdict artifact | | | |" >> "$GITHUB_STEP_SUMMARY"
+              echo "compatibility: $sat — NOT MEASURED (no verdict artifact; read that leg)"
+              continue
+            fi
+            fail=$(jq -r '.gate_fail' "$f")
+            types=$(jq -r '.types' "$f")
+            debt=$(jq -r '.known_debt | length' "$f")
+            breaks=$(jq -r --arg bt '`' '([.new_breaks[].type] + [.fp_drift[].type] + [.stale_allow[] | . + " (compiles now — remove from allow)"]) | map($bt + . + $bt) | join(", ")' "$f")
+            if [ "$fail" = "true" ]; then
+              red=$((red + 1))
+              echo "| $sat | ❌ RED | $types | ${breaks:-?} | $debt |" >> "$GITHUB_STEP_SUMMARY"
+              echo "compatibility: $sat — RED against $VERSION: ${breaks:-?}"
+              jq -r '(.new_breaks + .fp_drift)[] | "    \(.type): \(.error)"' "$f"
+            else
+              echo "| $sat | ✅ compiles | $types | — | $debt |" >> "$GITHUB_STEP_SUMMARY"
+              echo "compatibility: $sat — compiles against $VERSION ($types NodeType(s), $debt known-debt)"
+            fi
+          done
+          case "$COMPAT_RESULT" in
+            success|failure) ;;
+            *)
+              echo "- ❌ the compatibility gate did NOT run on this publishing run (satellite-compat=${COMPAT_RESULT}, satellite-compat-image=${COMPAT_IMAGE_RESULT}) — nothing above was measured" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::the gate decided to PUBLISH, but satellite-compat=${COMPAT_RESULT} (satellite-compat-image=${COMPAT_IMAGE_RESULT}): the compatibility of this set with the satellites was NOT measured. A skipped gate is painted like a passed one; it is not one. Read satellite-compat-image / plugins-modules for why the legs never ran."
+              exit 1 ;;
+          esac
+          if [ "$COMPAT_RESULT" = "success" ] && [ "$unmeasured" -gt 0 ]; then
+            echo "::error::satellite-compat reports success but $unmeasured satellite(s) above have no verdict artifact — a leg that measured nothing must not read as a pass. Either the matrix and the SATELLITES register in this step diverged, or a leg uploaded no report."
+            exit 1
+          fi
+          if [ "$red" -gt 0 ]; then
+            echo "- ❌ **$red satellite(s) do not compile against this set.** The set IS published and every instance gates itself; the red is \`satellite-compat\`'s own and is filed on the \`ci-failure\` issue. Fix lands in the SATELLITE (or core, if the break is the platform's) — the daily rebuild will not repair it on its own." >> "$GITHUB_STEP_SUMMARY"
+            echo "compatibility: $red satellite(s) RED — see the satellite-compat legs; this verdict lists, it does not re-fail"
+          else
+            echo "compatibility: every satellite compiles against $VERSION"
+          fi
+
       # Make the outcome unmissable on the run page. A 3-second success and a 20-minute delivery
       # are otherwise identical at a glance, which is how a merged fix sat unshipped.
       - name: Say plainly what this run did
@@ -2987,7 +3207,11 @@ jobs:
     # event that starts the cross-repo rebake wave used to be unfailable, and a failure nobody is
     # paged for is still invisible. A red notify job does NOT mean the images are missing —
     # `verify-images` answers that — it means no satellite learned about them.
-    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote, verify-images, publish-bake, notify-platform-update, delivery-verdict]
+    # `satellite-compat` (+ its image job) is in this list ON PURPOSE (2026-09-12): it is the
+    # per-build compatibility measurement that replaced the per-build satellite wave, it does not
+    # block the publish, and a red nobody is paged for is the 03:00 discovery it exists to prevent.
+    # Its verdict artifacts are read below so the alert names the satellite and the types.
+    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote, verify-images, publish-bake, notify-platform-update, delivery-verdict, satellite-compat-image, satellite-compat]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2996,6 +3220,14 @@ jobs:
     permissions:
       issues: write
     steps:
+      # The satellite verdicts, if any leg wrote one (same-run artifacts need no extra scope). A
+      # matching-nothing pattern downloads nothing, and the step below then simply has no
+      # compatibility lines to add — the alert is still filed.
+      - name: Collect the satellite verdicts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: satellite-compat-*
+          path: ${{ runner.temp }}/satellite-compat
       - name: Create or comment on ci-failure issue
         env:
           GH_TOKEN: ${{ github.token }}
@@ -3005,8 +3237,25 @@ jobs:
           # read "for commit ``". The fallbacks cover a failure IN gate, before it produced outputs.
           HEAD_SHA: ${{ needs.gate.outputs.sha || github.event.workflow_run.head_sha || github.sha }}
           REASON: ${{ needs.gate.outputs.reason }}
+          COMPAT_RESULT: ${{ needs.satellite-compat.result }}
+          VERSION: ${{ needs.portal-image.outputs.version }}
+          VERDICTS: ${{ runner.temp }}/satellite-compat
         run: |
           set -euo pipefail
+          # One line per satellite whose verdict says RED: the satellite, the set, the first three
+          # failing types with their first error. Composed with printf, never a multi-line literal —
+          # a body line at column 1 would end this block scalar (same reasoning as `gate`'s ledger).
+          compat=""; bt='`'
+          for f in "$VERDICTS"/satellite-compat-*/compile-check-verdict.json; do
+            [ -f "$f" ] || continue
+            sat=$(basename "$(dirname "$f")"); sat="${sat#satellite-compat-}"
+            [ "$(jq -r '.gate_fail' "$f")" = "true" ] || continue
+            first=$(jq -r --arg bt "$bt" '(.new_breaks + .fp_drift + [.stale_allow[] | {type: ., error: "compiles now — remove it from scripts/compile-check.allow"}]) | .[:3] | map($bt + .type + $bt + " — " + .error) | join("; ")' "$f")
+            compat=$(printf '%s\n* **%s** does not compile against %s%s%s: %s' "$compat" "$sat" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
+          done
+          if [ -n "$compat" ]; then
+            compat=$(printf '\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite still compiles against it. The fix lands in the SATELLITE (its NodeTypes, or its allow-file ratchet), or in core if the platform broke a surface it should not have — the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$COMPAT_RESULT" "$compat")
+          fi
           # Ensure the label exists (--force = update-or-create, idempotent). Non-fatal for the
           # same reason as in `gate`: this is the ALERT path, so a 503 here must not swallow the
           # alert it is decorating. If the label genuinely does not exist, the `--label` on the
@@ -3020,8 +3269,9 @@ jobs:
 
           * an IMAGE job / promote / verify-images: no complete image set was published. Publication is all-or-nothing, so every self-updating install stays on the PREVIOUS image until a CD run promotes the full set.
           * preflight / notify-platform-update: the images may be fine, but the release EVENT did not reach the control instance, so no node repo re-bakes against this commit until its own schedule poll (#2235). Read the job's ::error:: line - it names what to provision or what refused the delivery.
+          * satellite-compat (a matrix leg) / satellite-compat-image: the set IS published and the release event WAS sent - what failed is the per-build measurement that a satellite's NodeTypes still compile against it (the counterweight to the daily rebuild, 2026-09-12). A red leg names the satellite; the lines under Compatibility below name the types. No image and no publication is missing.
 
-          The hourly reconciler will re-attempt main's HEAD on its own (bounded at 3 attempts per commit, logged here); you do NOT need to force a merge to trigger delivery. This issue CLOSES ITSELF when a CD run reports a successful heal (#3176) - a later failure files a fresh issue rather than appending here, so this one's title and age stay true to its own cause."
+          The hourly reconciler will re-attempt main's HEAD on its own (bounded at 3 attempts per commit, logged here); you do NOT need to force a merge to trigger delivery. This issue CLOSES ITSELF when a CD run reports a successful heal (#3176) - a later failure files a fresh issue rather than appending here, so this one's title and age stay true to its own cause.${compat}"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \
             --limit 1 --json number --jq '.[0].number // empty')
           if [ -n "$existing" ]; then

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -401,6 +401,13 @@ jobs:
       conclusion: ${{ steps.required.outputs.conclusion }}
       # The architectures publish-bake runs a lane for — see that job's matrix.
       bake_arches: ${{ steps.arches.outputs.json }}
+      # The set the fleet is ON, read here BEFORE this run's promote moves `main` (2026-09-12):
+      # satellite-compat's baseline. Empty = could not be established (the reason says why), and
+      # every consumer treats empty as "refuse to judge", never as a verdict either way.
+      baseline_tester_digest: ${{ steps.baseline.outputs.digest }}
+      baseline_tester_version: ${{ steps.baseline.outputs.version }}
+      baseline_run_number: ${{ steps.baseline.outputs.run_number }}
+      baseline_reason: ${{ steps.baseline.outputs.reason }}
     steps:
       - uses: actions/checkout@v7
       # ─────────── Which architectures get a bake lane ───────────
@@ -684,6 +691,44 @@ jobs:
       #     Later ticks then cost ~40 s and print nothing — loud once, then quiet, which is the
       #     opposite of a repeating alarm nobody reads. Closing the issue is a deliberate human
       #     act and legitimately grants a fresh budget.
+      # ─────────── The set the fleet is on — satellite-compat's baseline (2026-09-12) ───────────
+      # Read HERE, pre-promote, from the same registry the completeness probe above reads, because
+      # after `promote` the `main` pointer names THIS run's set and the previous one is gone from
+      # every pointer. One manifest row answers the whole question: the digest (what to compile
+      # against), its version tag (3.0.0-ci.<run> — the run number of the CD run that built it) and
+      # therefore which run's `module-bundle-*` artifacts shipped WITH it (satellite-compat-image
+      # fetches those). A read that fails, or a `main` that carries no version tag, is recorded as
+      # "no baseline" with the reason — never fatal here, because the judge downstream treats an
+      # unestablished baseline as a REFUSAL to judge, which is the only honest reading of it.
+      - name: "Record the set the fleet is on (satellite-compat's baseline)"
+        id: baseline
+        run: |
+          set -euo pipefail
+          row=""
+          if rows=$(az acr manifest list-metadata --registry meshweaver --name mw-plugin-test --top 100 --orderby time_desc -o json --only-show-errors); then
+            row=$(printf '%s' "$rows" | jq -c '[.[] | select(.tags != null) | select(.tags | index("main"))] | .[0] // empty')
+          else
+            echo "reason=ACR manifest metadata for mw-plugin-test could not be read" >> "$GITHUB_OUTPUT"
+            echo "::warning::satellite-compat baseline NOT established: ACR manifest metadata for mw-plugin-test could not be read — every compat leg will refuse to judge this run"
+            exit 0
+          fi
+          if [ -z "$row" ]; then
+            echo "reason=no mw-plugin-test manifest carries the main tag (first publish?)" >> "$GITHUB_OUTPUT"
+            echo "::warning::satellite-compat baseline NOT established: no mw-plugin-test manifest carries the main tag"
+            exit 0
+          fi
+          digest=$(printf '%s' "$row" | jq -r '.digest')
+          version=$(printf '%s' "$row" | jq -r '[.tags[] | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+(-ci\\.[0-9]+)?$"))] | .[0] // empty')
+          run_number="${version##*-ci.}"
+          case "$digest" in sha256:*) ;; *) echo "reason=the main manifest's digest is not a sha256 (got '$digest')" >> "$GITHUB_OUTPUT"; echo "::warning::satellite-compat baseline NOT established: main's digest is '$digest'"; exit 0 ;; esac
+          if [ -z "$version" ] || ! [ "$run_number" -eq "$run_number" ] 2>/dev/null; then
+            echo "digest=$digest" >> "$GITHUB_OUTPUT"
+            echo "reason=mw-plugin-test:main ($digest) carries no 3.0.0-ci.<run> version tag, so the bundles that shipped with it cannot be located" >> "$GITHUB_OUTPUT"
+            echo "::warning::satellite-compat baseline NOT established: main ($digest) carries no ci version tag (tags: $(printf '%s' "$row" | jq -c .tags))"
+            exit 0
+          fi
+          { echo "digest=$digest"; echo "version=$version"; echo "run_number=$run_number"; } >> "$GITHUB_OUTPUT"
+          echo "baseline (the set the fleet is on): mw-plugin-test:main = $digest = $version, built by run #$run_number"
       - name: "Are there image-relevant changes since the newest published set?"
         id: relevance
         env:
@@ -2571,10 +2616,20 @@ jobs:
   #     an `if:` on a credential: `preflight` asserts the fleet-reader App RED, and a leg that
   #     cannot mint, pull or compile is a red leg. `fail-fast: false`, so one satellite's red does
   #     not cancel the others' measurement — the verdict is per satellite or it is not a verdict.
+  #   * RED MEANS "THIS BUILD BROKE IT" — and nothing else (maintainer, 2026-09-12: "why fail
+  #     compatibility?"). Each leg compiles the same content TWICE: against this run's set and
+  #     against the set the fleet is ON (`gate` records mw-plugin-test:main's digest and version
+  #     pre-promote; satellite-compat-image verifies GHCR holds it and re-uploads the four module
+  #     bundles the run that built it packed). compat-verdict.py then classifies per NodeType:
+  #     compiled at the baseline, not now → BROKE (the only red); failed at the baseline too, or
+  #     absent there → already broken, satellite side (green, advisory — its own daily run and
+  #     ci-main-red issue own it); no baseline → a refusal to judge (green, advisory, new-image
+  #     failures listed UNJUDGED). So the c88cd5d5c hazard — core reddened by a satellite's own
+  #     broken commit — is classified out, not tolerated. Both digests are in every verdict.
   #
-  # Budget: ubuntu-latest in a public repository — unbilled. Five parallel legs of ~2 min add
-  # ≤ ~3 min of wall time beside `plugins-bake` (which they do not wait for), and five concurrent
-  # jobs per build against the org's job ceiling. Narrowing the matrix to the satellites whose
+  # Budget: ubuntu-latest in a public repository — unbilled. Five parallel legs of ~2 min per
+  # compile, two compiles each (~4–5 min a leg), add ≤ ~5 min of wall time beside `plugins-bake`
+  # (which they do not wait for), and five concurrent jobs per build against the org's job ceiling. Narrowing the matrix to the satellites whose
   # NodeTypes reference the changed surface is the honest lever if that concurrency ever matters;
   # it is NOT done here — nothing in this run knows which satellite binds which surface, and a
   # matrix that guessed would skip exactly the leg it should have run.
@@ -2587,17 +2642,26 @@ jobs:
   # `plugins-bake-image` resolved on ACR; the legs then pull `ghcr.io/…@<that digest>` with
   # GITHUB_TOKEN. One set, one digest, two registries — verified, not assumed.
   satellite-compat-image:
-    name: "Compatibility: the tester on GHCR is this run's digest"
+    name: "Compatibility: this run's tester on GHCR, and the baseline set"
     needs: [preflight, gate, plugin-test-image, promote, plugins-bake-image]
     if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
+    # actions: read — `gh run download` of the BASELINE run's module-bundle artifacts (another
+    # run's artifacts need it; this run's do not). Job-level, in this workflow, so it demands
+    # nothing of any lane caller.
     permissions:
       contents: read
       packages: read
+      actions: read
     outputs:
       image: ${{ steps.mirror.outputs.image }}
       digest: ${{ steps.mirror.outputs.digest }}
+      # The baseline as VERIFIED here: the digest gate recorded, only if GHCR holds it AND the
+      # run that built it still has its four module bundles (re-uploaded below as
+      # `satellite-compat-baseline-bundles`). Empty = refuse to judge, with the reason.
+      baseline_digest: ${{ steps.baseline.outputs.digest }}
+      baseline_reason: ${{ steps.baseline.outputs.reason }}
     steps:
       - name: Log in to GHCR
         uses: docker/login-action@v4
@@ -2623,6 +2687,56 @@ jobs:
           echo "image=ghcr.io/$ns/mw-plugin-test" >> "$GITHUB_OUTPUT"
           echo "digest=$digest" >> "$GITHUB_OUTPUT"
           echo "satellite-compat tester: $ref = $digest (equal to ACR's)"
+      # ─────────── The baseline: verify it is pullable, and fetch the bundles that shipped with it ───────────
+      # `gate` recorded the digest and the run number pre-promote. Here: (1) GHCR must hold that
+      # digest (promote mirrored it when it was promoted); (2) the run that built it must still
+      # hold its four `module-bundle-*` artifacts (7-day retention) — the baseline compile must
+      # see the modules the fleet actually holds. Either missing = NO BASELINE, with the reason,
+      # and every leg refuses to judge; never a leg that compiles against half a baseline.
+      - name: "Establish the baseline set, or say why it cannot be"
+        id: baseline
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BASELINE_DIGEST: ${{ needs.gate.outputs.baseline_tester_digest }}
+          BASELINE_VERSION: ${{ needs.gate.outputs.baseline_tester_version }}
+          BASELINE_RUN_NUMBER: ${{ needs.gate.outputs.baseline_run_number }}
+          GATE_REASON: ${{ needs.gate.outputs.baseline_reason }}
+          NEW_DIGEST: ${{ steps.mirror.outputs.digest }}
+          IMAGE: ${{ steps.mirror.outputs.image }}
+          REPO: ${{ github.repository }}
+          WORKFLOW_FILE: main-cd.yml
+        run: |
+          set -euo pipefail
+          refuse() { echo "reason=$1" >> "$GITHUB_OUTPUT"; echo "::warning::satellite-compat baseline NOT established — every leg refuses to judge: $1"; exit 0; }
+          [ -n "$BASELINE_DIGEST" ] || refuse "${GATE_REASON:-gate recorded no baseline digest}"
+          [ -n "$BASELINE_RUN_NUMBER" ] || refuse "${GATE_REASON:-gate recorded no run number for the baseline $BASELINE_DIGEST}"
+          if [ "$BASELINE_DIGEST" = "$NEW_DIGEST" ]; then
+            refuse "the baseline digest equals this run's ($NEW_DIGEST) — main already pointed at this set before promote, so there is no PREVIOUS image to compare against"
+          fi
+          docker buildx imagetools inspect "$IMAGE@$BASELINE_DIGEST" --format '{{json .Manifest.Digest}}' >/dev/null \
+            || refuse "GHCR does not hold the baseline tester $BASELINE_DIGEST ($BASELINE_VERSION)"
+          run_id=$(gh api "repos/$REPO/actions/workflows/$WORKFLOW_FILE/runs?per_page=100" \
+            --jq "[.workflow_runs[] | select(.run_number == $BASELINE_RUN_NUMBER)] | .[0].id // empty") \
+            || refuse "could not list this workflow's runs to locate run #$BASELINE_RUN_NUMBER (the run that built $BASELINE_VERSION)"
+          [ -n "$run_id" ] || refuse "run #$BASELINE_RUN_NUMBER (the run that built $BASELINE_VERSION) is not among the last 100 runs of $WORKFLOW_FILE"
+          rm -rf baseline-bundles; mkdir -p baseline-bundles
+          gh run download "$run_id" -R "$REPO" -p 'module-bundle-*' -D baseline-bundles \
+            || refuse "run $run_id (#$BASELINE_RUN_NUMBER, $BASELINE_VERSION) has no downloadable module-bundle-* artifacts (expired, or that run never packed them)"
+          n=$(find baseline-bundles -name '*.module.nupkg' | wc -l | tr -d ' ')
+          [ "$n" -eq 4 ] || refuse "run $run_id (#$BASELINE_RUN_NUMBER) holds $n module bundle(s), not the 4 the satellites bind (AI, Markdown.Collaboration, Maps, Payments.Stripe)"
+          mkdir -p "$RUNNER_TEMP/baseline-bundles" && find baseline-bundles -name '*.module.nupkg' -exec cp {} "$RUNNER_TEMP/baseline-bundles/" \;
+          echo "digest=$BASELINE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "baseline set: $IMAGE@$BASELINE_DIGEST ($BASELINE_VERSION, run $run_id #$BASELINE_RUN_NUMBER) + 4 module bundles"
+      # Re-uploaded under THIS run so the reusable lane can take them by pattern with the runtime
+      # token — same-run artifacts need no extra scope in the lane.
+      - name: Hand the baseline bundles to the legs
+        if: ${{ steps.baseline.outputs.digest != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: satellite-compat-baseline-bundles
+          path: ${{ runner.temp }}/baseline-bundles/*.module.nupkg
+          retention-days: 1
+          if-no-files-found: error
 
   satellite-compat:
     name: "Compatibility: ${{ matrix.satellite }}'s NodeTypes compile against this set"
@@ -2672,6 +2786,18 @@ jobs:
       # being written by `plugins-bake` in parallel, and the bytes are the same by construction.
       module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration,Maps,Payments.Stripe}
       verdict-artifact: satellite-compat-${{ matrix.satellite }}
+      # 🚨 THE CONTROL (maintainer pushback, 2026-09-12: "why fail compatibility?"). A red compile
+      # alone cannot say which side moved. The same content is compiled a second time against the
+      # set the fleet is ON (gate's pre-promote record, verified by satellite-compat-image with the
+      # bundles that shipped with it), and compat-verdict.py classifies: compiled there and not now
+      # = THIS BUILD BROKE IT, the only red; failed there too = already broken, satellite side,
+      # green + advisory; no baseline = refusal to judge, green + advisory. So a red leg now means
+      # "core broke it", and c88cd5d5c's hazard — core reddened by a satellite's own broken
+      # commit — is classified out rather than merely tolerated.
+      judge-against-baseline: true
+      baseline-image-digest: ${{ needs.satellite-compat-image.outputs.baseline_digest }}
+      baseline-module-artifacts: satellite-compat-baseline-bundles
+      baseline-unavailable-reason: ${{ needs.satellite-compat-image.outputs.baseline_reason }}
     secrets:
       # GHCR takes any username with a token that can read the package; GITHUB_TOKEN can, because
       # promote pushed the mirror under it and the lane's job holds `packages: read`.
@@ -3120,12 +3246,12 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "### 🧩 Compatibility — every satellite's NodeTypes against \`${VERSION}\` (satellite-compat=${COMPAT_RESULT})"
+            echo "### 🧩 Compatibility — every satellite's NodeTypes against \`${VERSION}\`, judged against the set the fleet is on (satellite-compat=${COMPAT_RESULT})"
             echo ""
-            echo "| Satellite | Content | Verdict | NodeTypes | Breaks | Known debt |"
-            echo "|---|---|---|---:|---|---:|"
+            echo "| Satellite | Content | Verdict | NodeTypes | Types | Baseline → new |"
+            echo "|---|---|---|---:|---|---|"
           } >> "$GITHUB_STEP_SUMMARY"
-          red=0; unmeasured=0; redlist=""
+          red=0; unmeasured=0; redlist=""; advisory=""
           for sat in $SATELLITES; do
             f="$VERDICTS/satellite-compat-$sat/compile-check-verdict.json"
             if [ ! -f "$f" ]; then
@@ -3134,20 +3260,34 @@ jobs:
               echo "compatibility: $sat — NOT MEASURED (no verdict artifact; read that leg)"
               continue
             fi
-            fail=$(jq -r '.gate_fail' "$f")
+            verdict=$(jq -r '.verdict // (if .gate_fail then "broke" else "compatible" end)' "$f")
             csha=$(jq -r '.content.sha // "" | .[0:9]' "$f")
             types=$(jq -r '.types' "$f")
-            debt=$(jq -r '.known_debt | length' "$f")
-            breaks=$(jq -r --arg bt '`' '([.new_breaks[].type] + [.fp_drift[].type] + [.stale_allow[] | . + " (compiles now — remove from allow)"]) | map($bt + . + $bt) | join(", ")' "$f")
-            if [ "$fail" = "true" ]; then
-              red=$((red + 1)); redlist="${redlist:+$redlist, }$sat"
-              echo "| $sat | \`${csha:-?}\` | ❌ RED | $types | ${breaks:-?} | $debt |" >> "$GITHUB_STEP_SUMMARY"
-              echo "compatibility: $sat@${csha:-?} — RED against $VERSION: ${breaks:-?}"
-              jq -r '(.new_breaks + .fp_drift)[] | "    \(.type): \(.error)"' "$f"
-            else
-              echo "| $sat | \`${csha:-?}\` | ✅ compiles | $types | — | $debt |" >> "$GITHUB_STEP_SUMMARY"
-              echo "compatibility: $sat@${csha:-?} — compiles against $VERSION ($types NodeType(s), $debt known-debt)"
-            fi
+            images=$(jq -r --arg bt '`' '"\($bt)\((.images.baseline // "")[7:19] | if . == "" then "—" else . end)\($bt) → \($bt)\((.images.new // "")[7:19])\($bt)"' "$f")
+            case "$verdict" in
+              broke)
+                red=$((red + 1)); redlist="${redlist:+$redlist, }$sat"
+                list=$(jq -r --arg bt '`' '[.broke[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | 🔴 **THIS BUILD BROKE IT** | $types | ${list:-?} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — BROKEN BY THIS BUILD ($VERSION): ${list:-?}"
+                jq -r '.broke[] | "    \(.type): \(.error)"' "$f" ;;
+              already-broken)
+                advisory="${advisory:+$advisory; }$sat"
+                list=$(jq -r --arg bt '`' '[.already_broken[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | 🟡 already broken (satellite side, advisory) | $types | ${list:-?} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — ALREADY BROKEN on the baseline too (satellite side; its own daily run / ci-main-red issue own it): ${list:-?}"
+                jq -r '.already_broken[] | "    \(.type) (baseline: \(.baseline)): \(.error)"' "$f" ;;
+              no-baseline)
+                advisory="${advisory:+$advisory; }$sat (no baseline)"
+                reason=$(jq -r '.images.baseline_reason // .baseline_reason // "?"' "$f")
+                list=$(jq -r --arg bt '`' '[.unjudged[].type] | map($bt + . + $bt) | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | ⚪ NO BASELINE — refused to judge: $reason | $types | ${list:-—} (unjudged) | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — could not establish a baseline ($reason); ${list:-no} new-image failure(s) left UNJUDGED" ;;
+              *)
+                stale=$(jq -r --arg bt '`' '[.stale_allow[]] | map($bt + . + $bt + " (compiles now — remove from allow)") | join(", ")' "$f")
+                echo "| $sat | \`${csha:-?}\` | ✅ compatible | $types | ${stale:-—} | $images |" >> "$GITHUB_STEP_SUMMARY"
+                echo "compatibility: $sat@${csha:-?} — compatible with $VERSION ($types NodeType(s))" ;;
+            esac
           done
           case "$COMPAT_RESULT" in
             success|failure) ;;
@@ -3162,16 +3302,21 @@ jobs:
           fi
           echo "compat_red=$red" >> "$GITHUB_OUTPUT"
           echo "compat_red_list=$redlist" >> "$GITHUB_OUTPUT"
+          if [ -n "$advisory" ]; then
+            echo "- 🟡 advisory (not this build's): $advisory" >> "$GITHUB_STEP_SUMMARY"
+          fi
           if [ "$red" -gt 0 ]; then
             # 🚨 THE CONTRADICTION, STATED. A red leg fails `satellite-compat` (no continue-on-error,
             # by rule), so the RUN's conclusion is `failure` — while promote, notify, bake and seal
             # all completed. The run's colour then says COMPATIBILITY, not shipping. Said first,
             # here and in the run's headline below, so nobody reads "CD failed" as "nothing shipped".
-            echo "🚨 **DELIVERY COMPLETED** — this run is red because $red satellite(s) failed compatibility: ${redlist}. Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
-            echo "- The set IS published and every instance gates itself; the red is \`satellite-compat\`'s own and is filed on the \`ci-failure\` issue. Fix lands in the SATELLITE (or core, if the break is the platform's) — the daily rebuild will not repair it on its own." >> "$GITHUB_STEP_SUMMARY"
-            echo "🚨 DELIVERY COMPLETED — this run is red because $red satellite(s) failed compatibility: ${redlist}. Nothing failed to ship."
+            # And since the baseline control, red means ONE thing: these types compiled against the
+            # set the fleet is on and do not against this one — core's side, by measurement.
+            echo "🚨 **DELIVERY COMPLETED** — this run is red because this core build BROKE $red satellite(s): ${redlist} (previous image compiled, new image does not). Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
+            echo "- The set IS published and every instance gates itself; the red is \`satellite-compat\`'s own and is filed on the \`ci-failure\` issue. The break is on CORE's side by measurement: fix the surface in core (or, if the move was intended, land the satellite's adaptation) — the daily rebuild will not repair it on its own." >> "$GITHUB_STEP_SUMMARY"
+            echo "🚨 DELIVERY COMPLETED — this run is red because this core build BROKE $red satellite(s): ${redlist} (previous image compiled, new image does not). Nothing failed to ship."
           else
-            echo "compatibility: every satellite compiles against $VERSION"
+            echo "compatibility: no satellite was broken by this build ($VERSION)${advisory:+; advisories: $advisory}"
           fi
 
       # Make the outcome unmissable on the run page. A 3-second success and a 20-minute delivery
@@ -3207,7 +3352,7 @@ jobs:
           elif [ -n "$DEFERRED_TO" ]; then
             echo "### ⏳ DEFERRED for \`${SHORT}\` — run [${DEFERRED_TO}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${DEFERRED_TO}) is \`${DEFERRED_STATUS}\` on this commit since ${DEFERRED_SINCE}. The image set is incomplete because that publication is still creating it — a correct no-op, not a stuck delivery (#3513)." >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ] && [ "${COMPAT_RED:-0}" != "0" ]; then
-            echo "### 🚨 DELIVERY COMPLETED — this run is red because ${COMPAT_RED} satellite(s) failed compatibility: ${COMPAT_RED_LIST}. Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
+            echo "### 🚨 DELIVERY COMPLETED — this run is red because this core build BROKE ${COMPAT_RED} satellite(s): ${COMPAT_RED_LIST} (previous image compiled, new image does not). Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
             echo "✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON}) — the run's colour says COMPATIBILITY, not shipping; see the Compatibility table above and the \`ci-failure\` issue." >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ]; then
             echo "### ✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
@@ -3270,14 +3415,17 @@ jobs:
           for f in "$VERDICTS"/satellite-compat-*/compile-check-verdict.json; do
             [ -f "$f" ] || continue
             sat=$(basename "$(dirname "$f")"); sat="${sat#satellite-compat-}"
-            [ "$(jq -r '.gate_fail' "$f")" = "true" ] || continue
+            # Only BROKE lines: an already-broken satellite or an unestablished baseline is an
+            # advisory on the run page, never a line on an alert about THIS build.
+            [ "$(jq -r '.verdict // (if .gate_fail then "broke" else "" end)' "$f")" = "broke" ] || continue
             nred=$((nred + 1)); redlist="${redlist:+$redlist, }$sat"
             csha=$(jq -r '.content.sha // "" | .[0:9]' "$f")
-            first=$(jq -r --arg bt "$bt" '(.new_breaks + .fp_drift + [.stale_allow[] | {type: ., error: "compiles now — remove it from scripts/compile-check.allow"}]) | .[:3] | map($bt + .type + $bt + " — " + .error) | join("; ")' "$f")
-            compat=$(printf '%s\n* **%s** (main @ %s%s%s) does not compile against %s%s%s: %s' "$compat" "$sat" "$bt" "${csha:-?}" "$bt" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
+            base=$(jq -r '.images.baseline // "" | .[7:19]' "$f")
+            first=$(jq -r --arg bt "$bt" '.broke | .[:3] | map($bt + .type + $bt + " — " + .error) | join("; ")' "$f")
+            compat=$(printf '%s\n* **%s** (main @ %s%s%s): compiled against the previous image (%s%s%s) and does not against %s%s%s: %s' "$compat" "$sat" "$bt" "${csha:-?}" "$bt" "$bt" "${base:-?}" "$bt" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
           done
           if [ -n "$compat" ]; then
-            compat=$(printf '\n\n🚨 **DELIVERY COMPLETED** — this run is red because %s satellite(s) failed compatibility: %s. Nothing failed to ship.\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite still compiles against it. The fix lands in the SATELLITE (its NodeTypes, or its allow-file ratchet), or in core if the platform broke a surface it should not have — the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$nred" "$redlist" "$COMPAT_RESULT" "$compat")
+            compat=$(printf '\n\n🚨 **DELIVERY COMPLETED** — this run is red because this core build BROKE %s satellite(s): %s (previous image compiled, new image does not). Nothing failed to ship.\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite that compiled against the set the fleet is on no longer compiles against this one. That is CORE'"'"'s side by measurement: fix the surface in core, or — if the move was intended — land the satellite'"'"'s adaptation; the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$nred" "$redlist" "$COMPAT_RESULT" "$compat")
           fi
           # Ensure the label exists (--force = update-or-create, idempotent). Non-fatal for the
           # same reason as in `gate`: this is the ALERT path, so a 503 here must not swallow the
@@ -3292,7 +3440,7 @@ jobs:
 
           * an IMAGE job / promote / verify-images: no complete image set was published. Publication is all-or-nothing, so every self-updating install stays on the PREVIOUS image until a CD run promotes the full set.
           * preflight / notify-platform-update: the images may be fine, but the release EVENT did not reach the control instance, so no node repo re-bakes against this commit until its own schedule poll (#2235). Read the job's ::error:: line - it names what to provision or what refused the delivery.
-          * satellite-compat (a matrix leg) / satellite-compat-image: the set IS published and the release event WAS sent - what failed is the per-build measurement that a satellite's NodeTypes still compile against it (the counterweight to the daily rebuild, 2026-09-12). A red leg names the satellite; the lines under Compatibility below name the types. No image and no publication is missing.
+          * satellite-compat (a matrix leg) / satellite-compat-image: the set IS published and the release event WAS sent - what failed is the per-build measurement that a satellite's NodeTypes still compile against it (the counterweight to the daily rebuild, 2026-09-12). A red leg means THIS BUILD BROKE that satellite: its types compiled against the set the fleet is on and do not against this one (a satellite that was already broken, or an unestablished baseline, is an advisory on the run page, never a red). The lines under Compatibility below name the types. No image and no publication is missing.
 
           The hourly reconciler will re-attempt main's HEAD on its own (bounded at 3 attempts per commit, logged here); you do NOT need to force a merge to trigger delivery. This issue CLOSES ITSELF when a CD run reports a successful heal (#3176) - a later failure files a fresh issue rather than appending here, so this one's title and age stay true to its own cause.${compat}"
           existing=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -3107,6 +3107,7 @@ jobs:
           pattern: satellite-compat-*
           path: ${{ runner.temp }}/satellite-compat
       - name: "Compatibility: every satellite's NodeTypes compile against this set"
+        id: compat
         if: ${{ always() && needs.gate.outputs.publish == 'true' }}
         env:
           COMPAT_RESULT: ${{ needs.satellite-compat.result }}
@@ -3124,7 +3125,7 @@ jobs:
             echo "| Satellite | Content | Verdict | NodeTypes | Breaks | Known debt |"
             echo "|---|---|---|---:|---|---:|"
           } >> "$GITHUB_STEP_SUMMARY"
-          red=0; unmeasured=0
+          red=0; unmeasured=0; redlist=""
           for sat in $SATELLITES; do
             f="$VERDICTS/satellite-compat-$sat/compile-check-verdict.json"
             if [ ! -f "$f" ]; then
@@ -3139,7 +3140,7 @@ jobs:
             debt=$(jq -r '.known_debt | length' "$f")
             breaks=$(jq -r --arg bt '`' '([.new_breaks[].type] + [.fp_drift[].type] + [.stale_allow[] | . + " (compiles now — remove from allow)"]) | map($bt + . + $bt) | join(", ")' "$f")
             if [ "$fail" = "true" ]; then
-              red=$((red + 1))
+              red=$((red + 1)); redlist="${redlist:+$redlist, }$sat"
               echo "| $sat | \`${csha:-?}\` | ❌ RED | $types | ${breaks:-?} | $debt |" >> "$GITHUB_STEP_SUMMARY"
               echo "compatibility: $sat@${csha:-?} — RED against $VERSION: ${breaks:-?}"
               jq -r '(.new_breaks + .fp_drift)[] | "    \(.type): \(.error)"' "$f"
@@ -3159,9 +3160,16 @@ jobs:
             echo "::error::satellite-compat reports success but $unmeasured satellite(s) above have no verdict artifact — a leg that measured nothing must not read as a pass. Either the matrix and the SATELLITES register in this step diverged, or a leg uploaded no report."
             exit 1
           fi
+          echo "compat_red=$red" >> "$GITHUB_OUTPUT"
+          echo "compat_red_list=$redlist" >> "$GITHUB_OUTPUT"
           if [ "$red" -gt 0 ]; then
-            echo "- ❌ **$red satellite(s) do not compile against this set.** The set IS published and every instance gates itself; the red is \`satellite-compat\`'s own and is filed on the \`ci-failure\` issue. Fix lands in the SATELLITE (or core, if the break is the platform's) — the daily rebuild will not repair it on its own." >> "$GITHUB_STEP_SUMMARY"
-            echo "compatibility: $red satellite(s) RED — see the satellite-compat legs; this verdict lists, it does not re-fail"
+            # 🚨 THE CONTRADICTION, STATED. A red leg fails `satellite-compat` (no continue-on-error,
+            # by rule), so the RUN's conclusion is `failure` — while promote, notify, bake and seal
+            # all completed. The run's colour then says COMPATIBILITY, not shipping. Said first,
+            # here and in the run's headline below, so nobody reads "CD failed" as "nothing shipped".
+            echo "🚨 **DELIVERY COMPLETED** — this run is red because $red satellite(s) failed compatibility: ${redlist}. Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
+            echo "- The set IS published and every instance gates itself; the red is \`satellite-compat\`'s own and is filed on the \`ci-failure\` issue. Fix lands in the SATELLITE (or core, if the break is the platform's) — the daily rebuild will not repair it on its own." >> "$GITHUB_STEP_SUMMARY"
+            echo "🚨 DELIVERY COMPLETED — this run is red because $red satellite(s) failed compatibility: ${redlist}. Nothing failed to ship."
           else
             echo "compatibility: every satellite compiles against $VERSION"
           fi
@@ -3181,6 +3189,10 @@ jobs:
           DEFERRED_TO: ${{ steps.verdict.outputs.deferred_to }}
           DEFERRED_STATUS: ${{ steps.verdict.outputs.deferred_status }}
           DEFERRED_SINCE: ${{ steps.verdict.outputs.deferred_since }}
+          # From the Compatibility step above (2026-09-12): a red satellite leg reds the RUN while
+          # delivery completed, so the headline must say which of the two the colour means.
+          COMPAT_RED: ${{ steps.compat.outputs.compat_red }}
+          COMPAT_RED_LIST: ${{ steps.compat.outputs.compat_red_list }}
         run: |
           # 🚨 NO-OP is keyed on the gate having been SKIPPED — never on an empty reason. An empty
           # reason is ALSO what a gate that errored, was cancelled, or produced no outputs looks
@@ -3194,6 +3206,9 @@ jobs:
           # IS publishing it is the whole content of MeshWeaver#3513's third verdict.
           elif [ -n "$DEFERRED_TO" ]; then
             echo "### ⏳ DEFERRED for \`${SHORT}\` — run [${DEFERRED_TO}](${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${DEFERRED_TO}) is \`${DEFERRED_STATUS}\` on this commit since ${DEFERRED_SINCE}. The image set is incomplete because that publication is still creating it — a correct no-op, not a stuck delivery (#3513)." >> "$GITHUB_STEP_SUMMARY"
+          elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ] && [ "${COMPAT_RED:-0}" != "0" ]; then
+            echo "### 🚨 DELIVERY COMPLETED — this run is red because ${COMPAT_RED} satellite(s) failed compatibility: ${COMPAT_RED_LIST}. Nothing failed to ship." >> "$GITHUB_STEP_SUMMARY"
+            echo "✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON}) — the run's colour says COMPATIBILITY, not shipping; see the Compatibility table above and the \`ci-failure\` issue." >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ] && [ "$PROMOTE_RESULT" = "success" ]; then
             echo "### ✅ PUBLISHED an image set for \`${SHORT}\` (reason: ${REASON})" >> "$GITHUB_STEP_SUMMARY"
           elif [ "$PUBLISH" = "true" ]; then
@@ -3251,17 +3266,18 @@ jobs:
           # One line per satellite whose verdict says RED: the satellite, the set, the first three
           # failing types with their first error. Composed with printf, never a multi-line literal —
           # a body line at column 1 would end this block scalar (same reasoning as `gate`'s ledger).
-          compat=""; bt='`'
+          compat=""; bt='`'; nred=0; redlist=""
           for f in "$VERDICTS"/satellite-compat-*/compile-check-verdict.json; do
             [ -f "$f" ] || continue
             sat=$(basename "$(dirname "$f")"); sat="${sat#satellite-compat-}"
             [ "$(jq -r '.gate_fail' "$f")" = "true" ] || continue
+            nred=$((nred + 1)); redlist="${redlist:+$redlist, }$sat"
             csha=$(jq -r '.content.sha // "" | .[0:9]' "$f")
             first=$(jq -r --arg bt "$bt" '(.new_breaks + .fp_drift + [.stale_allow[] | {type: ., error: "compiles now — remove it from scripts/compile-check.allow"}]) | .[:3] | map($bt + .type + $bt + " — " + .error) | join("; ")' "$f")
             compat=$(printf '%s\n* **%s** (main @ %s%s%s) does not compile against %s%s%s: %s' "$compat" "$sat" "$bt" "${csha:-?}" "$bt" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
           done
           if [ -n "$compat" ]; then
-            compat=$(printf '\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite still compiles against it. The fix lands in the SATELLITE (its NodeTypes, or its allow-file ratchet), or in core if the platform broke a surface it should not have — the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$COMPAT_RESULT" "$compat")
+            compat=$(printf '\n\n🚨 **DELIVERY COMPLETED** — this run is red because %s satellite(s) failed compatibility: %s. Nothing failed to ship.\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite still compiles against it. The fix lands in the SATELLITE (its NodeTypes, or its allow-file ratchet), or in core if the platform broke a surface it should not have — the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$nred" "$redlist" "$COMPAT_RESULT" "$compat")
           fi
           # Ensure the label exists (--force = update-or-create, idempotent). Non-fatal for the
           # same reason as in `gate`: this is the ALERT path, so a 503 here must not swallow the

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2643,6 +2643,11 @@ jobs:
             repository: Systemorph/MeshWeaver.Crm
           - satellite: MeshWeaver.Reinsurance
             repository: Systemorph/MeshWeaver.Reinsurance
+          # Education runs no compile-check on its own PRs and carries no allow file, so its leg
+          # judges the whole tree with nothing grandfathered. MEASURED before it was listed, not
+          # predicted (2026-09-12, main 7c106210b, the lane's exact script path against tester
+          # sha256:1ad82ff0… + this set's four bundles): 13 NodeTypes, 13 clean, 0 debt, 7 s —
+          # and the same harness reds by name on a planted break, so the green is a reading.
           - satellite: MeshWeaver.Education
             repository: Systemorph/MeshWeaver.Education
           - satellite: MeshWeaver.Manufacturing
@@ -2656,7 +2661,7 @@ jobs:
       # The satellite's own default branch — what its daily run would bake. Deliberately NOT a sha
       # this run resolved: the satellites are not part of the image set, so there is no set identity
       # to keep consistent (contrast the Plugins checkouts, pinned to gate's plugins_sha), and each
-      # leg checks out exactly once.
+      # leg checks out exactly once and RECORDS the sha it judged in its verdict artifact.
       content-ref: main
       platform-ref: ${{ needs.gate.outputs.sha }}
       test-image: ${{ needs.satellite-compat-image.outputs.image }}:${{ needs.plugin-test-image.outputs.version }}
@@ -3116,30 +3121,31 @@ jobs:
           {
             echo "### 🧩 Compatibility — every satellite's NodeTypes against \`${VERSION}\` (satellite-compat=${COMPAT_RESULT})"
             echo ""
-            echo "| Satellite | Verdict | NodeTypes | Breaks | Known debt |"
-            echo "|---|---|---:|---|---:|"
+            echo "| Satellite | Content | Verdict | NodeTypes | Breaks | Known debt |"
+            echo "|---|---|---|---:|---|---:|"
           } >> "$GITHUB_STEP_SUMMARY"
           red=0; unmeasured=0
           for sat in $SATELLITES; do
             f="$VERDICTS/satellite-compat-$sat/compile-check-verdict.json"
             if [ ! -f "$f" ]; then
               unmeasured=$((unmeasured + 1))
-              echo "| $sat | ⚪ NOT MEASURED — no verdict artifact | | | |" >> "$GITHUB_STEP_SUMMARY"
+              echo "| $sat | | ⚪ NOT MEASURED — no verdict artifact | | | |" >> "$GITHUB_STEP_SUMMARY"
               echo "compatibility: $sat — NOT MEASURED (no verdict artifact; read that leg)"
               continue
             fi
             fail=$(jq -r '.gate_fail' "$f")
+            csha=$(jq -r '.content.sha // "" | .[0:9]' "$f")
             types=$(jq -r '.types' "$f")
             debt=$(jq -r '.known_debt | length' "$f")
             breaks=$(jq -r --arg bt '`' '([.new_breaks[].type] + [.fp_drift[].type] + [.stale_allow[] | . + " (compiles now — remove from allow)"]) | map($bt + . + $bt) | join(", ")' "$f")
             if [ "$fail" = "true" ]; then
               red=$((red + 1))
-              echo "| $sat | ❌ RED | $types | ${breaks:-?} | $debt |" >> "$GITHUB_STEP_SUMMARY"
-              echo "compatibility: $sat — RED against $VERSION: ${breaks:-?}"
+              echo "| $sat | \`${csha:-?}\` | ❌ RED | $types | ${breaks:-?} | $debt |" >> "$GITHUB_STEP_SUMMARY"
+              echo "compatibility: $sat@${csha:-?} — RED against $VERSION: ${breaks:-?}"
               jq -r '(.new_breaks + .fp_drift)[] | "    \(.type): \(.error)"' "$f"
             else
-              echo "| $sat | ✅ compiles | $types | — | $debt |" >> "$GITHUB_STEP_SUMMARY"
-              echo "compatibility: $sat — compiles against $VERSION ($types NodeType(s), $debt known-debt)"
+              echo "| $sat | \`${csha:-?}\` | ✅ compiles | $types | — | $debt |" >> "$GITHUB_STEP_SUMMARY"
+              echo "compatibility: $sat@${csha:-?} — compiles against $VERSION ($types NodeType(s), $debt known-debt)"
             fi
           done
           case "$COMPAT_RESULT" in
@@ -3250,8 +3256,9 @@ jobs:
             [ -f "$f" ] || continue
             sat=$(basename "$(dirname "$f")"); sat="${sat#satellite-compat-}"
             [ "$(jq -r '.gate_fail' "$f")" = "true" ] || continue
+            csha=$(jq -r '.content.sha // "" | .[0:9]' "$f")
             first=$(jq -r --arg bt "$bt" '(.new_breaks + .fp_drift + [.stale_allow[] | {type: ., error: "compiles now — remove it from scripts/compile-check.allow"}]) | .[:3] | map($bt + .type + $bt + " — " + .error) | join("; ")' "$f")
-            compat=$(printf '%s\n* **%s** does not compile against %s%s%s: %s' "$compat" "$sat" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
+            compat=$(printf '%s\n* **%s** (main @ %s%s%s) does not compile against %s%s%s: %s' "$compat" "$sat" "$bt" "${csha:-?}" "$bt" "$bt" "${VERSION:-this set}" "$bt" "${first:-(see the leg)}")
           done
           if [ -n "$compat" ]; then
             compat=$(printf '\n\n**Compatibility** (satellite-compat=%s) — the set IS published and every instance gates itself; what is red is the measurement that a satellite still compiles against it. The fix lands in the SATELLITE (its NodeTypes, or its allow-file ratchet), or in core if the platform broke a surface it should not have — the daily rebuild will not repair it on its own. Triage: the control instance, from the failing types below.%s' "$COMPAT_RESULT" "$compat")

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -130,6 +130,44 @@ on:
         required: false
         type: string
         default: ''
+      judge-against-baseline:
+        description: >-
+          When true, a red NEW-image compile is not the verdict — it is one of two readings. The
+          content is compiled a second time against `baseline-image-digest` (the set the fleet is
+          currently on) with `baseline-module-artifacts`, and `compat-verdict.py` classifies each
+          failing type: compiled at the baseline and not now = THIS BUILD BROKE IT (the only red);
+          failed at the baseline too, or did not exist there = already broken, satellite side
+          (green, advisory); no baseline = a refusal to judge (green, advisory, never attributed).
+          The platform's satellite-compat lane sets this; a node repo checking its own PR leaves it
+          false and keeps the plain gate (a red compile is red).
+        required: false
+        type: boolean
+        default: false
+      baseline-image-digest:
+        description: >-
+          The PREVIOUS platform image (digest) — what the fleet runs today, recorded by the caller
+          BEFORE its promote moved the pointer. Empty with judge-against-baseline means the
+          baseline could not be established; say why in baseline-unavailable-reason.
+        required: false
+        type: string
+        default: ''
+      baseline-module-artifacts:
+        description: >-
+          Artifact-name pattern of the module bundles that SHIPPED WITH the baseline image (the
+          previous run's `module-bundle-*`, re-uploaded by the caller in THIS run). The baseline
+          compile must see the modules the fleet actually holds, never this run's — a new bundle
+          against the old framework would misattribute a Plugins-side move as "already broken".
+        required: false
+        type: string
+        default: ''
+      baseline-unavailable-reason:
+        description: >-
+          Why no baseline could be established, when baseline-image-digest is empty and
+          judge-against-baseline is true. Printed in the verdict; a refusal is worth exactly what
+          its reason says.
+        required: false
+        type: string
+        default: ''
       upstream-seed:
         description: >-
           The upstream source(s) whose SEALED publication for this image's framework identity
@@ -402,6 +440,7 @@ jobs:
           MW_REPO_ROOT: ${{ github.workspace }}/repo
           MW_ALLOW_FILE: ${{ github.workspace }}/repo/scripts/compile-check.allow
           VERDICT_ARTIFACT: ${{ inputs.verdict-artifact }}
+          JUDGE: ${{ inputs.judge-against-baseline }}
           MW_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
           MW_CONTENT_SHA: ${{ steps.content.outputs.sha }}
         # --refs points at the assemblies unpacked from the platform image — a FLAT directory;
@@ -412,8 +451,102 @@ jobs:
         # platform-ref fails here on the unknown flag — RED, not a silent artifact-less pass.
         run: |
           set -euo pipefail
-          python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs \
-            ${VERDICT_ARTIFACT:+--report "$RUNNER_TEMP/compile-check-verdict.json"}
+          if [ "${JUDGE:-false}" = "true" ]; then
+            # One of TWO readings (see judge-against-baseline): report to the judge's input, and
+            # let the exit code through as a fact — the judge below decides the leg's colour.
+            mkdir -p "$RUNNER_TEMP/compat"
+            if python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs --report "$RUNNER_TEMP/compat/new.json"; then
+              echo "new image: the compile gate is green"
+            else
+              echo "new image: the compile gate exited $? — judged against the baseline below, not final here"
+            fi
+          else
+            python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs \
+              ${VERDICT_ARTIFACT:+--report "$RUNNER_TEMP/compile-check-verdict.json"}
+          fi
+      # ───────────── THE CONTROL: the same content against the PREVIOUS image ─────────────
+      # A red compile alone cannot say which side moved. The baseline reading — the image the
+      # fleet is on, with the module bundles that shipped with it — is what turns "does not
+      # compile" into "this build broke it" or "was already broken" (compat-verdict.py's header).
+      - name: Take the BASELINE's framework assemblies from the previous image
+        if: ${{ inputs.judge-against-baseline && inputs.baseline-image-digest != '' }}
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+          BASELINE_DIGEST: ${{ inputs.baseline-image-digest }}
+        run: |
+          set -euo pipefail
+          IMAGE="${TEST_IMAGE%%:*}@${BASELINE_DIGEST}"
+          docker pull -q "$IMAGE"
+          id=$(docker create "$IMAGE")
+          mkdir -p refs-baseline/shared-frameworks
+          docker cp "$id:/app/." refs-baseline/ >/dev/null
+          docker cp "$id:/usr/share/dotnet/shared/." refs-baseline/shared-frameworks/ >/dev/null
+          docker rm -v "$id" >/dev/null
+          echo "baseline framework assemblies: $(find refs-baseline -maxdepth 1 -name 'MeshWeaver.*.dll' | wc -l) from /app of $IMAGE"
+      - name: Download the baseline's module bundles
+        if: ${{ inputs.judge-against-baseline && inputs.baseline-image-digest != '' && inputs.baseline-module-artifacts != '' }}
+        uses: actions/download-artifact@v8
+        with:
+          pattern: ${{ inputs.baseline-module-artifacts }}
+          path: ${{ runner.temp }}/ref-bundles-baseline
+          merge-multiple: true
+      - name: Add the baseline's modules to the baseline reference set
+        if: ${{ inputs.judge-against-baseline && inputs.baseline-image-digest != '' && inputs.baseline-module-artifacts != '' }}
+        run: |
+          set -euo pipefail
+          BUNDLES="${RUNNER_TEMP:-/tmp}/ref-bundles-baseline"
+          shopt -s nullglob
+          added=0
+          for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
+            u="${RUNNER_TEMP:-/tmp}/refunpack-baseline-$(basename "$b")"; rm -rf "$u"; mkdir -p "$u"
+            unzip -o -q "$b" -d "$u"
+            [ -d "$u/meshweaver/modules" ] || { echo "::error::$(basename "$b"): no meshweaver/modules/ in the baseline bundle"; exit 1; }
+            cp -R "$u"/meshweaver/modules/*.dll refs-baseline/ 2>/dev/null || true
+            added=$((added + 1))
+          done
+          [ "$added" -gt 0 ] || { echo "::error::baseline-module-artifacts matched nothing — a baseline compiled against an image-only set would fail every module-binding type and read as 'already broken'"; exit 1; }
+          echo "baseline reference set topped up from $added bundle(s): $(find refs-baseline -name 'MeshWeaver.*.dll' | wc -l) assemblies"
+      - name: Compile-check every NodeType against the BASELINE image
+        if: ${{ inputs.judge-against-baseline && inputs.baseline-image-digest != '' }}
+        working-directory: repo
+        env:
+          MW_REPO_ROOT: ${{ github.workspace }}/repo
+          MW_ALLOW_FILE: ${{ github.workspace }}/repo/scripts/compile-check.allow
+          MW_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
+          MW_CONTENT_SHA: ${{ steps.content.outputs.sha }}
+        # The baseline's exit code is a READING too: a red here is the satellite's state on the set
+        # it already runs, which is the judge's second input, never this leg's colour.
+        run: |
+          set -euo pipefail
+          if python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs-baseline --report "$RUNNER_TEMP/compat/baseline.json"; then
+            echo "baseline image: the compile gate is green"
+          else
+            echo "baseline image: the compile gate exited $? — recorded as the baseline reading"
+          fi
+      # 🚨 THE JUDGE decides the leg's colour: red iff a type compiled at the baseline and does not
+      # now. Fetched at the pinned platform ref like compile-check.py; a caller naming
+      # judge-against-baseline against a platform-ref older than the judge fails here RED.
+      - name: "Judge: did THIS build break it, or was it already broken?"
+        if: ${{ inputs.judge-against-baseline }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLATFORM_REF: ${{ inputs.platform-ref }}
+          NEW_DIGEST: ${{ inputs.image-digest }}
+          BASELINE_DIGEST: ${{ inputs.baseline-image-digest }}
+          BASELINE_REASON: ${{ inputs.baseline-unavailable-reason }}
+        run: |
+          set -euo pipefail
+          gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compat-verdict.py?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$RUNNER_TEMP/compat-verdict.py" \
+            || { echo "::error::could not fetch .github/scripts/compat-verdict.py at ${PLATFORM_REF} from Systemorph/MeshWeaver — judge-against-baseline needs a platform ref that carries the judge"; exit 1; }
+          head -c 400 "$RUNNER_TEMP/compat-verdict.py" | grep -q "compat-verdict" || { echo "::error::the fetched compat-verdict.py at ${PLATFORM_REF} does not look like the judge"; exit 1; }
+          python3 "$RUNNER_TEMP/compat-verdict.py" --self-test
+          if [ -n "$BASELINE_DIGEST" ]; then
+            python3 "$RUNNER_TEMP/compat-verdict.py" --new "$RUNNER_TEMP/compat/new.json" --baseline "$RUNNER_TEMP/compat/baseline.json" \
+              --new-digest "$NEW_DIGEST" --baseline-digest "$BASELINE_DIGEST" --out "$RUNNER_TEMP/compile-check-verdict.json"
+          else
+            python3 "$RUNNER_TEMP/compat-verdict.py" --new "$RUNNER_TEMP/compat/new.json" \
+              --new-digest "$NEW_DIGEST" --baseline-reason "${BASELINE_REASON:-no baseline image was supplied}" --out "$RUNNER_TEMP/compile-check-verdict.json"
+          fi
       # 🚨 `always()` so a RED gate uploads its verdict too — that is the whole point of the
       # artifact — and `if-no-files-found: error` so a run that died before writing one fails
       # here rather than handing the consumer nothing to read. This is a reporter riding a

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -220,6 +220,12 @@ jobs:
           ref: ${{ inputs.content-ref || github.sha }}
           token: ${{ steps.content-token.outputs.token || github.token }}
           path: repo
+      # 🚨 The CONTENT commit, resolved once and recorded in the verdict. `content-ref` may be a
+      # branch (the platform passes each satellite's `main`); the verdict is a fact about ONE tree,
+      # so it names the sha — never "main", which has moved by the time anyone reads it.
+      - name: Resolve the content commit
+        id: content
+        run: echo "sha=$(git -C repo rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -396,6 +402,8 @@ jobs:
           MW_REPO_ROOT: ${{ github.workspace }}/repo
           MW_ALLOW_FILE: ${{ github.workspace }}/repo/scripts/compile-check.allow
           VERDICT_ARTIFACT: ${{ inputs.verdict-artifact }}
+          MW_CONTENT_REPOSITORY: ${{ inputs.content-repository || github.repository }}
+          MW_CONTENT_SHA: ${{ steps.content.outputs.sha }}
         # --refs points at the assemblies unpacked from the platform image — a FLAT directory;
         # compile-check.py globs it recursively, dedupes by filename, and compiles each
         # NodeType's resolved source-set. The script is the PLATFORM's, fetched above.

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -36,6 +36,15 @@ name: Node repo compile-check (reusable)
 #     secrets:
 #       acr-username: ${{ secrets.ACR_USERNAME }}
 #       acr-password: ${{ secrets.ACR_PASSWORD }}
+#
+# The SECOND caller shape (MeshWeaver, 2026-09-12): the platform's own CD points this lane at a
+# satellite's content — `content-repository: Systemorph/MeshWeaver.<X>`, `content-ref: main`, the
+# tester at THIS run's digest, this run's module bundles as `module-artifacts`, and a
+# `verdict-artifact` so the run can relay WHICH satellite broke on WHICH types. That is the
+# per-build counterweight to the fleet's daily rebuild (satellites rebuild once a day, not per
+# platform build): every core build still MEASURES compatibility, cheaply, so a break is known
+# within the hour rather than at 03:00 or on a portal at self-update. A node repo calling this lane
+# with no content-repository behaves exactly as before.
 
 on:
   workflow_call:
@@ -93,6 +102,34 @@ on:
         required: false
         type: string
         default: main
+      content-repository:
+        description: >-
+          The repository whose NodeTypes are compile-checked. Empty = the caller (every node repo
+          checking its own content — the original shape). The platform's CD sets it to each
+          satellite in turn (its `satellite-compat` matrix), so every core build measures every
+          satellite against the set it just promoted. With it set, `content-app-id` /
+          `content-app-private-key` are REQUIRED and asserted RED before the checkout: the caller's
+          GITHUB_TOKEN cannot read another repository.
+        required: false
+        type: string
+        default: ''
+      content-ref:
+        description: >-
+          The ref of content-repository to check. Empty = the caller's own commit. The platform's
+          CD passes the satellite's default branch — what that satellite's own daily run would bake.
+        required: false
+        type: string
+        default: ''
+      verdict-artifact:
+        description: >-
+          When set, the gate's verdict is ALSO written as JSON (compile-check.py --report) and
+          uploaded under this artifact name — for a caller that has to RELAY the result rather than
+          read this job's log (a matrix of these calls has no steps of its own). Uploaded on red as
+          well as green; a run that produced no report fails the upload RED rather than uploading
+          nothing, so "no verdict" can never be read as "clean".
+        required: false
+        type: string
+        default: ''
       upstream-seed:
         description: >-
           The upstream source(s) whose SEALED publication for this image's framework identity
@@ -116,18 +153,72 @@ on:
       registry-key:
         description: An instance key (mwi_…) able to read the packages named in registry-modules.
         required: false
+      content-app-id:
+        description: >-
+          App id of a GitHub App with Contents: Read on content-repository. Required whenever
+          content-repository is set (the caller's GITHUB_TOKEN cannot read another repository);
+          asserted RED before the checkout, never skipped. The platform passes its READ-ONLY
+          fleet-reader App.
+        required: false
+      content-app-private-key:
+        description: Private key (PEM) of that App.
+        required: false
 
 jobs:
   compile-check:
     name: Compile every NodeType (vs core)
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # 🚨 A job-level `permissions:` in a workflow_call lane is a DEMAND on every caller, not a
+    # grant (MeshWeaver#3933 took MeshWeaver.Plugins down for five hours with one `id-token:
+    # write` here). Both scopes below sit inside GitHub's RESTRICTED default (contents / packages /
+    # metadata read), so a caller that writes no `permissions:` at all — four satellites call this
+    # lane exactly that way, see .github/lane-caller-grants.yml — still satisfies them, and
+    # check-workflow-permission-pairing.py --fleet holds that against the roster on every core PR.
+    #   contents — the checkout
+    #   packages — the platform's CD pulls the tester from its GHCR mirror with GITHUB_TOKEN (core
+    #              holds no ACR password and OIDC would be `id-token`, the one scope no default
+    #              grants); a node repo pulling from ACR with its own credential does not use it.
     permissions:
       contents: read
+      packages: read
     steps:
+      # 🚨 A content checkout from ANOTHER repository needs a token that can read it. The caller's
+      # GITHUB_TOKEN is scoped to the calling repository alone, so `repository: Systemorph/<sat>`
+      # (private) answers 404 under it. When content-repository is set, the App credential is
+      # ASSERTED red, never fallen back on: a fallback to github.token would 404 anyway, one step
+      # later and blaming the checkout. Same shape as node-repo-publish-bake.yml's content checkout.
+      - name: Resolve the content repository's credential
+        id: content-repo
+        if: inputs.content-repository != ''
+        env:
+          REPO: ${{ inputs.content-repository }}
+          APP_ID: ${{ secrets.content-app-id }}
+          APP_KEY: ${{ secrets.content-app-private-key }}
+        run: |
+          set -euo pipefail
+          [ -n "$APP_ID" ]  || { echo "::error::content-repository is '$REPO' but secrets.content-app-id is empty — the caller's GITHUB_TOKEN cannot read another repository, so the checkout would 404. Pass a GitHub App installed on '$REPO' with Contents: Read."; exit 1; }
+          [ -n "$APP_KEY" ] || { echo "::error::content-repository is '$REPO' but secrets.content-app-private-key is empty — see content-app-id."; exit 1; }
+          echo "owner=${REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${REPO#*/}"   >> "$GITHUB_OUTPUT"
+      - name: Mint a read token for the content repository
+        id: content-token
+        if: inputs.content-repository != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.content-app-id }}
+          private-key: ${{ secrets.content-app-private-key }}
+          owner: ${{ steps.content-repo.outputs.owner }}
+          repositories: ${{ steps.content-repo.outputs.name }}
+          permission-contents: read
       - name: Check out the node repo
         uses: actions/checkout@v7
         with:
+          # Empty inputs fall through to the caller's own repo + commit — byte-identical to the
+          # default checkout for every node repo; only the platform's CD points these elsewhere.
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
+          token: ${{ steps.content-token.outputs.token || github.token }}
           path: repo
       - uses: actions/setup-python@v7
         with:
@@ -304,7 +395,26 @@ jobs:
         env:
           MW_REPO_ROOT: ${{ github.workspace }}/repo
           MW_ALLOW_FILE: ${{ github.workspace }}/repo/scripts/compile-check.allow
+          VERDICT_ARTIFACT: ${{ inputs.verdict-artifact }}
         # --refs points at the assemblies unpacked from the platform image — a FLAT directory;
         # compile-check.py globs it recursively, dedupes by filename, and compiles each
         # NodeType's resolved source-set. The script is the PLATFORM's, fetched above.
-        run: python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs
+        # --report only when a verdict artifact was asked for: the flag exists from the platform
+        # ref that introduced satellite-compat, and a caller naming an artifact against an older
+        # platform-ref fails here on the unknown flag — RED, not a silent artifact-less pass.
+        run: |
+          set -euo pipefail
+          python3 "$RUNNER_TEMP/compile-check.py" --refs ../refs \
+            ${VERDICT_ARTIFACT:+--report "$RUNNER_TEMP/compile-check-verdict.json"}
+      # 🚨 `always()` so a RED gate uploads its verdict too — that is the whole point of the
+      # artifact — and `if-no-files-found: error` so a run that died before writing one fails
+      # here rather than handing the consumer nothing to read. This is a reporter riding a
+      # gate whose result is already decided above, never a step the gate's own colour depends on.
+      - name: Upload the verdict
+        if: ${{ always() && inputs.verdict-artifact != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.verdict-artifact }}
+          path: ${{ runner.temp }}/compile-check-verdict.json
+          retention-days: 7
+          if-no-files-found: error

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -686,15 +686,25 @@ in parallel runs the same reusable compile gate the satellites run on their own 
 (`node-repo-compile-check.yml`, pointed at the satellite's `main` through the read-only fleet-reader
 App, recording the sha it resolved in the leg's verdict) against the tester **this run** promoted — pulled from its GHCR mirror at the digest
 `satellite-compat-image` asserts equal to ACR's — plus the module bundles **this run** packed, the
-same bytes `plugins-bake` seals. Measured on that lane, a leg costs ~2 min on an unbilled
-`ubuntu-latest` runner. The semantics are *red but not blocking*, and both halves are the point: it
+same bytes `plugins-bake` seals — **and a second time against the set the fleet is on**, the
+control that makes the red attributable (maintainer pushback, 2026-09-12: *"why fail
+compatibility?"* — one compile cannot say which side moved). `gate` records `mw-plugin-test:main`'s
+digest and `3.0.0-ci.<run>` tag before `promote` moves the pointer; `satellite-compat-image` verifies
+GHCR holds that digest and re-uploads the four module bundles the run that built it packed; each leg
+compiles against both sets and `compat-verdict.py` classifies per NodeType: compiled at the baseline
+and not now → **this build broke it**, the only red; failed at the baseline too (or absent there) →
+already broken, satellite side, green with an advisory (its own daily run and ci-main-red issue own
+it); no baseline → a **refusal to judge**, green with an advisory, new-image failures listed
+*unjudged* — an unestablished baseline never reads as "core broke it" nor as "fine". Both digests
+are in every verdict. Measured on that lane, a compile costs ~2 min on an unbilled `ubuntu-latest`
+runner, two per leg. The semantics are *red but not blocking*, and both halves are the point: it
 does not gate `promote`, `notify-platform-update` or `plugins-bake` (the set is published and every
 instance gates itself; a satellite's compile must never hold a veto over the platform's delivery —
 `PlatformNeverDependsOnPluginsGuard` pins the direction), yet a failing leg fails the job, so the run
 is red. **A red satellite leg turns the run RED while delivery has completed; the run's colour then
 says compatibility, not shipping** — which is why the verdict's summary and the alert open with
-`🚨 DELIVERY COMPLETED — this run is red because N satellite(s) failed compatibility: … Nothing
-failed to ship.` `alert-on-failure` files it on the `ci-failure` issue naming the satellite, the set and the
+`🚨 DELIVERY COMPLETED — this run is red because this core build BROKE N satellite(s): … (previous
+image compiled, new image does not). Nothing failed to ship.` `alert-on-failure` files it on the `ci-failure` issue naming the satellite, the set and the
 first failing types (from each leg's `verdict-artifact`), and `delivery-verdict` renders every leg
 under **Compatibility** — and goes red itself if the gate was *skipped* on a publishing run, because
 a skipped measurement painted grey is the one outcome worse than a red one. `fail-fast: false`, no

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -691,7 +691,10 @@ same bytes `plugins-bake` seals. Measured on that lane, a leg costs ~2 min on an
 does not gate `promote`, `notify-platform-update` or `plugins-bake` (the set is published and every
 instance gates itself; a satellite's compile must never hold a veto over the platform's delivery —
 `PlatformNeverDependsOnPluginsGuard` pins the direction), yet a failing leg fails the job, so the run
-is red, `alert-on-failure` files it on the `ci-failure` issue naming the satellite, the set and the
+is red. **A red satellite leg turns the run RED while delivery has completed; the run's colour then
+says compatibility, not shipping** — which is why the verdict's summary and the alert open with
+`🚨 DELIVERY COMPLETED — this run is red because N satellite(s) failed compatibility: … Nothing
+failed to ship.` `alert-on-failure` files it on the `ci-failure` issue naming the satellite, the set and the
 first failing types (from each leg's `verdict-artifact`), and `delivery-verdict` renders every leg
 under **Compatibility** — and goes red itself if the gate was *skipped* on a publishing run, because
 a skipped measurement painted grey is the one outcome worse than a red one. `fail-fast: false`, no

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -677,6 +677,33 @@ five attempts with backoff, then a loud error naming it a REGISTRY/INFRA failure
 sibling jobs in the same run reached the same registry fine. `alert-on-failure` still files the red
 on the `ci-failure` issue, so a genuinely broken bake is never silent.
 
+**`satellite-compat` (2026-09-12) — every core build MEASURES every satellite, none of them blocks
+it.** The fleet assumes the platform is backwards compatible within a major, so the satellites
+(SocialMedia, Crm, Reinsurance, Education, Manufacturing; Plugins is built inside this run) rebuild
+once a day rather than on every platform build — which took away the only per-build evidence that a
+core merge did not break them. This job is the counterweight: after `promote`, one leg per satellite
+in parallel runs the same reusable compile gate the satellites run on their own pull requests
+(`node-repo-compile-check.yml`, pointed at the satellite's `main` through the read-only fleet-reader
+App) against the tester **this run** promoted — pulled from its GHCR mirror at the digest
+`satellite-compat-image` asserts equal to ACR's — plus the module bundles **this run** packed, the
+same bytes `plugins-bake` seals. Measured on that lane, a leg costs ~2 min on an unbilled
+`ubuntu-latest` runner. The semantics are *red but not blocking*, and both halves are the point: it
+does not gate `promote`, `notify-platform-update` or `plugins-bake` (the set is published and every
+instance gates itself; a satellite's compile must never hold a veto over the platform's delivery —
+`PlatformNeverDependsOnPluginsGuard` pins the direction), yet a failing leg fails the job, so the run
+is red, `alert-on-failure` files it on the `ci-failure` issue naming the satellite, the set and the
+first failing types (from each leg's `verdict-artifact`), and `delivery-verdict` renders every leg
+under **Compatibility** — and goes red itself if the gate was *skipped* on a publishing run, because
+a skipped measurement painted grey is the one outcome worse than a red one. `fail-fast: false`, no
+`continue-on-error`, no `if:` on a credential: `preflight` asserts `FLEET_READER_APP_ID` /
+`FLEET_READER_APP_PRIVATE_KEY` red. A red here means "this set breaks that satellite's NodeTypes";
+the fix lands in the satellite (its source or its allow-file ratchet) or in core if a surface it
+should not have broken moved, and the daily rebuild will not repair it on its own. The lane measures
+the whole matrix rather than the satellites whose NodeTypes reference the changed surface: nothing
+in the run knows which satellite binds what, and a matrix that guessed would skip exactly the leg it
+should have run — if the five concurrent jobs per build ever matter against the org's job ceiling,
+that narrowing is the honest lever, not a shorter timeout.
+
 ### The release EVENT — the pipeline calls memex; memex registers and publishes
 
 **The contract (maintainer, 2026-09-03: *"end of github pipeline must call memex, which must

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -691,12 +691,22 @@ control that makes the red attributable (maintainer pushback, 2026-09-12: *"why 
 compatibility?"* — one compile cannot say which side moved). `gate` records `mw-plugin-test:main`'s
 digest and `3.0.0-ci.<run>` tag before `promote` moves the pointer; `satellite-compat-image` verifies
 GHCR holds that digest and re-uploads the four module bundles the run that built it packed; each leg
-compiles against both sets and `compat-verdict.py` classifies per NodeType: compiled at the baseline
-and not now → **this build broke it**, the only red; failed at the baseline too (or absent there) →
-already broken, satellite side, green with an advisory (its own daily run and ci-main-red issue own
-it); no baseline → a **refusal to judge**, green with an advisory, new-image failures listed
-*unjudged* — an unestablished baseline never reads as "core broke it" nor as "fine". Both digests
-are in every verdict. Measured on that lane, a compile costs ~2 min on an unbilled `ubuntu-latest`
+compiles against both sets and `compat-verdict.py` classifies **per NodeType**: compiled at the
+baseline and not now → **this build broke it**, the only red; failed at the baseline too → already
+broken, satellite side, green with an advisory (its own daily run and ci-main-red issue own it);
+*absent* from the baseline report (newer than the set the fleet is on) → **unjudged**, its own row,
+green with an advisory — only previous-compiled-ok → new-fails licenses the word "broke", and
+absence licenses neither "broke" nor "already broken"; no baseline at all → a **refusal to judge**,
+green with an advisory, new-image failures listed *unjudged* — an unestablished baseline never reads
+as "core broke it" nor as "fine". Both digests are in every verdict. **The baseline compile uses the
+baseline run's module bundles** (the four Plugins-packed modules, fetched from the run whose number
+the baseline's `3.0.0-ci.<run>` tag names), never this run's, although this run's are already at
+hand: the modules are Plugins content that moves between sets, and compiling the previous image with
+this run's bundles would make a Plugins-side move between the two compiles fail the baseline reading
+too and be filed as "already broken" (or fail it spuriously where the new bundle needs new core
+surface) — attributing a Plugins move to the satellite, or hiding a core break behind it. A future
+"we already have this run's bundles, why download the old ones" optimisation would break exactly
+that attribution. Measured on that lane, a compile costs ~2 min on an unbilled `ubuntu-latest`
 runner, two per leg. The semantics are *red but not blocking*, and both halves are the point: it
 does not gate `promote`, `notify-platform-update` or `plugins-bake` (the set is published and every
 instance gates itself; a satellite's compile must never hold a veto over the platform's delivery —

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -684,7 +684,7 @@ once a day rather than on every platform build — which took away the only per-
 core merge did not break them. This job is the counterweight: after `promote`, one leg per satellite
 in parallel runs the same reusable compile gate the satellites run on their own pull requests
 (`node-repo-compile-check.yml`, pointed at the satellite's `main` through the read-only fleet-reader
-App) against the tester **this run** promoted — pulled from its GHCR mirror at the digest
+App, recording the sha it resolved in the leg's verdict) against the tester **this run** promoted — pulled from its GHCR mirror at the digest
 `satellite-compat-image` asserts equal to ACR's — plus the module bundles **this run** packed, the
 same bytes `plugins-bake` seals. Measured on that lane, a leg costs ~2 min on an unbilled
 `ubuntu-latest` runner. The semantics are *red but not blocking*, and both halves are the point: it

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -128,10 +128,19 @@ public class CdImageVersionsShareOneSourceGuard
     /// unresolved — is the regression.</para>
     ///
     /// <para>🚨 <b>The one register this rule does not govern, and why it is still read here.</b>
-    /// <c>satellite-compat</c> (2026-09-12) points the reusable compile gate at each satellite's
-    /// <c>main</c>. Those checkouts are not members of the image set — nothing they contain is
-    /// built into an image or sealed beside one — so there is no set identity for their ref to
-    /// keep consistent, and pinning them to the plugins sha would be a category error (it is a
+    /// The rule's own hazard (commit ce16aa65c, 2026-09-01): <i>"A plugins merge landing mid-run
+    /// therefore produces an image built from a commit the pair tag does not name — the tag
+    /// asserting a provenance that was never true — and, the half that actually breaks hosts, a
+    /// portal image and the module bundles sealed beside it from DIFFERENT trees. There is no image
+    /// that can serve a mixed set of module builds."</i> Both halves are about SET MEMBERS: a tree
+    /// whose bytes enter the image or the seal, and a tag that asserts which tree that was.</para>
+    ///
+    /// <para><c>satellite-compat</c> (2026-09-12) points the reusable compile gate at each
+    /// satellite's <c>main</c>. Those checkouts are not members of the image set — nothing they
+    /// contain is built into an image or sealed beside one, and no tag names them — so there is no
+    /// provenance for a mid-run merge to falsify; a merge landing between two legs merely means two
+    /// satellites were measured at their own respective tips, each of which the leg RECORDS as a sha
+    /// in its verdict artifact. Pinning them to the plugins sha would be a category error (a
     /// different repository). The detector still SEES them (it must, or it is blind to a satellite
     /// that a future job promotes into a build input); what excuses them is a POSITIVE assertion
     /// in <see cref="TheSatelliteCompatRegister_IsAMeasurementNotAnImageInput"/>, not a blind spot.</para>

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -126,11 +126,20 @@ public class CdImageVersionsShareOneSourceGuard
     /// repository must take its ref from <c>needs.gate.outputs.plugins_sha</c>, the value
     /// <c>gate</c> resolved once. A branch name there — <c>main</c>, or the steering variable
     /// unresolved — is the regression.</para>
+    ///
+    /// <para>🚨 <b>The one register this rule does not govern, and why it is still read here.</b>
+    /// <c>satellite-compat</c> (2026-09-12) points the reusable compile gate at each satellite's
+    /// <c>main</c>. Those checkouts are not members of the image set — nothing they contain is
+    /// built into an image or sealed beside one — so there is no set identity for their ref to
+    /// keep consistent, and pinning them to the plugins sha would be a category error (it is a
+    /// different repository). The detector still SEES them (it must, or it is blind to a satellite
+    /// that a future job promotes into a build input); what excuses them is a POSITIVE assertion
+    /// in <see cref="TheSatelliteCompatRegister_IsAMeasurementNotAnImageInput"/>, not a blind spot.</para>
     /// </summary>
     [Fact]
     public void EveryPluginCheckoutUsesTheCommitTheGateResolved()
     {
-        var pins = PluginRefs();
+        var pins = PluginRefs().Where(x => !x.InSatelliteCompat).ToList();
 
         Assert.True(pins.Count >= 4,
             $"Expected at least the two image legs and the two reusable calls to name a plugin "
@@ -155,6 +164,46 @@ public class CdImageVersionsShareOneSourceGuard
             + "MW_PLUGINS_REF keeps steering the run through `gate`, which resolves it ONCE.");
     }
 
+    /// <summary>
+    /// <b>The <c>satellite-compat</c> register is a measurement, not an image input.</b> The
+    /// exemption above is only honest if what it exempts is exactly that: the satellites, at their
+    /// own default branch, and never the plugin repository whose commit IS a set member. Each
+    /// clause fails by name if a future edit turns the register into something else.
+    /// </summary>
+    [Fact]
+    public void TheSatelliteCompatRegister_IsAMeasurementNotAnImageInput()
+    {
+        var register = PluginRefs().Where(x => x.InSatelliteCompat).ToList();
+
+        Assert.True(register.Count >= 5,
+            $"Expected the satellite-compat matrix in {Workflow} to name at least the five satellites; "
+            + $"found {register.Count}. Either the job was renamed or its register moved — in both "
+            + "cases the exemption in EveryPluginCheckoutUsesTheCommitTheGateResolved excuses nothing "
+            + "and this guard checks nothing.");
+
+        var plugins = register.Where(x => x.Repo.Equals("Systemorph/MeshWeaver.Plugins", StringComparison.OrdinalIgnoreCase)).ToList();
+        Assert.True(plugins.Count == 0,
+            "satellite-compat must never check MeshWeaver.Plugins: Plugins is BUILT in this run at "
+            + "gate's plugins_sha and its publication is sealed by plugins-bake — compiling it from "
+            + "a moving branch here would judge a tree the set does not contain. Found:\n  "
+            + string.Join("\n  ", plugins.Select(x => $"line {x.Line}")));
+
+        // The matrix entries carry no `ref:` of their own; the ONE ref for the whole register is the
+        // reusable call's `content-ref:`, and it is the satellite's default branch — what that
+        // satellite's daily run would bake. A sha here would be one this run resolved for itself,
+        // which is precisely the shape the rule above forbids for a set member; for a non-member it
+        // would merely be a stale measurement wearing a pin's name.
+        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), Workflow));
+        var (start, end) = SatelliteCompatRange(lines);
+        var contentRef = lines[start..end]
+            .Where(l => !Regex.IsMatch(l, @"^\s*#"))
+            .Select(l => Regex.Match(l, @"^\s*content-ref:\s*(?<ref>\S+)\s*$"))
+            .Where(m => m.Success)
+            .Select(m => m.Groups["ref"].Value)
+            .ToList();
+        Assert.Equal(new[] { "main" }, contentRef);
+    }
+
     /// <summary>The one accepted ref: the sha <c>gate</c> resolved, and nothing else beside it.</summary>
     private static readonly Regex PinnedExactly =
         new(@"^[""']?\$\{\{\s*needs\.gate\.outputs\.plugins_sha\s*\}\}[""']?$", RegexOptions.Compiled);
@@ -165,10 +214,11 @@ public class CdImageVersionsShareOneSourceGuard
     /// Comment lines are skipped: this workflow explains its own history in prose, and a matcher
     /// that read a comment would report an edge that does not exist.
     /// </summary>
-    private static IReadOnlyList<(int Line, string Repo, string Ref)> PluginRefs()
+    private static IReadOnlyList<(int Line, string Repo, string Ref, bool InSatelliteCompat)> PluginRefs()
     {
         var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), Workflow));
-        var found = new List<(int, string, string)>();
+        var found = new List<(int, string, string, bool)>();
+        var (compatStart, compatEnd) = SatelliteCompatRange(lines);
 
         for (var i = 0; i < lines.Length; i++)
         {
@@ -185,10 +235,23 @@ public class CdImageVersionsShareOneSourceGuard
                 if (m.Success) { refValue = m.Groups["ref"].Value; break; }
             }
 
-            found.Add((i + 1, repo.Groups["repo"].Value, refValue));
+            found.Add((i + 1, repo.Groups["repo"].Value, refValue, i >= compatStart && i < compatEnd));
         }
 
         return found;
+    }
+
+    /// <summary>The [start, end) line range of the <c>satellite-compat</c> job, or an empty range
+    /// when the job is absent — in which case nothing is exempted and the register test above
+    /// fails by name rather than this helper guessing.</summary>
+    private static (int Start, int End) SatelliteCompatRange(string[] lines)
+    {
+        var start = Array.FindIndex(lines, l => l.Equals("  satellite-compat:", StringComparison.Ordinal));
+        if (start < 0) return (0, 0);
+        var end = Array.FindIndex(lines, start + 1, l =>
+            l.Length > 3 && l.StartsWith("  ", StringComparison.Ordinal) && l[2] != ' ' && l[^1] == ':'
+            && l[2..^1].All(c => char.IsLetterOrDigit(c) || c == '-' || c == '_'));
+        return (start, end < 0 ? lines.Length : end);
     }
 
     private static string FindRepoRoot()

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -140,8 +140,9 @@ public class CdImageVersionsShareOneSourceGuard
     /// contain is built into an image or sealed beside one, and no tag names them — so there is no
     /// provenance for a mid-run merge to falsify; a merge landing between two legs merely means two
     /// satellites were measured at their own respective tips, each of which the leg RECORDS as a sha
-    /// in its verdict artifact. Pinning them to the plugins sha would be a category error (a
-    /// different repository). The detector still SEES them (it must, or it is blind to a satellite
+    /// in its verdict artifact — beside BOTH image digests it judged against, this run's and the
+    /// baseline's. Pinning them to the plugins sha would be a category error (a different
+    /// repository). The detector still SEES them (it must, or it is blind to a satellite
     /// that a future job promotes into a build input); what excuses them is a POSITIVE assertion
     /// in <see cref="TheSatelliteCompatRegister_IsAMeasurementNotAnImageInput"/>, not a blind spot.</para>
     /// </summary>

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -250,13 +250,33 @@ public class PlatformBakeLaneGuard
     ///
     /// <para>What this guard still refuses: the samples trees (no deployment embeds them), and any
     /// checkout that is not <c>Systemorph/MeshWeaver.Plugins</c> — with ONE further, enumerated
-    /// exception. The plugins checkout is the deliberate cross-repo BUILD input. The second
-    /// decision arrived 2026-09-12 (maintainer: the fleet rebuilds once a day, so every core build
-    /// must still MEASURE compatibility): the <c>satellite-compat</c> job points the reusable
-    /// compile gate at each satellite's content. That is a read-and-compile, never a build input —
-    /// nothing it checks out reaches an image, and it runs after <c>promote</c> and blocks nothing.
-    /// Its register is asserted POSITIVELY below: exactly the five satellites, and only inside that
-    /// job. A sixth repository, or a satellite named anywhere else in the file, is a new decision.</para>
+    /// exception, and the original rule's reason is quoted here so the exception can be judged
+    /// against it rather than against its wording.</para>
+    ///
+    /// <para><b>The original (commit 410538457, 2026-08-26, PR #2445):</b> <i>"the set of
+    /// checked-out repositories in main-cd is exactly ["Systemorph/MeshWeaver.Plugins"]. Present,
+    /// and the only one. A third would be a new decision rather than an extension of this one."</i>
+    /// The HAZARD it closed is named in the same message: the ADOPT model — <i>"plugins arriving
+    /// pre-built from a bundle their own lane published"</i> — i.e. the #1814 bake-identity class,
+    /// <i>"nothing can be built against a framework other than the one shipping"</i>. A checkout is
+    /// dangerous there because what it feeds BECOMES the set: bytes from a tree the identity does not
+    /// name, published under an identity they were not built for.</para>
+    ///
+    /// <para><b>The exception (2026-09-12, maintainer: the fleet rebuilds once a day, so every core
+    /// build must still MEASURE compatibility):</b> <c>satellite-compat</c> points the reusable
+    /// compile gate at each satellite's content. It is OUTSIDE the hazard on every axis the original
+    /// names: the checkout is read-only content at <c>content-ref: main</c>, resolved to a sha that
+    /// the leg records in its verdict artifact; it is compiled into a throwaway <c>check.csproj</c>
+    /// against the set this run ALREADY promoted; nothing from it enters an image, a bundle or a
+    /// seal; no version is derived from it; it runs after <c>promote</c> and nothing waits for it;
+    /// and nothing downstream consumes the verdict. It cannot put bytes under the wrong identity
+    /// because it publishes no bytes. What it CAN do is make a core CD run red on a satellite's
+    /// state — which is the decision, not a side effect.</para>
+    ///
+    /// <para>So the register is asserted POSITIVELY below rather than the rule relaxed: exactly the
+    /// five satellites, only inside that job, and OUTSIDE it the only repository is still Plugins.
+    /// A sixth repository, a satellite named by another job, or a matrix that lost one is a new
+    /// decision and fails here by name.</para>
     /// </summary>
     [Fact]
     public void PlatformBake_CompilesOnlyWhatTheImageEmbeds()

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -270,8 +270,10 @@ public class PlatformBakeLaneGuard
     /// against the set this run ALREADY promoted; nothing from it enters an image, a bundle or a
     /// seal; no version is derived from it; it runs after <c>promote</c> and nothing waits for it;
     /// and nothing downstream consumes the verdict. It cannot put bytes under the wrong identity
-    /// because it publishes no bytes. What it CAN do is make a core CD run red on a satellite's
-    /// state — which is the decision, not a side effect.</para>
+    /// because it publishes no bytes. What it CAN do is make a core CD run red — and, since the
+    /// baseline control (the same content compiled against the set the fleet is on, recorded by
+    /// <c>gate</c> pre-promote), only when a type compiled there and does not against this set:
+    /// core's side by measurement, which is the decision, not a side effect.</para>
     ///
     /// <para>So the register is asserted POSITIVELY below rather than the rule relaxed: exactly the
     /// five satellites, only inside that job, and OUTSIDE it the only repository is still Plugins.
@@ -343,6 +345,21 @@ public class PlatformBakeLaneGuard
     private static string ExecutableLinesOf(string block) =>
         string.Join("\n", block.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
 
+    /// <summary>
+    /// The ONE cross-run download this file tolerates, and the block it must stay inside. The
+    /// original invariant (#1725, below) is about ADOPTION: a bundle from another run is a
+    /// different compilation of the same source, resolves a different framework identity, and so
+    /// must never be PUBLISHED as this run's. <c>satellite-compat-image</c> (2026-09-12) downloads
+    /// the previous run's module bundles for the opposite purpose — as the COMPILE REFERENCE of the
+    /// baseline reading (the set the fleet is on, so a satellite's "does not compile" can be
+    /// attributed to core or to the satellite). Those bytes are re-uploaded under a name only the
+    /// compat legs read, unpacked into <c>refs-baseline/</c>, and never enter a bake directory, a
+    /// seal or a publication. The exemption is the BLOCK, asserted positively by
+    /// <see cref="SatelliteCompatBaselineDownload_IsAReferenceNeverAPublication"/>; a
+    /// <c>gh run download</c> anywhere else in a publishing workflow is still the #1725 defect.
+    /// </summary>
+    private const string BaselineDownloadJob = "satellite-compat-image";
+
     [Fact]
     public void PlatformBake_NeverAdoptsAnotherBuildsBundles()
     {
@@ -352,7 +369,7 @@ public class PlatformBakeLaneGuard
             // Comments stripped for the same reason as above, in the other direction: a workflow is
             // judged on what it RUNS, so prose explaining why the artifact hop was removed must
             // never read as the hop itself.
-            .Select(f => (file: Path.GetFileName(f), text: ExecutableLinesOf(File.ReadAllText(f))))
+            .Select(f => (file: Path.GetFileName(f), text: ExecutableLinesOf(WithoutJob(File.ReadAllLines(f), BaselineDownloadJob))))
             .Where(x => x.text.Contains("publish-bake-bundles.sh", StringComparison.Ordinal))
             // The invariant is CROSS-RUN adoption (#1725): a bundle from another run is a different
             // compilation resolving a different framework identity. `gh run download` is cross-run
@@ -376,6 +393,49 @@ public class PlatformBakeLaneGuard
             + "different framework identity, so no pod can adopt what it publishes (#1725). "
             + "Bake inside the image being shipped instead. Offending workflow(s): "
             + string.Join(", ", offenders));
+    }
+
+    /// <summary>
+    /// <b>The baseline download is a compile reference, never a publication.</b> Both directions:
+    /// the exempted block must still CONTAIN the cross-run download (or the exemption above excuses
+    /// nothing and this guard has gone blind), and it must carry none of the forms by which bytes
+    /// reach a bake, a seal or the portals' storage. The lane that consumes the re-upload is held
+    /// to the same: the baseline bundles unpack into <c>refs-baseline/</c> only.
+    /// </summary>
+    [Fact]
+    public void SatelliteCompatBaselineDownload_IsAReferenceNeverAPublication()
+    {
+        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), Workflow));
+        var start = Array.FindIndex(lines, l => l.Equals($"  {BaselineDownloadJob}:", StringComparison.Ordinal));
+        Assert.True(start >= 0, $"no '{BaselineDownloadJob}:' job in {Workflow} — the exemption in "
+            + "PlatformBake_NeverAdoptsAnotherBuildsBundles names a block that does not exist, so it excuses nothing "
+            + "and this guard measures nothing. Delete the exemption with the job, in the same change.");
+        var end = Array.FindIndex(lines, start + 1, IsJobKey);
+        var block = ExecutableLinesOf(string.Join("\n", lines[start..(end < 0 ? lines.Length : end)]));
+
+        Assert.Contains("gh run download", block, StringComparison.Ordinal);
+        Assert.Contains("name: satellite-compat-baseline-bundles", block, StringComparison.Ordinal);
+        foreach (var publishing in new[] { "publish-bake-bundles.sh", "push-bundle-publication.sh", "--bake-output", "--seed ", "az storage", "BAKE_PUBLISH_TARGETS" })
+            Assert.DoesNotContain(publishing, block, StringComparison.Ordinal);
+
+        // The consumer side: the reusable lane unpacks the baseline bundles into the BASELINE
+        // reference directory and nowhere else, and the lane publishes nothing.
+        var lane = ExecutableLinesOf(File.ReadAllText(Path.Combine(FindRepoRoot(), ".github", "workflows", "node-repo-compile-check.yml")));
+        Assert.Contains("baseline-module-artifacts", lane, StringComparison.Ordinal);
+        Assert.Contains("refs-baseline/", lane, StringComparison.Ordinal);
+        foreach (var publishing in new[] { "publish-bake-bundles.sh", "push-bundle-publication.sh", "--bake-output", "az storage" })
+            Assert.DoesNotContain(publishing, lane, StringComparison.Ordinal);
+    }
+
+    /// <summary>The workflow's lines with ONE job's block removed — for a detector whose rule the
+    /// block is exempt from by a positive assertion elsewhere.</summary>
+    private static string WithoutJob(string[] lines, string jobName)
+    {
+        var start = Array.FindIndex(lines, l => l.Equals($"  {jobName}:", StringComparison.Ordinal));
+        if (start < 0) return string.Join("\n", lines);
+        var end = Array.FindIndex(lines, start + 1, IsJobKey);
+        if (end < 0) end = lines.Length;
+        return string.Join("\n", lines[..start].Concat(lines[end..]));
     }
 
     /// <summary>

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -249,9 +249,14 @@ public class PlatformBakeLaneGuard
     /// construction: nothing can be built against a framework other than the one shipping.
     ///
     /// <para>What this guard still refuses: the samples trees (no deployment embeds them), and any
-    /// checkout that is not <c>Systemorph/MeshWeaver.Plugins</c>. The plugins checkout is the ONE
-    /// deliberate cross-repo input — a second one would be a new decision, not an extension of
-    /// this one.</para>
+    /// checkout that is not <c>Systemorph/MeshWeaver.Plugins</c> — with ONE further, enumerated
+    /// exception. The plugins checkout is the deliberate cross-repo BUILD input. The second
+    /// decision arrived 2026-09-12 (maintainer: the fleet rebuilds once a day, so every core build
+    /// must still MEASURE compatibility): the <c>satellite-compat</c> job points the reusable
+    /// compile gate at each satellite's content. That is a read-and-compile, never a build input —
+    /// nothing it checks out reaches an image, and it runs after <c>promote</c> and blocks nothing.
+    /// Its register is asserted POSITIVELY below: exactly the five satellites, and only inside that
+    /// job. A sixth repository, or a satellite named anywhere else in the file, is a new decision.</para>
     /// </summary>
     [Fact]
     public void PlatformBake_CompilesOnlyWhatTheImageEmbeds()
@@ -272,13 +277,41 @@ public class PlatformBakeLaneGuard
             + "still compile-GATE on every PR in dotnet-test.yml's doc-gate — that proves the "
             + "content, which is the part worth paying for.");
 
-        // The main build checks out exactly ONE other repository — the plugins it builds and ships.
-        // Asserted POSITIVELY (present, and the only one) rather than as an absence: the portal
-        // host lives there now, so a main-cd without this checkout cannot build the deployment
-        // image at all (measured 2026-08-26: every push run failed at the version step and nothing
-        // published until this was restored). And a third `repository:` would be a new decision.
-        var text = ExecutableLinesOf(File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow)));
-        var repos = Regex.Matches(text, @"repository:\s*(\S+)")
+        // The main build checks out exactly ONE other repository AS A BUILD INPUT — the plugins it
+        // builds and ships. Asserted POSITIVELY (present, and the only one) rather than as an
+        // absence: the portal host lives there now, so a main-cd without this checkout cannot build
+        // the deployment image at all (measured 2026-08-26: every push run failed at the version
+        // step and nothing published until this was restored).
+        //
+        // The `satellite-compat` job (2026-09-12) is the enumerated exception: it names the five
+        // satellites in its matrix and hands them to node-repo-compile-check.yml as
+        // `content-repository: ${{ matrix.repository }}`. Both halves are asserted — the matrix
+        // lists exactly the five, and OUTSIDE that job the only repository named is Plugins — so a
+        // sixth satellite, a satellite named by another job, or a matrix that silently lost one all
+        // fail here by name. (`${{` is the matrix expression itself, seen through the same regex.)
+        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), Workflow));
+        var (compatStart, compatEnd) = JobRange(lines, "satellite-compat");
+        var compat = ExecutableLinesOf(string.Join("\n", lines[compatStart..compatEnd]));
+        var satellites = Regex.Matches(compat, @"repository:\s*(\S+)")
+            .Select(m => m.Groups[1].Value.Trim())
+            .Where(v => !v.StartsWith("${{", StringComparison.Ordinal))
+            .Distinct()
+            .OrderBy(v => v, StringComparer.Ordinal)
+            .ToList();
+        Assert.Equal(
+            new[]
+            {
+                "Systemorph/MeshWeaver.Crm",
+                "Systemorph/MeshWeaver.Education",
+                "Systemorph/MeshWeaver.Manufacturing",
+                "Systemorph/MeshWeaver.Reinsurance",
+                "Systemorph/MeshWeaver.SocialMedia",
+            },
+            satellites);
+        Assert.Contains("content-repository: ${{ matrix.repository }}", compat, StringComparison.Ordinal);
+
+        var outside = ExecutableLinesOf(string.Join("\n", lines[..compatStart].Concat(lines[compatEnd..])));
+        var repos = Regex.Matches(outside, @"repository:\s*(\S+)")
             .Select(m => m.Groups[1].Value.Trim())
             .Distinct()
             .ToList();
@@ -787,6 +820,19 @@ public class PlatformBakeLaneGuard
         if (end < 0)
             end = lines.Length;
         return string.Join("\n", lines[start..end]);
+    }
+
+    /// <summary>The [start, end) line range of one job's block — the job key line through the line
+    /// before the next job key. Asserted present: a job this guard pins by name that is gone would
+    /// otherwise turn its assertions into a pass over an empty string.</summary>
+    private static (int Start, int End) JobRange(string[] lines, string jobName)
+    {
+        var start = Array.FindIndex(lines, l => l.Equals($"  {jobName}:", StringComparison.Ordinal));
+        Assert.True(start >= 0, $"no '{jobName}:' job in {Workflow} — the per-build satellite compatibility "
+            + "measurement (2026-09-12) is the counterweight to the fleet's once-a-day rebuild; without it a "
+            + "core merge that breaks a satellite is found at 03:00 or on a portal at self-update.");
+        var end = Array.FindIndex(lines, start + 1, IsJobKey);
+        return (start, end < 0 ? lines.Length : end);
     }
 
     private static bool IsJobKey(string line) =>

--- a/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
@@ -63,7 +63,12 @@ public class PlatformNeverDependsOnPluginsGuard
         [
             new KeyValuePair<string, string>("main-cd.yml",
                 "publishes portal-ai + memex-migration from plugins-repo/src, keys the image set on the "
-                + "core/plugins PAIR (#2622), and packs+bakes the Plugins module bundles for that identity"),
+                + "core/plugins PAIR (#2622), packs+bakes the Plugins module bundles for that identity, "
+                + "and — since 2026-09-12, the counterweight to the satellites' once-a-day rebuild — "
+                + "points the reusable compile gate at each satellite's main in `satellite-compat`: a "
+                + "read-and-compile after `promote` that blocks nothing and builds nothing into an "
+                + "image, RED so a break is known within the hour rather than at 03:00 (its register "
+                + "is pinned by PlatformBakeLaneGuard)"),
             new KeyValuePair<string, string>("edge-images.yml",
                 "the manual edge channel — same two projects"),
         ]);
@@ -98,6 +103,10 @@ public class PlatformNeverDependsOnPluginsGuard
         "MeshWeaver.Reinsurance",
         "MeshWeaver.SocialMedia",
         "MeshWeaver.Manufacturing",
+        // Added 2026-09-12 with `satellite-compat`, the first workflow here to name it in an
+        // actionable form. Absent from this list the detector was blind to a Crm reach by
+        // construction — exactly the "stops seeing its subject" defect the summary describes.
+        "MeshWeaver.Crm",
     ];
 
     /// <summary>

--- a/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
@@ -71,10 +71,14 @@ public class PlatformNeverDependsOnPluginsGuard
                 + "PR verdict behind a sibling checkout, or plugin source entering core's build. "
                 + "satellite-compat is neither: it is on no pull request, it builds nothing into an "
                 + "image or seal, it runs after `promote` with nothing waiting on it, and it checks out "
-                + "read-only content at each satellite's main, recording the sha it judged. It CAN turn "
-                + "a core CD run red on a satellite's state — which is the decision (a break known "
-                + "within the hour rather than at 03:00), not a side effect. Its register is pinned by "
-                + "PlatformBakeLaneGuard to exactly the five satellites, inside that job only"),
+                + "read-only content at each satellite's main, recording the sha it judged. And its red "
+                + "is CLASSIFIED, not raw: every leg also compiles the same content against the set the "
+                + "fleet is on (gate's pre-promote record) and compat-verdict.py reds ONLY a type that "
+                + "compiled there and does not now — so a satellite's own broken commit (this hazard, "
+                + "exactly) is an advisory, never a red, and a red means core moved a surface. That is "
+                + "the decision (a break known within the hour rather than at 03:00), not a side effect. "
+                + "Its register is pinned by PlatformBakeLaneGuard to exactly the five satellites, inside "
+                + "that job only"),
             new KeyValuePair<string, string>("edge-images.yml",
                 "the manual edge channel — same two projects"),
         ]);

--- a/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformNeverDependsOnPluginsGuard.cs
@@ -65,10 +65,16 @@ public class PlatformNeverDependsOnPluginsGuard
                 "publishes portal-ai + memex-migration from plugins-repo/src, keys the image set on the "
                 + "core/plugins PAIR (#2622), packs+bakes the Plugins module bundles for that identity, "
                 + "and — since 2026-09-12, the counterweight to the satellites' once-a-day rebuild — "
-                + "points the reusable compile gate at each satellite's main in `satellite-compat`: a "
-                + "read-and-compile after `promote` that blocks nothing and builds nothing into an "
-                + "image, RED so a break is known within the hour rather than at 03:00 (its register "
-                + "is pinned by PlatformBakeLaneGuard)"),
+                + "points the reusable compile gate at each satellite's main in `satellite-compat`. "
+                + "This guard's hazard (commit c88cd5d5c, 2026-09-01) is an edge by which 'core's own "
+                + "build or release can be broken by a repository it should not know about': a core "
+                + "PR verdict behind a sibling checkout, or plugin source entering core's build. "
+                + "satellite-compat is neither: it is on no pull request, it builds nothing into an "
+                + "image or seal, it runs after `promote` with nothing waiting on it, and it checks out "
+                + "read-only content at each satellite's main, recording the sha it judged. It CAN turn "
+                + "a core CD run red on a satellite's state — which is the decision (a break known "
+                + "within the hour rather than at 03:00), not a side effect. Its register is pinned by "
+                + "PlatformBakeLaneGuard to exactly the five satellites, inside that job only"),
             new KeyValuePair<string, string>("edge-images.yml",
                 "the manual edge channel — same two projects"),
         ]);


### PR DESCRIPTION
## Phase 2(a) of the fleet CI refactor — the per-build counterweight to the daily rebuild

**Decision (maintainer, 2026-09-12):** the platform is assumed backwards compatible within a MAJOR; the satellites (MeshWeaver.SocialMedia, .Crm, .Reinsurance, .Education, .Manufacturing — Plugins is built inside CD already) rebuild **once a day**, not per platform build. That removed the only per-build evidence that a core merge did not break them. This PR is the counterweight: **every core build still MEASURES compatibility, cheaply**, so a break is known within the hour — not at 03:00 by the daily run, not on a portal at self-update.

Phase 2(b), the instance link probe (#4083), is another session's; `ModulePlatformLink.cs` / `Mesh.Contract` are untouched.

### Design

A new matrix job in `main-cd.yml`, **`satellite-compat`**, runs after `promote`: one leg per satellite, in parallel (`fail-fast: false`), each a `uses:` of the existing reusable **`node-repo-compile-check.yml`** — the very gate the satellites run on their own PRs — pointed at the satellite's `main`, at **this run's** set, **and — the control — at the set the fleet is currently on** (maintainer pushback via the reviewing session: *"why fail compatibility?"* — a single red compile cannot tell which side moved).

**The baseline control.** Every leg compiles the same content twice and `compat-verdict.py` (new, self-tested on every row) classifies per NodeType:

| previous image | new image | verdict | leg colour |
|---|---|---|---|
| compiled | **fails** | **BROKE — this core build broke it** | 🔴 RED — the only red |
| failed | fails | already broken — satellite side; its own daily run / ci-main-red issue own it | 🟢 green, advisory line naming satellite + first failing types |
| **absent** from the previous report (type newer than the set the fleet is on) | fails | **unjudged (no per-type baseline)** — its own row: only previous-compiled-ok → new-fails licenses "broke", and absence licenses neither "broke" nor "already broken"; never folded into either | 🟢 green, advisory |
| compiled | compiled | compatible | 🟢 |
| *unresolvable* | (any) | **refusal to judge** — "could not establish a baseline: <reason>"; new-image failures listed **unjudged**, never attributed | 🟢 green, advisory |

**Where the baseline comes from — one derivation, the one the run already has.** `gate` (pre-promote, already Azure-logged-in for its completeness probe) reads the `mw-plugin-test` manifest tagged `main` from ACR (`az acr manifest list-metadata`) and records its digest **and** its `3.0.0-ci.<run>` tag (`baseline_tester_digest` / `_version` / `_run_number`) — the set the fleet is on, read *before* this run's `promote` moves the pointer. `satellite-compat-image` then (1) asserts GHCR holds that digest, (2) locates the run that built it by `run_number` (= the version suffix; verified live: `3.0.0-ci.8414` ↔ run 34688449431 `run_number=8414`), (3) downloads that run's four `module-bundle-*` artifacts — the modules that **shipped with** the baseline — and re-uploads them as `satellite-compat-baseline-bundles` for the legs. Any step of that failing → **no baseline, with the reason** (`::warning::`, never fatal, never a skip painted grey: the leg still runs and reports the refusal). Both digests are recorded in every verdict JSON (`images.new` / `images.baseline` / `images.baseline_reason`).

**Why the baseline compiles against the baseline run's bundles and not this run's** (stated in the workflow comment and the contract paragraph so a later "we already have this run's bundles, why download the old ones" optimisation is told what it would break): the four modules are Plugins content packed per build. Compiling the *previous* image with *this* run's bundles would make a Plugins-side move between the two sets (a type renamed in MeshWeaver.AI, say) fail the baseline reading too and be filed as "already broken" — attributing a Plugins move to the satellite — or fail it spuriously where the new bundle needs new core surface, hiding a core break. The whole control is attribution; that optimisation would remove it.

Every classification is **per NodeType** (the type's own name in the baseline report's `ok` list), never inferred from the satellite's overall colour — `compat-verdict.py --self-test` holds that with an all-red-baseline case that still yields BROKE for the one type that compiled there.

Inputs per leg (all five identical except `content-repository`):

| Input | Value | Where it comes from |
|---|---|---|
| `content-repository` | `Systemorph/<satellite>` (matrix, literal per entry) | so the guards that inventory cross-repo reaches SEE each one |
| `content-ref` | `main` | the satellite's default branch — what its daily run would bake; the leg resolves it ONCE and records the sha (`content.sha`), shown as `<satellite> (main @ <sha>)` |
| `content-app-id` / `-private-key` | `secrets.FLEET_READER_APP_ID` / `_PRIVATE_KEY` | the READ-ONLY fleet App; `permission-contents: read`, `repositories:` = that one satellite (publish-bake's exact shape). Measured 2026-09-12: `meshweaver-reader` (installation 161095771) is installed org-wide, `repository_selection: all` — Crm included |
| `test-image` / `image-digest` | `ghcr.io/systemorph/mw-plugin-test:<version>` @ **this run's** tester digest | `satellite-compat-image` resolves the GHCR mirror `promote` phase B wrote and **asserts its digest equals** `plugins-bake-image.outputs.digest` (ACR) |
| `acr-username` / `acr-password` | `github.actor` / `GITHUB_TOKEN` | GHCR pull. Core holds no ACR password (it pushes by OIDC), and OIDC *inside* the lane would demand `id-token: write` of every satellite caller — the #3933 startup-failure shape |
| `module-artifacts` | `module-bundle-MeshWeaver.{AI,Markdown.Collaboration,Maps,Payments.Stripe}` | **this run's** `plugins-modules` artifacts — the same pattern and bytes `plugins-bake` seals; every satellite declares exactly these four (`registry-modules: AI Essentials Stripe Maps`, `upstream-seed: plugins`) |
| `platform-ref` | `needs.gate.outputs.sha` | `compile-check.py` and `compat-verdict.py` at this run's core sha |
| `verdict-artifact` | `satellite-compat-<satellite>` | the verdict as JSON, uploaded on red as well as green |
| `judge-against-baseline` | `true` | the classified verdict decides the leg's colour (a node repo's own PR gate leaves it `false`: plain red stays red) |
| `baseline-image-digest` / `baseline-unavailable-reason` | `satellite-compat-image.outputs.baseline_digest` / `.baseline_reason` | the previous set as verified above, or empty + why |
| `baseline-module-artifacts` | `satellite-compat-baseline-bundles` | the previous run's four bundles, re-uploaded under this run |

### Education — measured, green

Education has no `compile-check` job and no `scripts/compile-check.allow` on its `main`, so its leg judges the whole tree with nothing grandfathered — therefore it was **measured before being listed**, on the lane's exact script path (the lane's steps replayed: `docker cp /app` + shared frameworks from the promoted tester `mw-plugin-test@sha256:1ad82ff0cbac…`, the four `module-bundle-*` artifacts of publishing run 34684158910 unpacked into the reference set, `compile-check.py --refs … --report` with `MW_REPO_ROOT`/`MW_ALLOW_FILE` as the lane sets them) against Education `main` @ `7c106210ba6f0b8118dbe70b3cd101ce19d12020`:

```
scope: full — every NodeType in all 9 package(s)
compile-check: 13 NodeType(s), 13 distinct source set(s) (13 with a configuration lambda), 378 ref assemblies
── summary ──  13 clean · 0 known-debt · 0 NEW break(s) · 0 fingerprint-drift · 0 stale-allow · 0 unverifiable   (7s)
✓ compile gate GREEN (full tree): 13 clean, 0 known-debt (shrinking), no new breaks.
rc=0
```

Positive control on the same harness — a `ThisSymbolDoesNotExist` reference appended to `AgenticBusiness/Menu/Source/MenuAreas.cs` in the scratch clone: `✗ 1 NON-allowlisted NodeType(s) FAIL to compile (regression): - AgenticBusiness/Menu`, `gate_fail: true`, rc=1; clone restored. Education **stays in the matrix**, the reading in the workflow comment beside its entry. No Education issue was needed.

**Reusable lane changes** (`node-repo-compile-check.yml`, extended, not forked): optional `content-repository`, `content-ref`, `verdict-artifact`, `judge-against-baseline`, `baseline-image-digest`, `baseline-module-artifacts`, `baseline-unavailable-reason` inputs; optional `content-app-id` / `content-app-private-key` secrets (asserted RED when `content-repository` is set — never a fallback to `github.token`); job permissions gain `packages: read` — inside GitHub's RESTRICTED default, so the four satellites calling with `inherit` stay valid (`check-workflow-permission-pairing.py --fleet`: 44 pairs, 0 violations). With `judge-against-baseline` the new-image compile's exit code becomes a datum, a second compile runs against `refs-baseline/` (previous image + its bundles), and the judge (`compat-verdict.py`, fetched at `platform-ref` like `compile-check.py`, self-tested in-run) sets the leg's colour. A node repo calling with no `content-repository` behaves byte-for-byte as before.

**Scripts.** `compile-check.py`: `--report PATH` writes the verdict as JSON (`gate_fail`, `new_breaks[{type,error}]`, `fp_drift`, `stale_allow`, `known_debt`, the clean types **by name** (`ok`), counts, `content.{repository,sha}`); self-tested. `compat-verdict.py` (new): the classifier above; `--self-test` covers all rows in both directions — including the explicit fifth row *"type absent from baseline, fails on new ⇒ unjudged, not BROKE"*, alone, beside an already-broken type, and beside a BROKE type — plus per-type granularity, fingerprint-drift, stale-allow, known-debt-on-new and the CLI exit codes (1 = broke, 0 otherwise, 2 = no new report).

### Semantics — RED, but NOT blocking, and both halves are deliberate

**Stated plainly: a red satellite leg ANNOTATES delivery — the Compatibility table on the run summary and a line on the `ci-failure` issue — and never stops `promote`, `notify-platform-update`, `plugins-bake` or `publish-bake`. Nothing downstream consumes the verdict.**

**And the contradiction that follows, stated: a red satellite leg turns the run RED while delivery has completed; the run's colour then says compatibility, not shipping.** (No `continue-on-error`, by rule, so `satellite-compat` = `failure` makes the run's conclusion `failure` even though promote, notify, bake and seal all completed.) And since the baseline control, red means exactly one thing. So the verdict's summary opens — and its final headline repeats — `🚨 DELIVERY COMPLETED — this run is red because this core build BROKE <n> satellite(s): <list> (previous image compiled, new image does not). Nothing failed to ship.`, and the `ci-failure` alert body carries the same line above its Compatibility section (which lists **only** BROKE lines — an already-broken satellite or an unestablished baseline is an advisory on the run page, never an alert about this build). The same sentence is in `ContinuousDeliveryContract.md`.

* **Not blocking.** Nothing waits for it: `promote` is already done, `notify-platform-update` and `plugins-bake` do not `need` it. The set is published; each instance gates itself. Blocking the publish on a satellite's compile would hand every satellite a veto over the platform's delivery.
* **Red.** A failing leg fails the job → the run is red →
  * **`alert-on-failure`** (`satellite-compat` + `satellite-compat-image` in its `needs`) downloads the verdict artifacts and appends the banner plus one line per BROKE satellite — satellite, content sha, both digests, the set, the first three failing types with their first error.
  * **`delivery-verdict`** (both jobs in `needs`) renders a per-satellite table (content sha, verdict 🔴/🟡/✅/⚪, NodeType count, types, `baseline → new` digests) under **Compatibility**, runs under `always()` on a publishing run, and **goes red itself only if the gate was skipped/cancelled** on a publishing run or reports success with a satellite lacking a verdict. Executed locally against fixture verdicts for all rows (broke, already-broken, unjudged, already-broken with absent types, compatible, no-baseline) plus a not-measured leg: table, advisory line, banner and outputs as designed; `skipped` → rc 1; `success` with a missing verdict → rc 1.
  * **`preflight`** asserts `FLEET_READER_APP_ID` / `FLEET_READER_APP_PRIVATE_KEY` RED naming both secret stores. No `continue-on-error` anywhere; no `if:` on a secret; a leg that cannot mint, pull or compile is a red leg. Timeouts: lane job 20 (existing), `satellite-compat-image` 10, all literal.

**What a red means and who acts:** "**this core build broke** that satellite's NodeTypes — they compiled against the set the fleet is on and do not against this one." The `ci-failure` issue names satellite, both digests, set and types → the control instance's triage. The fix is on **core's side by measurement**: restore the surface, or — if the move was intended — land the satellite's adaptation. A satellite that was already broken is *not* a red here (advisory; its own daily run / ci-main-red issue own it), and a stale allow entry is an advisory. The daily rebuild will not repair a core break on its own.

### Budget

* Runner: `ubuntu-latest` in a public repo — **zero billed minutes**.
* **Measured compile duration: 1 min 50 s** — the same lane, same digest-pinned image + four sealed modules, on MeshWeaver.Crm's own CI (`compile-check / Compile every NodeType (vs core)`, run 34686027657, 2026-09-12 09:31:58Z → 09:33:48Z). Not a trial of this branch (below). **Two compiles per leg now** (new + baseline): expect ~4–5 min a leg; the extra compile is the control the red rests on.
* Wall time: the legs need `plugins-modules` and run **beside** `plugins-bake` (which needs the same thing and takes longer): expected addition to CD's critical path ~0; worst case ≈ +5 min. `satellite-compat-image` (~1 min) runs beside `plugins-modules`.
* Concurrency: **5 jobs per build** against the org's 60-job ceiling; at ~43 merges/day ≈ 215 legs ≈ ~900 unbilled runner-minutes/day.
* **Not done, and why:** narrowing the matrix to the satellites whose NodeTypes reference the changed surface. Nothing in the run knows which satellite binds which surface (that map lives in the satellites' node JSON), and a matrix that guessed would skip exactly the leg it should have run — a skipped leg reads as satisfied. If the concurrency cost ever matters, that narrowing is the honest lever; a shorter timeout is not.

### The guards — original rationale, and why this job is outside each hazard

Each guard's comment quotes the commit that wrote the rule it extends (found by `git log -S`); each was proven able to fail by mutating the workflow (then restored, md5-verified).

| Guard | Original (commit, date) — the hazard, quoted | Why `satellite-compat` is outside it | Does the hazard apply? |
|---|---|---|---|
| `PlatformBakeLaneGuard.PlatformBake_CompilesOnlyWhatTheImageEmbeds` | **410538457, 2026-08-26 (PR #2445)**: *"the set of checked-out repositories in main-cd is exactly ["Systemorph/MeshWeaver.Plugins"]. Present, and the only one. A third would be a new decision rather than an extension of this one."* Hazard: the ADOPT model — *"plugins arriving pre-built from a bundle their own lane published"*, the **#1814 bake-identity class**. A checkout is dangerous there because what it feeds **becomes the set**. | Read-only content at `content-ref: main`, resolved once to a sha the leg records; compiled into a throwaway `check.csproj` against the set ALREADY promoted; nothing enters an image, bundle or seal; no version derived; after `promote`, nothing waits, nothing consumes the verdict. | **No.** Rule not relaxed: the register is asserted positively (exactly five, only in that job; outside it still only Plugins). Dropping Crm → red. |
| `CdImageVersionsShareOneSourceGuard.EveryPluginCheckoutUsesTheCommitTheGateResolved` | **ce16aa65c, 2026-09-01**: *"A plugins merge landing mid-run therefore produces an image built from a commit the pair tag does not name … a portal image and the module bundles sealed beside it from DIFFERENT trees."* Both halves are about **set members**. | The satellites are not set members: no image or seal holds their bytes, no tag names them; each leg records its sha beside both digests it judged against. | **No.** Detector still SEES the register; new fact `TheSatelliteCompatRegister_IsAMeasurementNotAnImageInput` excuses it only with `content-ref: main` and never Plugins. `content-ref` → sha: red. |
| `PlatformNeverDependsOnPluginsGuard.OnlyTheImageLanes_ReachIntoAPluginRepository` | **c88cd5d5c, 2026-09-01**: an edge by which *"core's own build or release can be broken by a repository it should not know about"*. | On no pull request; builds nothing into an image or seal; runs after `promote`; reads content only. **And the red is classified**: a satellite's own broken commit fails at the baseline too → advisory, never red. | **No longer, by construction** — a red means core moved a surface, measured against the set the fleet is on. main-cd was already ledgered; the reason names the gate and the control; `MeshWeaver.Crm` joins `SatelliteRepos`. Narrower shape (API-read-only) rejected: it cannot compile NodeTypes. |
| `PlatformBakeLaneGuard.PlatformBake_NeverAdoptsAnotherBuildsBundles` | **#1725**: *"a bundle from another run is a DIFFERENT compilation of the same source and resolves a different framework identity, so no pod can adopt what it publishes"* — `gh run download` in a publishing workflow is the defect. | `satellite-compat-image` downloads the **previous** run's bundles as a **compile reference** for the baseline reading; re-uploaded under a name only the compat legs read, unpacked into `refs-baseline/`, never into a bake directory, seal or publication. | **No.** The detector skips exactly that job's block; new fact `SatelliteCompatBaselineDownload_IsAReferenceNeverAPublication` asserts the block still contains the download + re-upload and that neither it nor the consuming lane carries any publishing form (`publish-bake-bundles.sh`, `push-bundle-publication.sh`, `--bake-output`, `--seed`, `az storage`, `BAKE_PUBLISH_TARGETS`). Planting `publish-bake-bundles.sh` in the block → red; a `gh run download` outside it → the original fact red. |

### Guards (all with `--root .` and `--self-test`; verbatim summary lines, after the last push)

```
check-workflow-timeouts: 85 job(s) checked, 3 reusable-call job(s) exempt, 0 violation(s), cap=45 min   (--self-test rc=0, --root . rc=0)
check-workflow-shell: 1 finding(s): 0 live, 1 allow-listed, 0 stale entr(ies), 0 allow-file error(s)   (rc=0/0)
check-workflow-yaml-keys: 34 workflow file(s) and 0 composite action(s) checked, 0 violation(s)   (rc=0/0)
check-pr-secret-preflight: 2 secret(s) reachable on a Dependabot pull request, 2 asserted by a preflight, 0 violation(s)   (rc=0/0)
check-workflow-permission-pairing: 3 caller/lane permission pair(s) resolved, 0 violation(s)   (rc=0/0)
check-workflow-permission-pairing (fleet): 44 roster caller/lane pair(s) resolved, 0 violation(s)   rc=0
actionlint -shellcheck= -pyflakes= (CI's flags) rc=0; with embedded shellcheck on: identical to main's 6 pre-existing info/style notes
compile-check.py --self-test rc=0
compat-verdict.py --self-test rc=0: broke (red) · already-broken (green, advisory) · compatible · no-baseline (green, unjudged) · type-absent-from-baseline ⇒ unjudged, never BROKE (row 5) — all rows both directions, per-type granularity, drift, stale-allow and known-debt edges, CLI exit codes
test-cd-steps.py: all cases passed against main-cd.yml steps `release` + `decide` + `verdict` + `heal` (extracted, not copied)   rc=0
dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror:
Passed!  - Failed:     0, Passed:   434, Skipped:     0, Total:   434, Duration: 16 s - MeshWeaver.Documentation.Test.dll (net10.0)   rc=0
```

### Docs
One dated paragraph in `Data/Architecture/ContinuousDeliveryContract.md` ("After the promote" section), now covering the baseline control and the banner. No new page. No What's New entry: CI-only, no user-visible effect.

### First-run plan
* **Which run:** the first `Continuous Delivery (main)` run after merge whose `gate` decides `publish=true`. Reconcile ticks that publish nothing skip the compat lane by design, and `delivery-verdict` does not judge it on those.
* **What to check:** (1) `gate`'s line `baseline (the set the fleet is on): mw-plugin-test:main = sha256:… = 3.0.0-ci.<n>, built by run #<n>` and `satellite-compat-image` green with `satellite-compat tester: … (equal to ACR's)` and `baseline set: ghcr.io/…@sha256:… (<version>, run <id> #<n>) + 4 module bundles` — a `baseline NOT established: <reason>` warning instead means every leg refuses to judge (⚪) and the reason is the thing to fix; (2) **five** `Compatibility: <satellite>'s NodeTypes compile against this set` legs, none skipped or cancelled (the verdict's Compatibility step goes RED if the job did not run); (3) five `satellite-compat-*` artifacts, each a `compile-check-verdict.json` with `verdict`, `content.sha`, `images.new` and `images.baseline`; (4) the **Compatibility** table listing all five as ✅ (or 🟡 with a named satellite-side cause; expected: Education 13 clean); (5) `delivery-verdict` green; no `ci-failure` issue opened by this run.
* **If a leg is red:** it means this build broke that satellite. The run is red, `alert-on-failure` files/comments the `ci-failure` issue with the banner and `* **<satellite>** (main @ <sha>): compiled against the previous image (<digest>) and does not against <version>: <type> — <error>; …` → **control-instance triage**: read the leg's log (both compiles are there); the fix is core's — restore the surface, or land the satellite's adaptation if the move was intended. The set is already published and every instance gates itself — nothing to roll back in delivery.
* **Rollback of this PR:** `git revert` of the merge commit. Nothing else needs undoing — no instance, publication, tag, registry entry or downstream job consumes the verdict artifacts or the new jobs' outputs; the lane's new inputs are optional and the satellites' callers do not pass them.

### Not done / to watch
* **No trial run.** `main-cd.yml`'s `workflow_dispatch` resolves *main's HEAD* server-side and, with `rebuild=true`, publishes a real image set, seals the Plugins publication and POSTs the release event — not a branch trial. The reusable lane has no dispatch trigger. The compile duration is the same lane on Crm's CI; the verdict/alert shell was executed locally from the workflow file against fixtures; the first real execution is the first main build after merge.
* **Cross-registry digest**: `promote` phase B copies the index to GHCR by digest; `satellite-compat-image` asserts equality and fails RED naming both digests if that ever stops holding.
* **Baseline availability**: the previous run's bundle artifacts live 7 days and the run lookup scans the last 100 runs of `main-cd.yml` (~1.5 days at current cadence); a baseline older than that yields a refusal-to-judge with that reason, not a red. `main` carries a `3.0.0-ci.<n>` tag today (measured: `3.0.0-ci.8414`).
* **Education** is measured green today; it runs no compile-check on its own PRs, so a future Education merge can turn its leg 🟡 on its own change — the table's `content.sha` and the baseline column tell that apart from a core break.
* **`plugins-modules` comment** says "this repo holds no registry credential" while `MW_REGISTRY_KEY` exists in core's secrets (no `MW_REGISTRY_URL` var). Not touched; noting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
