### PR TITLE
chart: render Hosting__ControlInbox__Url into the portal ConfigMap (feedback hand-over to the control inbox)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -496,6 +496,17 @@ data:
   {{- end }}
   # A TimeSpan: a real default, never "" (the same typed-key rule as SelfUpdate__MinRollInterval).
   Hosting__ReportInterval: "{{ .Values.config.memex_portal.Hosting__ReportInterval | default "01:00:00" }}"
+  # ---- Feedback hand-over to the control instance (MeshWeaver.Plugins#1713) -----------------
+  # The URL of the control instance's signed inbox that the Feedback plugin hands a technical
+  # submission (bug / idea / technical question) to after Submit — for the fleet that is
+  # https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds. Binds Hosting:ControlInbox:Url.
+  # Empty = the hand-over is OFF and a submission stays in the instance's own Inbox (one warning
+  # per technical submission naming both keys). The control instance leaves it empty: it lists
+  # Hosting/PlatformBuilds as a webhook target and delivers into its own inbox. The other half,
+  # Hosting__ControlInbox__Secret, is a SECRET (Key Vault via a SecretProviderClass, envFrom) —
+  # never a key here. Rendered explicitly so an overlay setting it reaches the container
+  # (config-key-coverage): before this line existed the key was consumed by nothing.
+  Hosting__ControlInbox__Url: "{{ .Values.config.memex_portal.Hosting__ControlInbox__Url | default "" }}"
   WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 | default "" }}"
   # 🚨 #3312 — how a target says it is AUTHENTICATED, paired with the slot it authenticates.
   # Names the CONFIGURATION KEY holding that target's shared HMAC (never the secret itself), and

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -922,6 +922,12 @@ config:
     Hosting__Deployment: ""
     Hosting__ReportTo: ""
     Hosting__ReportInterval: "01:00:00"
+    # ---- Feedback hand-over to the control instance (MeshWeaver.Plugins#1713). The signed inbox
+    # the Feedback plugin hands a technical submission to; the fleet value is
+    # https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds. Empty = hand-over OFF (the
+    # control instance leaves it empty). The HMAC half, Hosting__ControlInbox__Secret, is a SECRET
+    # from Key Vault — set per environment in the overlay, never here.
+    Hosting__ControlInbox__Url: ""
     # The writable root for store-installed modules (ModuleRoot.ConfigKey). Empty here means
     # "follow Deployment__DataRoot", which the template applies — a deployment only sets this
     # when its module tree must live somewhere other than the data root.


### PR DESCRIPTION
## Why

Systemorph/Memex#298 declares `config.memex_portal.Hosting__ControlInbox__Url` on memex-cloud's record and overlay, and that repo's `config-key-coverage` gate went RED: *`config.memex_portal.Hosting__ControlInbox__Url — NEW — reaches no container`*. The portal ConfigMap (`deploy/helm/templates/memex-portal/config.yaml`) names every key explicitly — no range over `config.memex_portal` — so a key the chart does not template is silently dropped, and the Feedback plugin's hand-over to the control instance's signed inbox (MeshWeaver.Plugins#1713, `Hosting:ControlInbox:Url`) would ship inert. Same shape as #3970 (`Teams__AgentSend`), fixed the same way.

## What

- `config.yaml`: render `Hosting__ControlInbox__Url` from `.Values.config.memex_portal.Hosting__ControlInbox__Url | default ""`, in the Hosting inventory section beside `Hosting__ReportTo`. Empty = hand-over OFF (the plugin logs one warning per technical submission and leaves it in the instance's Inbox); the control instance leaves it empty and delivers into its own inbox.
- `values.yaml`: neutral default `""` so `check-values-are-read` stays green; comment names the fleet value `https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds`.
- Deliberately NOT rendered: `Hosting__ControlInbox__Secret` — the HMAC half is a secret that arrives through a Key Vault `SecretProviderClass` (envFrom), never a ConfigMap key.

## Verified

- `helm lint deploy/helm` — 1 chart linted, 0 failed
- `deploy/aks/scripts/check-chart-invariants.sh` — all 7 values combinations render a self-consistent deployment
- `deploy/aks/scripts/check-values-are-read.sh` — 123/123 config keys across 3 values files read by a template (176 readable keys); and against Memex#298's `values.memexcloud.public.yaml` with `CHART_DIR` pointed at this chart: 108/108
- `deploy/aks/scripts/test-chart-drift-compare.sh` — all classification assertions passed
- `helm template` with the key set renders `Hosting__ControlInbox__Url: "https://memex.systemorph.com/api/hooks/Hosting/PlatformBuilds"`; unset renders `""`
- `dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror` — Passed: 432, Failed: 0

Merging this does not ship it: memex-cloud carries the key only after its next hop (C) deploy from a chart ref that includes this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
