### PR TITLE
ci: a runner input on the module-pack and gate lanes — heavy legs can run on the self-hosted aks-silos scale set (phase 3a, core half)

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -56,6 +56,30 @@ name: Node repo gate (reusable)
 #       acr-password: ${{ secrets.ACR_PASSWORD }}
 #       stage-repo-app-id: ${{ secrets.MESHWEAVER_APP_ID }}
 #       stage-repo-app-private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+#
+# ──────── `runner` — declared, and REFUSED for anything but ubuntu-latest (2026-09-12) ────────
+# node-repo-module-pack.yml grew a `runner` input the same day, so a caller can move its heavy
+# legs onto the Systemorph org's self-hosted `aks-silos` scale set (ARC gha-runner-scale-set on
+# the AKS silos pool, ephemeral, min 0 / max 8; proven on Memex run 34681270793). This lane
+# declares the SAME input so a caller sees one contract — and honours it NOWHERE, on purpose. The
+# gate shard's contract is `docker run` of the tester image (above), and the aks-silos runners
+# have NO DOCKER: measured 2026-09-12 in Systemorph/Memex
+# `deployments/aks/ci-runners/arc-runner-scale-set-values.yaml` — no `containerMode:` at all
+# (neither `dind` nor `kubernetes`), one `runner` container from
+# `ghcr.io/actions/actions-runner:2.337.0`, no dind sidecar, no socket mount. That image carries
+# the docker CLI and no daemon. A shard moved there would die at `docker login`, every run.
+#
+# So `plan` REFUSES any value but `ubuntu-latest`, red and by name. A declared input that is
+# silently ignored would let a caller believe its shards moved while they did not — "skipped reads
+# as passed", the shape this file forbids everywhere else. The day the scale set gains a daemon
+# (`containerMode: dind`, or a Kubernetes-mode runner with a daemon sidecar) the change is: drop
+# the refusal in `plan`, put `runs-on: ${{ inputs.runner }}` on `gate`, and — only if a shard ever
+# runs setup-dotnet, which today it does not (the tester runs INSIDE the container, the runner
+# needs no SDK) — `DOTNET_INSTALL_DIR: /home/runner/.dotnet` at job level, because that image is
+# non-root (uid 1001) and ships neither .NET nor Node. Also worth knowing before that day: the
+# runner pod is LIMITED to 2 vCPU / 6 GiB (the node is 16 / 62), and a shard is ~60 serial package
+# installs against a live mesh. Callers: wire this from its OWN repository variable, never the
+# module-pack one — `vars.MW_RUNNER_GATE`, unset today — so a per-family opt-in stays per family.
 
 on:
   workflow_call:
@@ -300,6 +324,17 @@ on:
         required: false
         type: boolean
         default: false
+      runner:
+        description: >-
+          The `runs-on` label the gate shards WOULD run on — declared for parity with
+          node-repo-module-pack.yml's input of the same name, and honoured by NO job here today:
+          a shard is a `docker run` of the tester image, and the self-hosted `aks-silos` scale set
+          has no Docker daemon (measured 2026-09-12; see the header). `plan` fails RED on any value
+          but `ubuntu-latest`, so a caller can never believe its shards moved when they did not.
+          Leave it unset; move the module-pack lane's legs instead.
+        required: false
+        type: string
+        default: ubuntu-latest
     secrets:
       acr-username:
         description: Registry user able to pull the test image.
@@ -351,6 +386,17 @@ jobs:
       run_all: ${{ steps.affected.outputs.run_all }}
       nothing-to-gate: ${{ steps.plan.outputs.nothing_to_gate }}
     steps:
+      # 🚨 The `runner` input is declared and NOT honoured — see the header. An unreadable or
+      # unsupported value is RED here, before anything is planned, so "my shards moved" can never
+      # be believed of a run whose shards stayed. This is an assertion on a caller's CONFIG, not a
+      # skip: nothing downstream is conditional on it.
+      - name: The gate's shards run on GitHub-hosted runners (the `runner` input)
+        env:
+          RUNNER_LABEL: ${{ inputs.runner }}
+        run: |
+          set -euo pipefail
+          [ "$RUNNER_LABEL" = ubuntu-latest ] || { echo "::error::runner is '$RUNNER_LABEL', and this lane honours no other value: a gate shard is a 'docker run' of the tester image, and the self-hosted aks-silos scale set has no Docker daemon (measured 2026-09-12 — header of node-repo-gate.yml). Leave the input unset here; move only node-repo-module-pack.yml's legs."; exit 1; }
+          echo "gate shards: ubuntu-latest — the only value this lane honours (runner='$RUNNER_LABEL')"
       - uses: actions/checkout@v7
         with:
           # The affected computation diffs against the PR base — it needs the base commits.

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -265,6 +265,56 @@ name: node-repo module pack
 # bytes. There is no `_complete` sentinel to shrink here — unlike the prebuilt-bundle bake, this
 # lane uploads one independent bundle per module and never seals a listing, so a partial run costs
 # only the modules it did not reach, never the ones it did.
+#
+# ──────────── Where the heavy legs run (`runner`, 2026-09-12) ────────────
+# The heaviest billed job family in the fleet comes out of THIS lane: MeshWeaver.Plugins'
+# `Module bundles / Module tests` legs cost ~7,800 billed minutes a day over the seven days to
+# 2026-09-12 (40–76 legs a day). The Systemorph org runs a self-hosted runner scale set on the AKS
+# silos node pool — `runs-on` label `aks-silos`, ARC `gha-runner-scale-set`, ephemeral, min 0 /
+# max 8 — proven on Memex run 34681270793 (runner `aks-silos-gknmd-runner-t9dl7`). The `runner`
+# input is how a caller moves the heavy legs there, and ONLY them:
+#
+#   * `pack` (Module bundle) and `tests` (Module tests) honour `runs-on: ${{ inputs.runner }}`.
+#   * `select`, `prepare`, `build-workspace` and `verify` stay on `ubuntu-latest` whatever the
+#     input says. `select` and `verify` are seconds of orchestration. `prepare` and
+#     `build-workspace` NEED DOCKER — `docker pull/save/load/run` of the platform and tester
+#     images; the compiler IS the image — and the aks-silos runners have NONE. Measured
+#     2026-09-12 in Systemorph/Memex `deployments/aks/ci-runners/arc-runner-scale-set-values.yaml`:
+#     no `containerMode:` at all (neither `dind` nor `kubernetes`), a single `runner` container
+#     from `ghcr.io/actions/actions-runner:2.337.0`, no dind sidecar, no socket mount. That image
+#     carries the `docker` CLI and no daemon, so every `docker …` there dies on the socket — a
+#     red, never a silent pass, but a leg that cannot run. Moving those two is not a `runs-on`
+#     edit; it is `containerMode: dind` on the scale set first.
+#
+# Two more facts about that runner image, both measured on Memex's `runner-proof.yml`:
+#   * it is NON-ROOT (`USER runner`, uid 1001; passwordless `sudo` exists). `actions/setup-dotnet`
+#     installs to `/usr/share/dotnet` by default, which is not writable there, so BOTH honouring
+#     jobs set `DOTNET_INSTALL_DIR=/home/runner/.dotnet` at job level whenever `runner` is anything
+#     but `ubuntu-latest`. On `ubuntu-latest` the variable is left EMPTY, which setup-dotnet reads
+#     as unset (`process.env['DOTNET_INSTALL_DIR'] ? … : default`, v6 installer.ts) — the default
+#     path is byte-identical to before this input existed.
+#   * it ships NO toolchain: no .NET, no Node, no `gh`, no `zstd`. What the moved legs take from
+#     the image is `bash`, `git`, `jq`, `curl`, `sudo` and Ubuntu's `python3` (a dependency of the
+#     `software-properties-common` the image installs); the SDK comes from setup-dotnet exactly as
+#     before. The ONE step in `pack` that needs `gh` (`gh run download`, the ledger's REUSE leg) and
+#     the ONE that needs Docker (the `docker cp` fallback, taken only when the
+#     `platform-refs-<digest>` cache `prepare` filled minutes earlier has been evicted) both fail
+#     RED naming what is missing; neither skips.
+#
+# The runner POD is not the node. The scale set requests 500m / 4Gi and LIMITS each runner to
+# 2 vCPU / 6 GiB (the node behind it is 16 vCPU / 62 GiB, shared with the portals). A suite that
+# needs more than 6 GiB is killed there, not slowed — so the first opt-in is a MEASUREMENT of one
+# job family, not a fleet switch.
+#
+# A caller opts in PER JOB FAMILY behind a repository variable, so the move is revertible in ONE
+# edit and never reaches a family nobody measured:
+#
+#     with:
+#       runner: ${{ vars.MW_RUNNER_HEAVY || 'ubuntu-latest' }}
+#
+# Unset, the variable resolves to `ubuntu-latest` and nothing changes. Every current caller — the
+# six satellites and this repo's main-cd — passes nothing and inherits that default. Doc:
+# Doc/Architecture/ModuleBuildArchitecture ("The pipeline, end to end", the 2026-09-12 note).
 
 on:
   workflow_call:
@@ -548,6 +598,20 @@ on:
         required: false
         type: string
         default: off
+      runner:
+        description: >-
+          The `runs-on` label for the HEAVY legs — `pack` (Module bundle) and `tests` (Module
+          tests) — and nothing else; see "Where the heavy legs run" at the top of this file.
+          `ubuntu-latest` (the default) is exactly today's behaviour. `aks-silos` is the Systemorph
+          org's self-hosted scale set: non-root, NO Docker, no preinstalled toolchain, 2 vCPU /
+          6 GiB per runner — the two honouring jobs set DOTNET_INSTALL_DIR under /home/runner for
+          it. Wire it from a repository variable (`vars.MW_RUNNER_HEAVY`, falling back to
+          `ubuntu-latest` when unset — the header shows the expression) so the move is one edit
+          to revert. `select`, `prepare`, `build-workspace` and `verify`
+          ignore it — the middle two need a Docker daemon the scale set does not have.
+        required: false
+        type: string
+        default: ubuntu-latest
     secrets:
       publish-token:
         description: The registry's Plugins:Registry:PublishToken. Required when publish is true.
@@ -1494,8 +1558,13 @@ jobs:
   pack:
     name: Module bundle (${{ matrix.entry.module }})
     needs: [select, prepare, build-workspace]
-    runs-on: ubuntu-latest
+    # `runner` — one of the two jobs that honour it; see "Where the heavy legs run" in the header.
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 45
+    env:
+      # The self-hosted runner is non-root: setup-dotnet cannot write /usr/share/dotnet there.
+      # EMPTY on ubuntu-latest, which setup-dotnet reads as unset — the default path is unchanged.
+      DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
     # Inherit the caller's least-privilege map; declaring OIDC here rejects basic-auth callers at
     # graph creation time, before this job's `acr-login` mode can choose its conditional steps.
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
@@ -1783,6 +1852,12 @@ jobs:
         run: |
           set -euo pipefail
           [ -n "$IMAGE" ] || { echo "::error::platform-image-digest is set but platform-image is empty — name the image the digest belongs to"; exit 1; }
+          # 🚨 The ONE step in this job that needs a Docker daemon, and it runs only when the
+          # `platform-refs-<digest>` cache `prepare` filled earlier in this run has been evicted. A
+          # runner without a daemon (the `aks-silos` scale set — "Where the heavy legs run", top of
+          # this file) cannot take this fallback: say so by name, not three commands later on a
+          # socket error.
+          docker info >/dev/null 2>&1 || { echo "::error::platform-refs-$DIGEST missed the cache and this runner ($RUNNER_NAME) has no Docker daemon to pull $IMAGE with — prepare filled that cache in this same run, so this is an eviction or a foreign runner label. Re-run, or keep 'pack' on ubuntu-latest (the lane's 'runner' input)."; exit 1; }
           if [ "$ACR_LOGIN" = basic ]; then
             [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::platform-image-digest is set but basic ACR credentials were not passed — the image cannot be pulled"; exit 1; }
             echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
@@ -2974,8 +3049,14 @@ jobs:
       !inputs.publish
       && needs.select.result == 'success'
       && needs.select.outputs.test-count != '0'
-    runs-on: ubuntu-latest
+    # `runner` — the other job that honours it; see "Where the heavy legs run" in the header. This
+    # job runs no `docker` at all: a checkout, setup-dotnet, `dotnet test`, `jq`, `python3`.
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 45
+    env:
+      # The self-hosted runner is non-root: setup-dotnet cannot write /usr/share/dotnet there.
+      # EMPTY on ubuntu-latest, which setup-dotnet reads as unset — the default path is unchanged.
+      DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
     strategy:
       # One module's red suite must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -48,6 +48,31 @@ select ─┬─► prepare (ONCE) ──► build (ONE workspace) ──► pac
 6. **verify** — unconditionally pairs the selection against the receipts; a skipped pack with a
    non-zero selection is RED, and so is a delegated suite that produced no test receipt.
 
+> 📅 **2026-09-12 — where the heavy legs run (`runner`).** `node-repo-module-pack.yml` and
+> `node-repo-gate.yml` both take an optional `runner` input (default `ubuntu-latest`, so every
+> current caller is unchanged). In the module-pack lane **`pack` and `tests` honour it**;
+> `select`, `prepare`, `build-workspace` and `verify` stay on `ubuntu-latest` whatever it says,
+> because the middle two `docker pull/save/load/run` the platform and tester images. The label it
+> exists for is `aks-silos`, the Systemorph org's self-hosted ARC scale set on the AKS silos pool
+> (ephemeral, min 0 / max 8; proven on Memex run 34681270793), and three measured facts about it
+> decide what may move: it has **no Docker** (its `arc-runner-scale-set-values.yaml` sets no
+> `containerMode`, and the pod is one `ghcr.io/actions/actions-runner:2.337.0` container with no
+> dind sidecar — the CLI is there, the daemon is not); it is **non-root** (uid 1001), so the two
+> honouring jobs set `DOTNET_INSTALL_DIR=/home/runner/.dotnet` whenever `runner` is not
+> `ubuntu-latest` (`actions/setup-dotnet` cannot write `/usr/share/dotnet` there — measured on
+> Memex's `runner-proof.yml`); and it ships **no toolchain** (no .NET, Node, `gh` or `zstd` —
+> setup-dotnet supplies the SDK as before; the moved legs take only `bash`, `git`, `jq`, `curl`,
+> `sudo` and Ubuntu's `python3` from the image). Each runner pod is limited to 2 vCPU / 6 GiB, so
+> an opt-in is a measurement of one job family, not a fleet switch. The gate lane therefore
+> **declares the same input and honours it nowhere**: a shard is a `docker run` of the tester
+> image, so `plan` fails RED on any value but `ubuntu-latest` — a declared input that was silently
+> ignored would let a caller believe its shards moved. A caller opts in per job family behind a
+> repository variable (`runner: ${{ vars.MW_RUNNER_HEAVY || 'ubuntu-latest' }}` on the module-pack
+> call; a separate variable for the gate on the day the scale set gains Docker), so the move is one
+> edit to revert. The two steps of `pack` that need what the image lacks — `gh run download` on the
+> ledger's reuse leg and the `docker cp` fallback when `prepare`'s `platform-refs-<digest>` cache
+> entry has been evicted — fail RED naming the missing tool; neither skips.
+
 ### Where a module's own suite runs — and why `publish` decides
 
 A `needs:` on a `uses:` job waits for the **whole** called workflow, so anything inside the last


### PR DESCRIPTION
Phase 3(a), core half. Adds an optional `runner` input (string, default `ubuntu-latest`) to the two reusable lanes that produce the fleet's heaviest billed job family, so a caller can move the heavy legs onto the Systemorph org's self-hosted `aks-silos` scale set (ARC `gha-runner-scale-set` on the AKS silos pool; ephemeral, min 0 / max 8; proven on Memex run 34681270793 on `aks-silos-gknmd-runner-t9dl7`). **Default behaviour is unchanged for every current caller** (the six satellites and this repo's `main-cd`, none of which pass the input).

## 🚨 The Docker measurement — it decides what can move

Read 2026-09-12 from `Systemorph/Memex` → `deployments/aks/ci-runners/arc-runner-scale-set-values.yaml` (the applied helm values, rev 1):

- **no `containerMode:` key at all** — neither `dind` nor `kubernetes`;
- the runner pod template is **one container**, `ghcr.io/actions/actions-runner:2.337.0`, `command: ["/home/runner/run.sh"]` — no dind sidecar, no `/var/run/docker.sock` mount;
- that image's Dockerfile (`actions/runner` v2.337.0, `images/Dockerfile`) installs the **docker CLI + buildx and no daemon**, runs as `USER runner` (uid 1001, passwordless `sudo`), and ships `sudo lsb-release gpg-agent software-properties-common curl jq unzip git` — **no .NET, no Node, no `gh`, no `zstd`**; `python3` arrives as a dependency of `software-properties-common`;
- resources: requests `500m / 4Gi`, **limits `2` vCPU / `6Gi`** per runner. The 16 vCPU / 62 GiB is the *node*, shared with the portals — a runner never sees more than 2 cores and 6 GiB.

**So the aks-silos runners have no Docker.** Every `docker …` there dies on the socket (a red, not a silent pass). That rules out every leg whose contract is the tester/platform image.

## What moves, what does not

| Lane | Job | Honours `runner`? | Why |
|---|---|---|---|
| `node-repo-module-pack.yml` | `pack` — *Module bundle (…)* | **yes** | `dotnet build/publish` (sdk entries) or consumes the workspace artifact (container entries), packs, inspects, tests inline on publish runs. No Docker on the main path. |
| `node-repo-module-pack.yml` | `tests` — *Module tests (…)* | **yes** | checkout → setup-dotnet → `dotnet test` → `jq` receipt → `python3` ledger. No `docker` anywhere in the job. |
| `node-repo-module-pack.yml` | `select`, `verify` | no | seconds of orchestration; stay on `ubuntu-latest`. |
| `node-repo-module-pack.yml` | `prepare`, `build-workspace` | **no — cannot** | `docker pull/save/load/run` of the platform and tester images; the compiler *is* the image. Moving them means `containerMode: dind` on the scale set first, not a `runs-on` edit. |
| `node-repo-gate.yml` | `gate` — *Gate shard i/n* | **no — cannot** | the shard's contract is `docker login/pull/run` of the tester image. The input is **declared for parity and honoured nowhere**; `plan` fails RED on any value but `ubuntu-latest`, so a caller can never believe its shards moved when they did not. |
| `node-repo-gate.yml` | `plan`, `verify` | no | orchestration. |

Two steps inside the *movable* `pack` job assume something the runner image lacks, and both now fail RED by name rather than skip:

- the **`docker cp` fallback** (`Take the platform from the image`) — taken only when the `platform-refs-<digest>` cache that `prepare` filled minutes earlier in the same run has been evicted. It now asserts `docker info` first and names the runner, the digest and the input (`re-run, or keep 'pack' on ubuntu-latest`) instead of dying three commands later on a socket error;
- **`gh run download`** on the ledger's *reuse* leg (`ledger: required` only) — `gh` is not on the image; the step runs under `set -euo pipefail` and reds on the missing binary. Not changed; documented.

`sudo chmod a+r /tmp/coredumps/*.dmp || true` (evidence step) works there — the image grants passwordless `sudo` — and is a reporter anyway.

## The non-root rule

`actions/setup-dotnet` installs to `/usr/share/dotnet` by default, which is not writable on that image (measured on Memex's `runner-proof.yml`, which sets `DOTNET_INSTALL_DIR: /home/runner/.dotnet` at job level). Both honouring jobs now carry, at job level:

```yaml
env:
  DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
```

On `ubuntu-latest` the variable is EMPTY, which setup-dotnet v6 reads as unset (`process.env['DOTNET_INSTALL_DIR'] ? … : default` in `installer.ts`) — the install path stays `/usr/share/dotnet`, i.e. the default path is byte-identical to before. (An unconditional `/home/runner/.dotnet` would also work on `ubuntu-latest`, but it moves the SDK out of the directory holding the image's preinstalled runtimes; the conditional keeps the default caller's run exactly as it was.)

## How a caller opts in — per job family, revertible in one edit

```yaml
module-pack:
  uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@<sha>
  with:
    runner: ${{ vars.MW_RUNNER_HEAVY || 'ubuntu-latest' }}
```

Unset, the variable resolves to `ubuntu-latest` and nothing changes. **Do not wire the gate lane to the same variable** — it would red the gate the moment the variable is set; it gets its own (`vars.MW_RUNNER_GATE`) on the day the scale set gains Docker. The first opt-in is a *measurement* of one job family (2 vCPU / 6 GiB per runner; a suite that needs more is OOM-killed, not slowed), not a fleet switch.

## Not in this PR (satellite half / follow-ups)

- **`Portal hosts` is not produced by these lanes.** MeshWeaver.Plugins' `portal-hosts-hosts` / `portal-hosts-build` / `portal-hosts-test` are that repo's own jobs (`runs-on: ubuntu-latest` in its `ci.yml`), and they pre-pull Testcontainers images with `docker pull` — so they are also **not movable** to aks-silos as they stand. Only `Module bundles` (`modules-floor`, calling this lane `@main`) is affected by this PR.
- No caller is changed here; Plugins' `ci.yml` wiring of `runner:` behind `vars.MW_RUNNER_HEAVY` is the satellite half.
- No `containerMode` change to the scale set (Memex repo).

## Docs

One dated paragraph in `Doc/Architecture/ModuleBuildArchitecture` under the lane list (nothing else on that page touched). `dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror` — see the checks.

## Guards

`check-workflow-timeouts`, `check-workflow-shell`, `check-workflow-yaml-keys`, `check-pr-secret-preflight`, `check-workflow-permission-pairing` (incl. `--fleet .github/lane-caller-grants.yml`, self-test + run) all green on this tree; `actionlint` reports no findings beyond the 15 pre-existing shellcheck info/style lines already on `origin/main`.

Pairs-with: none — a workflow input on two reusable lanes; no public C# surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
