### PR TITLE
fix(#4083): the module link probe compares assembly versions — roll-forward tolerated, roll-back is a hard verdict, and FileLoadException has a state

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -110,6 +110,94 @@ The one exception: an unresolved assembly whose simple name is the **platform's 
 (`MeshWeaver.`) is refused. That is the whole-assembly shape of the same defect and a certain load
 failure.
 
+### 2026-09-12 — assembly versions are compared, asymmetrically (MeshWeaver#4083)
+
+> This section **narrows** the two paragraphs above it. Where they disagree, this one holds.
+
+**What happened.** On 2026-09-11 core #4012 bumped YamlDotNet 16.3.0 → 18.1.0. `MeshWeaver.AI`
+references YamlDotNet directly and versionless, was built on an image carrying 18, and landed
+through the registry on portal pods whose image shipped 16. The probe said `Linkable`. Every new
+pod crash-looped at hub construction on `FileLoadException 0x80131040` (memex-cloud, 60+ restarts;
+Memex#281 carried the pin move). Two independent causes, neither of them the `MeshWeaver.` prefix
+filter — that line sits inside the *not carried* branch, and a running portal carries YamlDotNet:
+
+1. **The closure rule excluded the reference.** The bundle shipped its own YamlDotNet, so the
+   reference fell under *"built together with the module"* — a premise that is false exactly when
+   the platform carries the same simple name, because the platform's already-loaded copy is what
+   the loader binds and the bundle's copy never runs. The pair that decides is module ↔ platform.
+2. **No version was ever compared.** `ResolveScope` kept only the referenced assembly's *name*;
+   the comparison was type-name existence, and both YamlDotNet majors carry the same type names.
+   `ModuleLinkState` had no state to put a `FileLoadException` verdict in even if one had been
+   computed — `Unlinkable` models the `TypeLoadException` shape.
+
+**The rule now.** For every assembly reference of a module whose simple name the platform surface
+carries — third-party included; `MeshWeaver.*` keep the type-identity rule *and* are compared like
+everything else — the reference's manifest **version and public key token** are compared against
+the **platform's** copy, and the module's own closure no longer short-circuits a reference the
+platform's copy would win (`ModulePlatformSurface.IsPlatformBound`: on a running process the
+trusted platform assemblies and the application directory; every assembly of a published document
+or a file set). The verdict is:
+
+| Reference vs platform copy | Verdict | Why |
+|---|---|---|
+| **higher** version | **`BindingConflict`** — hard: refused at landing and boot, `ModuleUnloadable` at the roll | the loader refuses the bind itself; the exception is certain, not a risk |
+| **lower** version | `Linkable`, with the drift on `Advisories` | the loader rolls **forward** — patch drift is ordinary, and a gate that reds on it is switched off within the week |
+| equal | as before | — |
+| different **public key token** under the same name | **`BindingConflict`** | a different key is a different assembly to the loader, whatever the versions |
+| the surface records **no version** | `Linkable`, advisory | unknown is unknown — never a hard verdict on a document that predates the section |
+
+**Why asymmetric.** .NET binding rolls forward and never back: a request for `16.3.0.0` binds
+happily to a loaded `18.1.0.0`, a request for `18.1.0.0` against a loaded `16.3.0.0` is
+`FileLoadException`. A symmetric equality check would red every portal whose image is a patch
+ahead of a module's build — which is the ordinary state of the fleet between waves — and the gate
+would be switched off. The check refuses only what the loader refuses, and *reports* the rest.
+`AssemblyVersion` is pinned per line (`3.0.0.0` across the whole 3.0 line), so for `MeshWeaver.*`
+the comparison is a no-op today and starts deciding when a module built on the next line meets an
+image on this one — which is exactly a bind the loader would refuse.
+
+**Both directions of the incident.** The probe runs on the *same* code (`ModulePlatformLink.Check`)
+at every call site, and the new state is honoured at each: **(i) the roll candidate** —
+`ReleaseAvailabilityService.SelectRollTarget → Judge → ModuleLinkObservation.Measure` links every
+landed module against the *candidate's* published surface; `BindingConflict` is the
+`ModuleUnloadable` hold, the roll-forward drift is a verdict advisory. **(ii) the module landing**
+— `ModuleLandingService.LandCore` links the incoming bytes, closure and all, against the *running*
+surface before anything touches the disk (this path already probed; the closure rule was what hid
+the reference), and refuses on `MayLoad == false`, which `BindingConflict` is. The boot probe
+(`MeshBuilder.TryLoad`) and prebuilt adoption (`PrebuiltAdoptionPolicy.AfterLink`) refuse the same
+way. There is no call site at which a `BindingConflict` reads as anything but a refusal, because
+`MayLoad` is true for `Linkable` alone.
+
+**The document.** `platform-surface.json` gains an `identities` sibling of `assemblies`, keyed by
+the same names — version and public key token per listed assembly, read from each assembly's
+manifest without loading it:
+
+```json
+{
+  "identity": "s5b8b0e2c…",
+  "assemblies": { "YamlDotNet": ["YamlDotNet.Serialization.Deserializer", "…"], "…": [] },
+  "identities": { "YamlDotNet": { "version": "16.3.0.0", "publicKeyToken": "ec19458f3c15af5e" }, "…": {} }
+}
+```
+
+A sibling, not a richer `assemblies` value, because every reader shipped before this date requires
+each `assemblies` value to be an array of strings and throws otherwise — and ignores an unknown root
+property. An older platform reads the new document as before; a newer platform reading an older
+document sees no identities and reports every version comparison as unknown. The producer is
+unchanged in kind: `ModulePlatformSurface.ToJson`, written by `BakeOutput.WritePlatformSurface`
+and by `mw-plugin-test platform-surface`; `publish-bake-bundles.sh` uploads whatever the bake
+wrote.
+
+**What this still does not see.** Member-level skew (below), and the publish side: nothing yet
+compares a bundle about to be published against the images the fleet actually runs (#4066). Every
+receiving pod measures for itself, with this probe.
+
+Tests: `ModuleLinkVersionTest` (the 09-11 shape verbatim — two stand-in `YamlDotNet` builds with
+identical type names — every arm of the table, the closure exception for a module's own superseded
+sibling, and both directions on the real landing service and the boot-shaped check) and, in
+`ReleaseLinkGateTest`, `AModuleBoundAboveTheTargetsVersion_HoldsTheRoll_NamingBothVersions` /
+`AModuleBoundBelowTheTargetsVersion_Clears_WithTheDriftAsAnAdvisory` for the roll-candidate
+direction.
+
 ### What it does NOT see
 
 **Member-level skew.** A method or constructor signature that moved on a type that still exists —

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md
@@ -187,6 +187,18 @@ unchanged in kind: `ModulePlatformSurface.ToJson`, written by `BakeOutput.WriteP
 and by `mw-plugin-test platform-surface`; `publish-bake-bundles.sh` uploads whatever the bake
 wrote.
 
+**Where a hold shows — a hold must be visible where a person looks, not only logged.**
+
+| Path | Where the verdict is written | What it says |
+|---|---|---|
+| roll candidate (i) | `Admin/UpdatePolicy` → `heldReason` (the poller writes `verdict.HoldReason` verbatim); the Updates tab renders it | `Views: its landed module MeshWeaver.AI cannot load on 3.0.0-ci.8323 (…): … references YamlDotNet 18.0.0.0 (this platform carries 16.0.0.0) — the target's copy is what the loader binds …` |
+| module landing (ii) | the module's own **refusal marker** `modules/activation.d/<Name>.refused` (`ModuleActivationSidecar.RefusedLanding`), read by `PendingModuleActivations` onto the package card (⛔ *Not installed on this platform: it needs YamlDotNet 18.1.0.0, this platform provides 16.3.0.0 …*, localized) and into `/health`'s activation report | `held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0` |
+| boot | the unloadable marker (`<Name>.unloadable`, unchanged) → quarantined on the card and in `/health` | the probe's report |
+
+Before this date the landing path's refusal was **one warning line in a pod log** (`PluginBundleClient`: *"landing failed — the module is unchanged"*) and nothing else: no entry is written on a refusal, so no status surface had anything to show. The marker is written by the refusing landing, cleared by the next landing of that module that lands anything, and by uninstall.
+
+**Blast radius, measured 2026-09-12** — the registry's published module set (30 module bundles on memex.meshweaver.cloud) under the new rule, each bundle's own copies in its closure, against the image's `/app` + shared frameworks as the surface: `3.0.0-ci.8372` (memex) and `3.0.0-ci.8403` (memex-cloud): **0 held**, 1 advisory (ContainerRegistry: System.Reactive 6.1.0.0 → platform 7.0.0.0, rolls forward). `3.0.0-ci.8323` — the image that crash-looped on 09-11 — **20 of 30 held**: `MeshWeaver.AI` on `YamlDotNet 18.0.0.0` vs `16.0.0.0` *and* `System.Reactive 7.0.0.0` vs `6.1.0.0`, `MeshWeaver.Publish` on YamlDotNet, eighteen others on System.Reactive (core bumped both on 09-11, after 8323 was built). The rule fires on exactly the image that failed and on nothing the fleet runs now.
+
 **What this still does not see.** Member-level skew (below), and the publish side: nothing yet
 compares a bundle about to be published against the images the fleet actually runs (#4066). Every
 receiving pod measures for itself, with this probe.

--- a/src/MeshWeaver.Hosting/PrebuiltAdoptionPolicy.cs
+++ b/src/MeshWeaver.Hosting/PrebuiltAdoptionPolicy.cs
@@ -267,9 +267,32 @@ public static class PrebuiltAdoptionPolicy
             case ModuleLinkState.Linkable:
                 return decision with
                 {
-                    Reason = decision.Reason + $"; {link.CheckedTypeReferences} platform type reference(s) resolve",
+                    Reason = decision.Reason + $"; {link.CheckedTypeReferences} platform type reference(s) resolve"
+                             + (link.Advisories.IsDefaultOrEmpty
+                                 ? ""
+                                 : "; version skew that rolls forward, advisory: " + string.Join("; ", link.Advisories)),
                     LinkCheckRequired = false,
                 };
+            case ModuleLinkState.BindingConflict:
+            {
+                // The FileLoadException shape (#4083): a hard verdict like Unlinkable — the
+                // assembly never binds on this platform, whatever its types look like.
+                var conflicts = link.BindingConflicts.IsDefaultOrEmpty
+                    ? "(none named)"
+                    : string.Join(", ", link.BindingConflicts.Take(5))
+                      + (link.BindingConflicts.Length > 5 ? $" … +{link.BindingConflicts.Length - 5}" : "");
+                return live.RequirePrebuilt
+                    ? new AdoptionDecision(AdoptionVerdict.Refuse,
+                        $"{link.Module} references assembly versions this deployment does not carry "
+                        + $"({conflicts}) — the platform's copy binds and never rolls back — and this "
+                        + $"mesh does not compile module content "
+                        + $"({PrebuiltAssemblySeeder.RequirePrebuiltConfigKey}): rebake the package for "
+                        + $"framework {live.FrameworkIdentity}", LinkCheckRequired: false)
+                    : new AdoptionDecision(AdoptionVerdict.CompileInstead,
+                        $"{link.Module} references assembly versions this deployment does not carry "
+                        + $"({conflicts}) — the platform's copy binds and never rolls back; the live "
+                        + "source compiles instead", LinkCheckRequired: false);
+            }
             case ModuleLinkState.Unlinkable:
             {
                 var missing = link.MissingTypes.IsDefaultOrEmpty

--- a/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
+++ b/src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs
@@ -89,7 +89,8 @@ public sealed record IncompatibleModule(string Entry, string Name, string Error,
     /// and removes the shape entirely.</para>
     /// </summary>
     /// <param name="entry">The raw entry or resolved path that was going to be installed.</param>
-    /// <param name="verdict">The refusal — <see cref="ModuleLinkState.Unlinkable"/> or
+    /// <param name="verdict">The refusal — <see cref="ModuleLinkState.Unlinkable"/>,
+    /// <see cref="ModuleLinkState.BindingConflict"/> or
     /// <see cref="ModuleLinkState.Indeterminate"/>.</param>
     public static IncompatibleModule FromLinkRefusal(string entry, ModuleLinkVerdict verdict)
     {
@@ -98,7 +99,10 @@ public sealed record IncompatibleModule(string Entry, string Name, string Error,
             entry,
             Path.GetFileNameWithoutExtension(entry) is { Length: > 0 } name ? name : verdict.Module,
             verdict.Report(),
-            verdict.MissingTypes.IsDefaultOrEmpty ? null : verdict.MissingTypes[0])
+            // The first thing the loader would refuse: an assembly that cannot bind comes before
+            // any type in it (#4083), then the first missing type.
+            !verdict.BindingConflicts.IsDefaultOrEmpty ? verdict.BindingConflicts[0]
+            : verdict.MissingTypes.IsDefaultOrEmpty ? null : verdict.MissingTypes[0])
         {
             RefusedBeforeLoad = true,
         };

--- a/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
@@ -33,6 +33,18 @@ public enum ModuleLinkState
     /// refused there is the whole platform's update, on a publication that may simply predate the
     /// surface document; the boot-time probe is the safety net.</summary>
     Indeterminate,
+
+    /// <summary>🚨 The <see cref="FileLoadException"/> shape (#4083): the module's bytes reference
+    /// an assembly the platform carries — third-party included — at a HIGHER version than the
+    /// platform's copy, or under a different public key token. The platform's copy is what the
+    /// loader binds (a copy travelling in the module's own bundle never loads when the platform
+    /// already carries the simple name), and .NET binds a reference only to an equal or HIGHER
+    /// version: the bind itself is refused, whatever the type names look like — both YamlDotNet
+    /// majors carry the same types, and 2026-09-11 crash-looped every new pod on exactly that.
+    /// A hard verdict everywhere <see cref="Unlinkable"/> is one: refused at landing and at boot,
+    /// a hold at the roll gate. Appended, never inserted: the state is on the wire in
+    /// serialized verdicts.</summary>
+    BindingConflict,
 }
 
 /// <summary>
@@ -66,8 +78,32 @@ public sealed record ModuleLinkVerdict(
 {
     /// <summary>True only for <see cref="ModuleLinkState.Linkable"/> — the one state a caller may
     /// load on. Written as an explicit predicate so no call site can spell the check as
-    /// <c>!= Unlinkable</c> and quietly admit <see cref="ModuleLinkState.Indeterminate"/>.</summary>
+    /// <c>!= Unlinkable</c> and quietly admit <see cref="ModuleLinkState.Indeterminate"/> — or,
+    /// since #4083, <see cref="ModuleLinkState.BindingConflict"/>.</summary>
     public bool MayLoad => State == ModuleLinkState.Linkable;
+
+    /// <summary>
+    /// 🚨 The assembly references that CANNOT bind on this platform (#4083), each as
+    /// <c>Name wanted (this platform carries have)</c>: the module asks for a HIGHER version of an
+    /// assembly the platform carries, or for a different public key token. Non-empty exactly when
+    /// <see cref="State"/> is <see cref="ModuleLinkState.BindingConflict"/>.
+    /// </summary>
+    public ImmutableArray<string> BindingConflicts { get; init; } = [];
+
+    /// <summary>
+    /// Version skew that is REPORTED and never refused (#4083): a reference to a LOWER version than
+    /// the platform carries (the loader rolls forward — patch drift is ordinary, and a gate that
+    /// reds on it is switched off within the week), and a carried assembly whose version the
+    /// surface does not record (a <see cref="ModulePlatformSurface.PublishedFileName"/> written
+    /// before versions were published: unknown is unknown, never a hard verdict). Carried on a
+    /// <see cref="ModuleLinkState.Linkable"/> verdict too — a reader that wants the drift can read
+    /// it; nothing decides on it.
+    /// </summary>
+    public ImmutableArray<string> Advisories { get; init; } = [];
+
+    /// <summary>How many assembly references were compared by version against the platform's copy
+    /// — the version half's DENOMINATOR, beside <see cref="CheckedTypeReferences"/>.</summary>
+    public int ComparedAssemblyReferences { get; init; }
 
     /// <summary>
     /// The operator-facing sentence: which module, what it wants that this build does not have,
@@ -78,9 +114,8 @@ public sealed record ModuleLinkVerdict(
     public string Report() => State switch
     {
         ModuleLinkState.Linkable =>
-            $"Module '{Module}' links against this platform ({CheckedTypeReferences} type "
-            + $"reference(s) checked across {CheckedAssemblies.Length} platform assembly/assemblies"
-            + Unchecked() + ").",
+            $"Module '{Module}' links against this platform ({Denominator()}" + Unchecked() + ")"
+            + Advised() + ".",
         ModuleLinkState.Unlinkable =>
             $"Module '{Module}' was built against a platform this deployment is NOT running and "
             + "CANNOT be loaded here: it references "
@@ -89,12 +124,33 @@ public sealed record ModuleLinkVerdict(
             + "throws TypeLoadException at the first render that touches it — every render, "
             + "forever, with nothing connecting it to the install. Move the platform and the "
             + "module together: this module becomes loadable when the platform updates. "
-            + $"({CheckedTypeReferences} type reference(s) checked across "
-            + $"{CheckedAssemblies.Length} platform assembly/assemblies" + Unchecked() + ")",
+            + $"({Denominator()}" + Unchecked() + ")" + Advised(),
+        ModuleLinkState.BindingConflict =>
+            $"Module '{Module}' was built against assembly VERSIONS this deployment is NOT running "
+            + "and CANNOT be loaded here: it references "
+            + string.Join(", ", BindingConflicts)
+            + ". The platform's copy is what the loader binds — a copy of the same assembly "
+            + "travelling in the module's own bundle never loads when the platform carries the "
+            + "name — and .NET binds a reference only to an EQUAL or HIGHER version under the same "
+            + "public key token, never to a lower one. Loading it anyway throws FileLoadException "
+            + "(0x80131040) the first time any code path touches the assembly; on 2026-09-11 that "
+            + "was hub construction, and every new pod crash-looped. Move the platform and the "
+            + "module together: this module becomes loadable on a platform carrying at least the "
+            + "referenced version"
+            + (MissingTypes.IsDefaultOrEmpty
+                ? ""
+                : " — and it also references " + string.Join(", ", MissingTypes)
+                  + ", which the platform's copy does not have")
+            + $". ({Denominator()}" + Unchecked() + ")" + Advised(),
         _ =>
             $"Module '{Module}': whether it links against this platform could NOT be determined "
             + $"({Detail}). Not loading it: an unanswerable check is not a passed one.",
     };
+
+    private string Denominator() =>
+        $"{CheckedTypeReferences} type reference(s) checked across {CheckedAssemblies.Length} "
+        + $"platform assembly/assemblies, {ComparedAssemblyReferences} assembly reference(s) "
+        + "compared by version";
 
     private string Unchecked() =>
         UncheckedAssemblies.IsDefaultOrEmpty
@@ -102,6 +158,35 @@ public sealed record ModuleLinkVerdict(
             : $"; {UncheckedAssemblies.Length} referenced assembly/assemblies are neither the "
               + "platform's nor this module's own closure and were NOT checked: "
               + string.Join(", ", UncheckedAssemblies);
+
+    private string Advised() =>
+        Advisories.IsDefaultOrEmpty
+            ? string.Empty
+            : $" Advisory ({Advisories.Length}), reported and deciding nothing: "
+              + string.Join("; ", Advisories);
+}
+
+/// <summary>
+/// What a platform assembly IS, as the loader identifies it (#4083): the manifest version and the
+/// public key token, read from the assembly's own identity without loading it. Null members are
+/// UNKNOWN — a surface document written before versions were published, an unsigned assembly —
+/// and unknown compares as an advisory, never as a conflict.
+/// </summary>
+/// <param name="Version">The assembly's manifest version, or null when not known.</param>
+/// <param name="PublicKeyToken">The public key token as 16 lowercase hex characters, or null for
+/// an unsigned assembly or one whose token is not known.</param>
+public sealed record PlatformAssemblyIdentity(Version? Version, string? PublicKeyToken)
+{
+    /// <summary>The identity of an <see cref="AssemblyName"/> — a loaded assembly's, a file's
+    /// manifest, or a reference's — in this record's spelling.</summary>
+    public static PlatformAssemblyIdentity Of(AssemblyName name)
+    {
+        ArgumentNullException.ThrowIfNull(name);
+        var token = name.GetPublicKeyToken();
+        return new PlatformAssemblyIdentity(
+            name.Version,
+            token is { Length: > 0 } ? Convert.ToHexStringLower(token) : null);
+    }
 }
 
 /// <summary>
@@ -138,23 +223,43 @@ public sealed class ModulePlatformSurface
     // silent about everything else, so a reference to an undeclared assembly is judged by the same
     // carries/platform-prefix rules as against a live surface.
     private readonly ImmutableDictionary<string, ImmutableHashSet<string>> _declared;
+    // 🚨 The DECLARED identities (#4083): assembly → version + public key token, read from the
+    // document's `identities` section. An assembly the document declares types for but no identity
+    // (a document written before #4083) is carried with an UNKNOWN identity, which the probe
+    // reports as an advisory and never as a conflict.
+    private readonly ImmutableDictionary<string, PlatformAssemblyIdentity> _declaredIdentities;
+    // 🚨 Which carried assemblies the loader binds to the PLATFORM's copy even when a module ships
+    // its own (#4083): on a running process the trusted platform assemblies and the application
+    // directory — a copy loaded from a LANDED module directory is not one of them, since a module
+    // re-landing its own siblings must be measured against the siblings it brings, not the
+    // generation it supersedes. Null means every carried assembly: a published document describes
+    // a platform image's /app alone, and a file set IS the platform host.
+    private readonly ImmutableHashSet<string>? _platformBound;
     // Per-instance memo of what each platform assembly exports. ConcurrentDictionary because a
     // caller may check several modules in parallel; an instance field, so its lifetime is the
     // batch's.
     private readonly ConcurrentDictionary<string, ImmutableHashSet<string>?> _types =
+        new(StringComparer.OrdinalIgnoreCase);
+    private readonly ConcurrentDictionary<string, PlatformAssemblyIdentity?> _identities =
         new(StringComparer.OrdinalIgnoreCase);
 
     private ModulePlatformSurface(
         ImmutableDictionary<string, string> files,
         ImmutableDictionary<string, Assembly> loaded,
         ImmutableDictionary<string, ImmutableHashSet<string>>? declared = null,
-        string? identity = null)
+        string? identity = null,
+        ImmutableDictionary<string, PlatformAssemblyIdentity>? declaredIdentities = null,
+        ImmutableHashSet<string>? platformBound = null)
     {
         _files = files;
         _loaded = loaded;
         _declared = declared
             ?? ImmutableDictionary<string, ImmutableHashSet<string>>.Empty
                 .WithComparers(StringComparer.OrdinalIgnoreCase);
+        _declaredIdentities = declaredIdentities
+            ?? ImmutableDictionary<string, PlatformAssemblyIdentity>.Empty
+                .WithComparers(StringComparer.OrdinalIgnoreCase);
+        _platformBound = platformBound;
         Identity = identity;
     }
 
@@ -178,12 +283,45 @@ public sealed class ModulePlatformSurface
     /// <param name="probeDirectories">Directories to add — production passes the application base
     /// directory. Missing directories are skipped.</param>
     public static ModulePlatformSurface OfRunningProcess(params string[] probeDirectories)
-        => Of(AppDomain.CurrentDomain.GetAssemblies(), probeDirectories);
+    {
+        // 🚨 What binds AHEAD of a module's own copy on this process (#4083): the trusted platform
+        // assemblies (the application's closure plus the shared frameworks — the TPA binder is
+        // consulted before any LoadFrom sibling) and whatever sits in the application directory.
+        // A copy this process loaded from a LANDED module's directory is deliberately not in the
+        // set: it is what a superseded generation brought, not what the next boot binds.
+        var platformBound = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        var tpa = AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty;
+        foreach (var path in tpa.Split(Path.PathSeparator, StringSplitOptions.RemoveEmptyEntries))
+            platformBound.Add(Path.GetFileNameWithoutExtension(path));
+        var baseDirectory = Path.TrimEndingDirectorySeparator(Path.GetFullPath(AppContext.BaseDirectory));
+        var loadedAssemblies = AppDomain.CurrentDomain.GetAssemblies();
+        foreach (var assembly in loadedAssemblies)
+        {
+            var name = assembly.GetName().Name;
+            if (string.IsNullOrEmpty(name) || assembly.IsDynamic || string.IsNullOrEmpty(assembly.Location))
+                continue;
+            if (IsUnder(assembly.Location, baseDirectory))
+                platformBound.Add(name);
+        }
+        foreach (var directory in probeDirectories ?? [])
+        {
+            if (string.IsNullOrWhiteSpace(directory) || !Directory.Exists(directory)
+                || !string.Equals(
+                    Path.TrimEndingDirectorySeparator(Path.GetFullPath(directory)), baseDirectory,
+                    StringComparison.OrdinalIgnoreCase))
+                continue;
+            foreach (var file in Directory.EnumerateFiles(directory, "*.dll"))
+                platformBound.Add(Path.GetFileNameWithoutExtension(file));
+        }
+        return Of(loadedAssemblies, platformBound.ToImmutable(), probeDirectories);
+    }
 
     /// <summary>
     /// The pure form: an explicit set of loaded assemblies and probe directories. The seam a test
     /// fabricates an OLDER platform through — which is the only way to reproduce the defect
-    /// without two builds of the product.
+    /// without two builds of the product. The loaded assemblies handed in are what the loader
+    /// binds, so they are the platform-bound set (<see cref="IsPlatformBound"/>); the probe
+    /// directories' files are not.
     /// </summary>
     /// <param name="loadedAssemblies">The assemblies a module would bind to, in precedence order;
     /// the first of a simple name wins, exactly as the loader resolves it.</param>
@@ -192,6 +330,19 @@ public sealed class ModulePlatformSurface
         IEnumerable<Assembly> loadedAssemblies, params string[] probeDirectories)
     {
         ArgumentNullException.ThrowIfNull(loadedAssemblies);
+        var assemblies = loadedAssemblies.ToArray();
+        var platformBound = assemblies
+            .Select(a => a.GetName().Name)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .Select(n => n!)
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+        return Of(assemblies, platformBound, probeDirectories);
+    }
+
+    private static ModulePlatformSurface Of(
+        IEnumerable<Assembly> loadedAssemblies, ImmutableHashSet<string> platformBound,
+        string[]? probeDirectories)
+    {
         var loaded = ImmutableDictionary.CreateBuilder<string, Assembly>(StringComparer.OrdinalIgnoreCase);
         foreach (var assembly in loadedAssemblies)
         {
@@ -209,7 +360,17 @@ public sealed class ModulePlatformSurface
                 files.TryAdd(Path.GetFileNameWithoutExtension(file), file);
         }
 
-        return new ModulePlatformSurface(files.ToImmutable(), loaded.ToImmutable());
+        return new ModulePlatformSurface(
+            files.ToImmutable(), loaded.ToImmutable(), platformBound: platformBound);
+    }
+
+    private static bool IsUnder(string path, string directory)
+    {
+        var parent = Path.GetDirectoryName(Path.GetFullPath(path));
+        return parent is not null
+               && string.Equals(
+                   Path.TrimEndingDirectorySeparator(parent), directory,
+                   StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -244,7 +405,8 @@ public sealed class ModulePlatformSurface
     /// <para>The shape is minimal and documented in <c>Doc/Architecture/ModulePlatformLinkGate</c>:</para>
     /// <code>
     /// { "identity": "s&lt;hash&gt;",
-    ///   "assemblies": { "MeshWeaver.Blazor": ["MeshWeaver.Blazor.BlazorView`2", …], … } }
+    ///   "assemblies": { "MeshWeaver.Blazor": ["MeshWeaver.Blazor.BlazorView`2", …], … },
+    ///   "identities": { "YamlDotNet": { "version": "16.3.0.0", "publicKeyToken": "ec19458f3c15af5e" }, … } }
     /// </code>
     /// <para>Every assembly this surface carries is listed with the SAME set <see cref="TypesOf"/>
     /// answers — type definitions and exported/forwarded types, full names, nested as
@@ -252,6 +414,16 @@ public sealed class ModulePlatformSurface
     /// live process would. An assembly whose surface cannot be read (no file, unreadable metadata)
     /// is OMITTED rather than written empty: an empty list would read as "this assembly has no
     /// types" and report every reference to it as missing.</para>
+    ///
+    /// <para>🚨 <b><c>identities</c> (#4083)</b> carries, per listed assembly, the manifest version
+    /// and public key token the loader binds by — the two facts type names cannot express (both
+    /// YamlDotNet majors carry the same type names; only the version refuses the bind). A SIBLING
+    /// of <c>assemblies</c> rather than a richer value inside it, because every reader shipped
+    /// before this section requires each <c>assemblies</c> value to be an array of strings and
+    /// throws otherwise — and ignores an unknown root property. So an older platform reads the new
+    /// document exactly as before, and a newer platform reading an older document sees no
+    /// identities and reports every version comparison as unknown (an advisory, never a
+    /// verdict).</para>
     /// </summary>
     /// <param name="identity">The framework build identity the described platform resolves, or
     /// null when the writer does not know it.</param>
@@ -259,22 +431,38 @@ public sealed class ModulePlatformSurface
     {
         var names = _declared.Keys.Concat(_loaded.Keys).Concat(_files.Keys)
             .Distinct(StringComparer.OrdinalIgnoreCase)
-            .OrderBy(name => name, StringComparer.Ordinal);
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToArray();
         using var buffer = new MemoryStream();
         using (var writer = new Utf8JsonWriter(buffer))
         {
             writer.WriteStartObject();
             writer.WriteString(IdentityProperty, identity ?? Identity);
             writer.WriteStartObject(AssembliesProperty);
+            var listed = new List<string>();
             foreach (var name in names)
             {
                 var types = TypesOf(name);
                 if (types is null)
                     continue;
+                listed.Add(name);
                 writer.WriteStartArray(name);
                 foreach (var type in types.OrderBy(t => t, StringComparer.Ordinal))
                     writer.WriteStringValue(type);
                 writer.WriteEndArray();
+            }
+            writer.WriteEndObject();
+            writer.WriteStartObject(IdentitiesProperty);
+            foreach (var name in listed)
+            {
+                if (IdentityOf(name) is not { } assemblyIdentity)
+                    continue;
+                writer.WriteStartObject(name);
+                if (assemblyIdentity.Version is { } version)
+                    writer.WriteString(VersionProperty, version.ToString(4));
+                if (assemblyIdentity.PublicKeyToken is { } token)
+                    writer.WriteString(PublicKeyTokenProperty, token);
+                writer.WriteEndObject();
             }
             writer.WriteEndObject();
             writer.WriteEndObject();
@@ -330,20 +518,116 @@ public sealed class ModulePlatformSurface
                 $"{PublishedFileName}: '{AssembliesProperty}' is empty — a platform with no "
                 + "assemblies is not a surface anything could link against");
 
+        // 🚨 OPTIONAL (#4083): a document written before versions were published has no
+        // `identities`, and reads as a surface whose every version is UNKNOWN — advisory, never a
+        // verdict. Present, it is held to the documented shape like everything else: a malformed
+        // version would otherwise become a silent "unknown" on a document that claims to know.
+        var identities = ImmutableDictionary.CreateBuilder<string, PlatformAssemblyIdentity>(
+            StringComparer.OrdinalIgnoreCase);
+        if (root.TryGetProperty(IdentitiesProperty, out var identitiesElement))
+        {
+            if (identitiesElement.ValueKind != JsonValueKind.Object)
+                throw new JsonException(
+                    $"{PublishedFileName}: '{IdentitiesProperty}' is not an object");
+            foreach (var entry in identitiesElement.EnumerateObject())
+            {
+                if (entry.Value.ValueKind != JsonValueKind.Object)
+                    throw new JsonException(
+                        $"{PublishedFileName}: '{IdentitiesProperty}.{entry.Name}' is not an object");
+                Version? version = null;
+                if (entry.Value.TryGetProperty(VersionProperty, out var versionElement))
+                {
+                    if (versionElement.ValueKind != JsonValueKind.String
+                        || !Version.TryParse(versionElement.GetString(), out version))
+                        throw new JsonException(
+                            $"{PublishedFileName}: '{IdentitiesProperty}.{entry.Name}.{VersionProperty}' "
+                            + "is not a version");
+                }
+                string? token = null;
+                if (entry.Value.TryGetProperty(PublicKeyTokenProperty, out var tokenElement))
+                {
+                    if (tokenElement.ValueKind != JsonValueKind.String)
+                        throw new JsonException(
+                            $"{PublishedFileName}: '{IdentitiesProperty}.{entry.Name}.{PublicKeyTokenProperty}' "
+                            + "is not a string");
+                    token = tokenElement.GetString();
+                }
+                identities[entry.Name] = new PlatformAssemblyIdentity(version, token);
+            }
+        }
+
         return new ModulePlatformSurface(
             ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
             ImmutableDictionary<string, Assembly>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase),
             declared.ToImmutable(),
-            identity);
+            identity,
+            identities.ToImmutable());
     }
 
     private const string IdentityProperty = "identity";
     private const string AssembliesProperty = "assemblies";
+    private const string IdentitiesProperty = "identities";
+    private const string VersionProperty = "version";
+    private const string PublicKeyTokenProperty = "publicKeyToken";
 
     /// <summary>Whether this platform carries an assembly of that simple name at all.</summary>
     public bool Carries(string assemblyName) =>
         _loaded.ContainsKey(assemblyName) || _files.ContainsKey(assemblyName)
         || _declared.ContainsKey(assemblyName);
+
+    /// <summary>
+    /// 🚨 Whether the PLATFORM's copy of <paramref name="assemblyName"/> is what the loader binds
+    /// even when a module ships its own copy (#4083). True for every assembly a published document
+    /// or a file set carries (they describe a platform image and nothing else); on a running
+    /// process, true for the trusted platform assemblies and the application directory, and false
+    /// for a copy this process loaded from a landed module's directory — that copy is a superseded
+    /// generation's, and a module re-landing its own siblings is measured against the siblings it
+    /// brings. This is the predicate that decides whether a reference into the module's OWN
+    /// closure is in the denominator: it is, exactly when the platform's copy wins.
+    /// </summary>
+    public bool IsPlatformBound(string assemblyName) =>
+        Carries(assemblyName) && (_platformBound is null || _platformBound.Contains(assemblyName));
+
+    /// <summary>
+    /// The identity — manifest version and public key token — of the copy of
+    /// <paramref name="assemblyName"/> this platform binds, read from the loaded assembly's name,
+    /// the file's manifest, or the document's <c>identities</c> section; never by loading anything.
+    /// Null when the assembly is not carried or its identity is not known (a document written
+    /// before #4083, an unreadable file).
+    /// </summary>
+    public PlatformAssemblyIdentity? IdentityOf(string assemblyName) =>
+        _identities.GetOrAdd(assemblyName, ReadIdentity);
+
+    private PlatformAssemblyIdentity? ReadIdentity(string assemblyName)
+    {
+        if (_declaredIdentities.TryGetValue(assemblyName, out var declared))
+            return declared;
+        if (!_declared.IsEmpty)
+            return null; // a declared surface knows only what its document says
+
+        // The loaded copy is the exact identity bound; its name is metadata, already in memory.
+        if (_loaded.TryGetValue(assemblyName, out var assembly))
+            return PlatformAssemblyIdentity.Of(assembly.GetName());
+
+        if (_files.GetValueOrDefault(assemblyName) is not { } path)
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+                return null;
+            var metadata = peReader.GetMetadataReader();
+            if (!metadata.IsAssembly)
+                return null;
+            return PlatformAssemblyIdentity.Of(metadata.GetAssemblyDefinition().GetAssemblyName());
+        }
+        catch (Exception exception) when (exception is IOException or BadImageFormatException
+                                              or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
 
     /// <summary>
     /// The full type names <paramref name="assemblyName"/> exposes here — type definitions AND
@@ -455,11 +739,24 @@ public sealed class ModulePlatformSurface
 /// <para><b>What is in the denominator, and what is deliberately not.</b> A referenced assembly is
 /// checked when the PLATFORM carries it. An assembly travelling in the module's OWN closure is not
 /// checked — it was built together with the module, and their agreement is not this gate's
-/// question. An assembly that is in neither is NAMED in the verdict and left unchecked: it is a
-/// private dependency whose absence fails as a <c>FileNotFoundException</c>, a different defect
-/// with a different remedy. The one exception is an assembly whose simple name is the PLATFORM's
-/// own (<see cref="PlatformAssemblyPrefix"/>) that this deployment does not carry at all — that is
-/// the whole-assembly shape of the same defect and is refused.</para>
+/// question — <i>unless the platform carries the same simple name and its copy is what the loader
+/// binds</i> (<see cref="ModulePlatformSurface.IsPlatformBound"/>, #4083): then the module's copy
+/// never loads, the "built together" premise is false, and the pair that decides is
+/// module ↔ platform. An assembly that is in neither is NAMED in the verdict and left unchecked:
+/// it is a private dependency whose absence fails as a <c>FileNotFoundException</c>, a different
+/// defect with a different remedy. The one exception is an assembly whose simple name is the
+/// PLATFORM's own (<see cref="PlatformAssemblyPrefix"/>) that this deployment does not carry at
+/// all — that is the whole-assembly shape of the same defect and is refused.</para>
+///
+/// <para><b>Two measurements, one verdict (#4083).</b> Type references are resolved by NAME
+/// against the platform copy's types (the <c>TypeLoadException</c> shape,
+/// <see cref="ModuleLinkState.Unlinkable"/>); assembly references are compared by IDENTITY —
+/// version and public key token — against the platform copy's (the <c>FileLoadException</c>
+/// shape, <see cref="ModuleLinkState.BindingConflict"/>). The second is asymmetric because the
+/// loader is: a reference to a lower version than the platform carries rolls forward and is
+/// reported as an advisory; a reference to a higher version, or to a different key, is refused
+/// by the loader and is a hard verdict here. <c>MeshWeaver.*</c> assemblies keep the type-identity
+/// rule and are compared by version like every other carried assembly.</para>
 ///
 /// <para><b>Member-level skew is NOT covered and must not be assumed to be.</b> This checks TYPE
 /// references. A method or constructor signature that moved on a type that still exists (#2234's
@@ -515,7 +812,9 @@ public static class ModulePlatformLink
     /// <param name="entryBytes">The entry assembly's bytes.</param>
     /// <param name="moduleName">The module's assembly simple name (for the report).</param>
     /// <param name="closure">The simple names of the assemblies travelling WITH the module,
-    /// including the entry itself — references to those are out of the denominator.</param>
+    /// including the entry itself — references to those are out of the denominator, unless the
+    /// platform carries the same simple name and its copy is what the loader binds
+    /// (<see cref="ModulePlatformSurface.IsPlatformBound"/>, #4083).</param>
     /// <param name="surface">The platform this module would be loaded into.</param>
     public static ModuleLinkVerdict Check(
         byte[] entryBytes, string moduleName, IReadOnlySet<string> closure,
@@ -556,8 +855,74 @@ public static class ModulePlatformLink
             return Indeterminate(moduleName, $"{exception.GetType().Name}: {exception.Message}");
         }
 
+        List<string> conflicts = [];
+        List<string> advisories = [];
+        var comparedRefs = 0;
+
         using (peReader)
         {
+            // 🚨 THE VERSION HALF (#4083). Type names cannot express "the reference asks for
+            // 18.1.0.0 and this platform has 16.3.0.0": both YamlDotNet majors carry the same
+            // type names, and on 2026-09-11 the type walk below said Linkable while every new
+            // pod crash-looped on FileLoadException at hub construction. So every assembly
+            // reference whose simple name the platform carries is compared by IDENTITY against the
+            // platform's copy — the copy the loader binds. The rule is ASYMMETRIC on purpose,
+            // because .NET binding rolls FORWARD and never back: a reference to a LOWER version
+            // than the platform carries binds to the platform's newer copy (an advisory, so the
+            // drift is on record; never a refusal, because patch drift is ordinary and a gate that
+            // reds on it is switched off within the week), a reference to a HIGHER version is
+            // refused by the loader itself and is therefore a hard verdict here, and a different
+            // public key token under the same name is refused whatever the versions say.
+            foreach (var handle in metadata.AssemblyReferences)
+            {
+                var reference = metadata.GetAssemblyReference(handle);
+                var assemblyName = metadata.GetString(reference.Name);
+                if (!InDenominator(assemblyName, closure, surface))
+                    continue;
+
+                var wanted = PlatformAssemblyIdentity.Of(reference.GetAssemblyName());
+                var have = surface.IdentityOf(assemblyName);
+                comparedRefs++;
+                if (have is null)
+                {
+                    advisories.Add(
+                        $"{assemblyName}: the module references {wanted.Version?.ToString(4) ?? "an unversioned copy"}, "
+                        + "and this platform's surface records no version for its copy — not "
+                        + "compared (a surface published before versions were recorded reads as "
+                        + "unknown, never as a conflict)");
+                    continue;
+                }
+
+                if (wanted.PublicKeyToken is { } wantedToken && have.PublicKeyToken is { } haveToken
+                    && !string.Equals(wantedToken, haveToken, StringComparison.OrdinalIgnoreCase))
+                {
+                    conflicts.Add(
+                        $"{assemblyName} with public key token {wantedToken} (this platform carries "
+                        + $"public key token {haveToken})");
+                    continue;
+                }
+
+                // An unversioned reference (0.0.0.0) binds to any version; nothing to compare.
+                if (wanted.Version is not { } wantedVersion || wantedVersion == UnversionedReference)
+                    continue;
+                if (have.Version is not { } haveVersion)
+                {
+                    advisories.Add(
+                        $"{assemblyName}: the module references {wantedVersion.ToString(4)}, and the "
+                        + "version of this platform's copy is not known — not compared");
+                    continue;
+                }
+                var order = wantedVersion.CompareTo(haveVersion);
+                if (order > 0)
+                    conflicts.Add(
+                        $"{assemblyName} {wantedVersion.ToString(4)} (this platform carries "
+                        + $"{haveVersion.ToString(4)})");
+                else if (order < 0)
+                    advisories.Add(
+                        $"{assemblyName}: the module references {wantedVersion.ToString(4)}, this "
+                        + $"platform carries {haveVersion.ToString(4)} — binds and rolls forward");
+            }
+
             foreach (var handle in metadata.TypeReferences)
             {
                 var reference = metadata.GetTypeReference(handle);
@@ -565,8 +930,10 @@ public static class ModulePlatformLink
                     continue; // same-assembly or module-scoped reference — nothing external to check
 
                 // The module's own closure: built together with the entry, so their agreement is
-                // not this gate's question.
-                if (closure.Contains(assemblyName))
+                // not this gate's question — UNLESS the platform carries the same simple name and
+                // its copy is what the loader binds (#4083), in which case the module's copy never
+                // loads and the pair that decides is module ↔ platform.
+                if (closure.Contains(assemblyName) && !surface.IsPlatformBound(assemblyName))
                     continue;
 
                 if (!surface.Carries(assemblyName))
@@ -607,14 +974,38 @@ public static class ModulePlatformLink
             }
         }
 
+        // A binding conflict is the loader's FIRST refusal — the assembly never binds, so no type
+        // in it is ever looked up — which is why it outranks a missing type in the verdict.
+        var state = conflicts.Count > 0 ? ModuleLinkState.BindingConflict
+            : missing.Count > 0 ? ModuleLinkState.Unlinkable
+            : ModuleLinkState.Linkable;
         return new ModuleLinkVerdict(
-            missing.Count == 0 ? ModuleLinkState.Linkable : ModuleLinkState.Unlinkable,
+            state,
             moduleName,
             [.. missing.Distinct(StringComparer.Ordinal).OrderBy(m => m, StringComparer.Ordinal)],
             checkedRefs,
             [.. checkedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)],
-            [.. uncheckedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)]);
+            [.. uncheckedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)])
+        {
+            BindingConflicts = [.. conflicts.Distinct(StringComparer.Ordinal).OrderBy(c => c, StringComparer.Ordinal)],
+            Advisories = [.. advisories.Distinct(StringComparer.Ordinal).OrderBy(a => a, StringComparer.Ordinal)],
+            ComparedAssemblyReferences = comparedRefs,
+        };
     }
+
+    /// <summary>The version an assembly reference carries when the compiler was given no version
+    /// at all — it binds to any copy, so there is nothing to compare.</summary>
+    private static readonly Version UnversionedReference = new(0, 0, 0, 0);
+
+    /// <summary>
+    /// Whether a reference to <paramref name="assemblyName"/> is measured against the platform:
+    /// the platform carries it, and either the module does not ship its own copy or the platform's
+    /// copy is what the loader binds anyway (<see cref="ModulePlatformSurface.IsPlatformBound"/>).
+    /// </summary>
+    private static bool InDenominator(
+        string assemblyName, IReadOnlySet<string> closure, ModulePlatformSurface surface) =>
+        surface.Carries(assemblyName)
+        && (!closure.Contains(assemblyName) || surface.IsPlatformBound(assemblyName));
 
     private static ModuleLinkVerdict Indeterminate(string moduleName, string detail) =>
         new(ModuleLinkState.Indeterminate, moduleName, [], 0, [], [], detail);

--- a/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
+++ b/src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs
@@ -88,7 +88,53 @@ public sealed record ModuleLinkVerdict(
     /// assembly the platform carries, or for a different public key token. Non-empty exactly when
     /// <see cref="State"/> is <see cref="ModuleLinkState.BindingConflict"/>.
     /// </summary>
-    public ImmutableArray<string> BindingConflicts { get; init; } = [];
+    public ImmutableArray<string> BindingConflicts => [.. Conflicts.Select(c => c.Describe())];
+
+    /// <summary>The binding conflicts as DATA (#4083) — assembly, what the module asks for, what
+    /// the platform provides — so a status surface can render them in the viewer's language and a
+    /// marker can carry them without re-parsing a sentence. <see cref="BindingConflicts"/> is the
+    /// operator spelling of the same list.</summary>
+    public ImmutableArray<AssemblyBindingConflict> Conflicts { get; init; } = [];
+
+    /// <summary>
+    /// The short status-line form of a refusal, for the module's own status surfaces (the
+    /// activation sidecar's refusal marker, the package card, <c>/health</c>) — e.g.
+    /// <c>held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0</c>. Null for
+    /// <see cref="ModuleLinkState.Linkable"/>. English by design, like <see cref="Report"/>; the
+    /// viewer-facing card localizes the sentence and takes <see cref="Needs"/> /
+    /// <see cref="Provides"/> as data.
+    /// </summary>
+    public string? HoldSummary() => State switch
+    {
+        ModuleLinkState.Linkable => null,
+        ModuleLinkState.BindingConflict =>
+            "held: " + string.Join("; ", Conflicts.Select(c => c.Short())),
+        ModuleLinkState.Unlinkable =>
+            "held: references " + string.Join(", ", MissingTypes.Take(3))
+            + (MissingTypes.Length > 3 ? $" (+{MissingTypes.Length - 3} more)" : "")
+            + ", which this platform does not carry",
+        _ => $"held: whether it links could not be determined ({Detail})",
+    };
+
+    /// <summary>What the refused module NEEDS, as language-neutral data for a localized status
+    /// line: the conflicting assemblies with the versions the module asks for
+    /// (<c>YamlDotNet 18.1.0.0, System.Reactive 7.0.0.0</c>), or for a type refusal the first
+    /// missing types. Null when nothing is refused.</summary>
+    public string? Needs() => State switch
+    {
+        ModuleLinkState.BindingConflict => string.Join(", ", Conflicts.Select(c => $"{c.Assembly} {c.Referenced}")),
+        ModuleLinkState.Unlinkable => string.Join(", ", MissingTypes.Take(3))
+            + (MissingTypes.Length > 3 ? $" (+{MissingTypes.Length - 3})" : ""),
+        ModuleLinkState.Indeterminate => Detail,
+        _ => null,
+    };
+
+    /// <summary>What this platform PROVIDES for each conflicting assembly, in the order of
+    /// <see cref="Needs"/> (<c>16.3.0.0, 6.1.0.0</c>); null unless the refusal is a binding
+    /// conflict.</summary>
+    public string? Provides() => State == ModuleLinkState.BindingConflict
+        ? string.Join(", ", Conflicts.Select(c => c.Provided))
+        : null;
 
     /// <summary>
     /// Version skew that is REPORTED and never refused (#4083): a reference to a LOWER version than
@@ -164,6 +210,29 @@ public sealed record ModuleLinkVerdict(
             ? string.Empty
             : $" Advisory ({Advisories.Length}), reported and deciding nothing: "
               + string.Join("; ", Advisories);
+}
+
+/// <summary>
+/// One assembly reference the loader would refuse to bind on this platform (#4083): the module
+/// asks for a HIGHER version than the platform provides, or a different public key token.
+/// </summary>
+/// <param name="Assembly">The assembly's simple name.</param>
+/// <param name="Referenced">What the module's bytes ask for — a version (<c>18.1.0.0</c>) or, for
+/// a key conflict, a public key token.</param>
+/// <param name="Provided">What the platform's copy carries, in the same spelling.</param>
+/// <param name="IsPublicKeyToken">True when the conflict is the key, not the version.</param>
+public sealed record AssemblyBindingConflict(
+    string Assembly, string Referenced, string Provided, bool IsPublicKeyToken = false)
+{
+    /// <summary>The operator spelling, as <see cref="ModuleLinkVerdict.BindingConflicts"/> lists it.</summary>
+    public string Describe() => IsPublicKeyToken
+        ? $"{Assembly} with public key token {Referenced} (this platform carries public key token {Provided})"
+        : $"{Assembly} {Referenced} (this platform carries {Provided})";
+
+    /// <summary>The status-line spelling: <c>references YamlDotNet 18.1.0.0, platform provides 16.3.0.0</c>.</summary>
+    public string Short() => IsPublicKeyToken
+        ? $"references {Assembly} with public key token {Referenced}, platform provides {Provided}"
+        : $"references {Assembly} {Referenced}, platform provides {Provided}";
 }
 
 /// <summary>
@@ -855,7 +924,7 @@ public static class ModulePlatformLink
             return Indeterminate(moduleName, $"{exception.GetType().Name}: {exception.Message}");
         }
 
-        List<string> conflicts = [];
+        List<AssemblyBindingConflict> conflicts = [];
         List<string> advisories = [];
         var comparedRefs = 0;
 
@@ -896,9 +965,7 @@ public static class ModulePlatformLink
                 if (wanted.PublicKeyToken is { } wantedToken && have.PublicKeyToken is { } haveToken
                     && !string.Equals(wantedToken, haveToken, StringComparison.OrdinalIgnoreCase))
                 {
-                    conflicts.Add(
-                        $"{assemblyName} with public key token {wantedToken} (this platform carries "
-                        + $"public key token {haveToken})");
+                    conflicts.Add(new AssemblyBindingConflict(assemblyName, wantedToken, haveToken, IsPublicKeyToken: true));
                     continue;
                 }
 
@@ -914,9 +981,8 @@ public static class ModulePlatformLink
                 }
                 var order = wantedVersion.CompareTo(haveVersion);
                 if (order > 0)
-                    conflicts.Add(
-                        $"{assemblyName} {wantedVersion.ToString(4)} (this platform carries "
-                        + $"{haveVersion.ToString(4)})");
+                    conflicts.Add(new AssemblyBindingConflict(
+                        assemblyName, wantedVersion.ToString(4), haveVersion.ToString(4)));
                 else if (order < 0)
                     advisories.Add(
                         $"{assemblyName}: the module references {wantedVersion.ToString(4)}, this "
@@ -987,7 +1053,7 @@ public static class ModulePlatformLink
             [.. checkedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)],
             [.. uncheckedAssemblies.ToImmutable().OrderBy(a => a, StringComparer.OrdinalIgnoreCase)])
         {
-            BindingConflicts = [.. conflicts.Distinct(StringComparer.Ordinal).OrderBy(c => c, StringComparer.Ordinal)],
+            Conflicts = [.. conflicts.Distinct().OrderBy(c => c.Assembly, StringComparer.Ordinal)],
             Advisories = [.. advisories.Distinct(StringComparer.Ordinal).OrderBy(a => a, StringComparer.Ordinal)],
             ComparedAssemblyReferences = comparedRefs,
         };

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -623,6 +623,8 @@
   "ui.moduleBuiltForNewerPlatform": "Hier nicht aktiv: Diese Version wurde für eine neuere Plattform gebaut. Sie wird aktiv, sobald diese Installation aktualisiert wird.",
   "ui.moduleRunsPreviousVersion": "Läuft mit der vorherigen Version {0}: Version {1} ist installiert, lädt aber auf dieser Plattform nicht. Sie wird aktiv, sobald ein hier ladbarer Build erscheint.",
   "ui.moduleDeclaresNewerPlatform": "Deklariert Plattform ≥ {0}; diese Installation läuft mit {1}. Nur ein Hinweis — ob es lädt, wird gemessen, nicht deklariert.",
+  "ui.moduleHeldAtLanding": "Auf dieser Plattform nicht installiert: es benötigt {0}, diese Plattform stellt {1} bereit. Es wird installiert, sobald diese Installation auf eine Plattform aktualisiert, die es bereitstellt.",
+  "ui.moduleHeldAtLandingTypes": "Auf dieser Plattform nicht installiert: es verweist auf {0}, was diese Plattform nicht hat. Es wird installiert, sobald diese Installation aktualisiert wird.",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",
   "ui.resetToDefault": "Auf Standard zurücksetzen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -623,6 +623,8 @@
   "ui.moduleBuiltForNewerPlatform": "Not running here: this version was built for a newer platform. It activates when this installation updates.",
   "ui.moduleDeclaresNewerPlatform": "Declares platform ≥ {0}; this installation runs {1}. Advisory only — whether it loads is measured, not declared.",
   "ui.moduleRunsPreviousVersion": "Running the previous version {0}: version {1} is installed but does not load on this platform. It activates once a build that loads here ships.",
+  "ui.moduleHeldAtLanding": "Not installed on this platform: it needs {0}, this platform provides {1}. It installs when this installation updates to a platform that provides it.",
+  "ui.moduleHeldAtLandingTypes": "Not installed on this platform: it references {0}, which this platform does not have. It installs when this installation updates.",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -787,6 +787,19 @@ public static class CatalogLayoutAreas
                 .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
                            + "display: block; margin-top: 6px;"));
 
+        // 🚨 #4083 — a landing this installation REFUSED: the bytes cannot bind on this platform
+        // (a higher assembly version than the platform provides, or a missing type), nothing
+        // landed, and a restart changes nothing. It used to be one warning line in a pod log;
+        // the card says what the module needs and what this platform provides, as DATA inside a
+        // localized sentence — platform-owned chrome follows the VIEWER.
+        else if (activation.RefusalForPackage($"{PackageInstaller.InstalledPartition}/{pkg.Id}") is { } refusal)
+            card = card.WithView(Controls.Body(
+                    "⛔ " + (refusal.Provides is not null
+                        ? host.Localize("ui.moduleHeldAtLanding", refusal.Needs ?? "?", refusal.Provides)
+                        : host.Localize("ui.moduleHeldAtLandingTypes", refusal.Needs ?? "?")))
+                .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
+                           + "display: block; margin-top: 6px;"));
+
         // 🚨 #3649 — the FIFTH state, and the first that is not a fault: the newest generation
         // does not load on this platform, so this installation runs the previous one. The module
         // works; the line says which version that is and that the newer one is waiting on a

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -360,6 +360,109 @@ public static class ModuleActivationSidecar
         }
     }
 
+    // ── the refused-landing marker (#4083) ──────────────────────────────────
+
+    /// <summary>
+    /// 🚨 What a LANDING refused, and why — the marker that makes a refusal visible where a person
+    /// looks (#4083). A refusal at landing writes no generation and no entry (that is the point:
+    /// the previous generation keeps serving), so before this marker the only trace of "module X
+    /// was not installed because its bytes cannot bind here" was one warning line in a pod log.
+    /// The marker is the landing path's counterpart of <see cref="UnloadableGeneration"/> (which
+    /// only boots write): written by the landing that refused, cleared by the next landing of the
+    /// same module that lands anything, and by uninstall.
+    /// </summary>
+    /// <param name="Version">The package version whose bytes were refused, when known.</param>
+    /// <param name="PackagePath">The mesh path of the install record that asked, when recorded —
+    /// what the package card matches on.</param>
+    /// <param name="Reason">The status-line sentence, e.g. <c>held: references YamlDotNet
+    /// 18.1.0.0, platform provides 16.3.0.0</c> (<c>ModuleLinkVerdict.HoldSummary</c>).</param>
+    /// <param name="RefusedAt">When the landing refused it.</param>
+    /// <param name="Needs">What the module needs, as data for a localized line
+    /// (<c>YamlDotNet 18.1.0.0</c>); null when not measured that way.</param>
+    /// <param name="Provides">What this platform provides for it (<c>16.3.0.0</c>); null for a
+    /// refusal that is not a binding conflict.</param>
+    public sealed record RefusedLanding(
+        string? Version, string? PackagePath, string Reason, DateTimeOffset RefusedAt,
+        string? Needs = null, string? Provides = null);
+
+    /// <summary>The per-module refusal marker's file suffix inside <see cref="EntriesDirectoryName"/>
+    /// — like <see cref="UnloadableMarkerSuffix"/>, deliberately not <c>.json</c>.</summary>
+    public const string RefusedMarkerSuffix = ".refused";
+
+    /// <summary>The marker file recording that the last landing of a module was REFUSED here:
+    /// <c>modules/activation.d/&lt;Name&gt;.refused</c>.</summary>
+    public static string RefusedMarkerPath(string baseDirectory, string moduleName) =>
+        Path.Combine(EntriesDirectory(baseDirectory), moduleName + RefusedMarkerSuffix);
+
+    /// <summary>Records that a landing of <paramref name="moduleName"/> was refused — an atomic
+    /// replace of that module's own marker. Idempotent.</summary>
+    public static void SetRefused(string baseDirectory, string moduleName, RefusedLanding refusal)
+    {
+        ValidateModuleName(moduleName);
+        ArgumentNullException.ThrowIfNull(refusal);
+        Directory.CreateDirectory(EntriesDirectory(baseDirectory));
+        WriteAtomic(RefusedMarkerPath(baseDirectory, moduleName), JsonSerializer.Serialize(refusal, Json));
+    }
+
+    /// <summary>Removes the module's refusal marker — a later landing landed something, or the
+    /// module was uninstalled. Tolerant of an absent file and a read-only volume.</summary>
+    public static void ClearRefused(string baseDirectory, string moduleName)
+    {
+        ValidateModuleName(moduleName);
+        try
+        {
+            File.Delete(RefusedMarkerPath(baseDirectory, moduleName));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Another replica clearing the same marker, or a read-only volume.
+        }
+    }
+
+    /// <summary>The module's refusal marker, or null when there is none or it cannot be read.</summary>
+    public static RefusedLanding? ReadRefused(string baseDirectory, string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName))
+            return null;
+        try
+        {
+            var text = TryReadAllText(RefusedMarkerPath(baseDirectory, moduleName));
+            return text is null ? null : JsonSerializer.Deserialize<RefusedLanding>(text, Json);
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException or JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>Every refusal marker under the deployment, module name → marker, sorted by name.
+    /// A refused FIRST install has no activation entry at all, so the report enumerates the
+    /// markers rather than the entries.</summary>
+    public static ImmutableSortedDictionary<string, RefusedLanding> ReadRefusals(string baseDirectory)
+    {
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, RefusedLanding>(StringComparer.OrdinalIgnoreCase);
+        var directory = EntriesDirectory(baseDirectory);
+        if (!Directory.Exists(directory))
+            return builder.ToImmutable();
+        IEnumerable<string> files;
+        try
+        {
+            files = Directory.EnumerateFiles(directory, "*" + RefusedMarkerSuffix).ToArray();
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return builder.ToImmutable();
+        }
+        foreach (var file in files)
+        {
+            var name = Path.GetFileName(file);
+            name = name[..^RefusedMarkerSuffix.Length];
+            if (ReadRefused(baseDirectory, name) is { } refusal)
+                builder[name] = refusal;
+        }
+        return builder.ToImmutable();
+    }
+
     /// <summary>Attaches the marker's identity to <paramref name="entry"/> when — and only when —
     /// the marker measured the generation the entry currently heads.</summary>
     private static ModuleActivationEntry WithUnloadableMarker(string baseDirectory, ModuleActivationEntry entry)

--- a/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLandingService.cs
@@ -717,24 +717,41 @@ public sealed class ModuleLandingService : IDisposable
         var landedBefore = ModuleActivationSidecar.Read(baseDirectory,
             msg => logger?.LogWarning("{Message}", msg));
         var surface = PlatformSurface(landedBefore);
-        var held = LinkHoldReason();
+        var linkVerdict = LinkVerdict();
+        var held = linkVerdict.MayLoad ? null : linkVerdict.Report();
         if (held is not null && !holdUnloadable)
         {
             logger?.LogWarning("Module '{Name}' REFUSED at landing: {Reason}", name, held);
+            // 🚨 The refusal is RECORDED where a person looks (#4083), not only logged: the
+            // module's own refusal marker, which the activation report reads onto the package
+            // card and /health as "held: references YamlDotNet 18.1.0.0, platform provides
+            // 16.3.0.0". Nothing landed, so there is no entry to carry it — the marker is the
+            // record. Best-effort: a marker that cannot be written must not turn a refusal into
+            // a different failure.
+            try
+            {
+                ModuleActivationSidecar.SetRefused(baseDirectory, name, new ModuleActivationSidecar.RefusedLanding(
+                    version, packagePath, linkVerdict.HoldSummary()!, DateTimeOffset.UtcNow,
+                    linkVerdict.Needs(), linkVerdict.Provides()));
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+            {
+                logger?.LogWarning(e, "Module '{Name}': the refusal marker could not be written", name);
+            }
             throw new InvalidOperationException($"Module '{name}' refused: {held}");
         }
 
-        string? LinkHoldReason()
+        ModuleLinkVerdict LinkVerdict()
         {
             var entryBytes = assemblies.First(a =>
                 string.Equals(a.FileName, entryDll, StringComparison.OrdinalIgnoreCase)).Bytes;
             // The module's own closure travels WITH it, so a reference into it is not this gate's
-            // question — the two were built together. Only the PLATFORM side is measured.
+            // question — the two were built together — UNLESS the platform carries the same
+            // simple name and its copy is what binds (#4083); the probe decides which.
             var closure = assemblies
                 .Select(a => Path.GetFileNameWithoutExtension(a.FileName))
                 .ToHashSet(StringComparer.OrdinalIgnoreCase);
-            var verdict = ModulePlatformLink.Check(entryBytes, name, closure, surface);
-            return verdict.MayLoad ? null : verdict.Report();
+            return ModulePlatformLink.Check(entryBytes, name, closure, surface);
         }
 
         // 🚨 THE GENERATION IS CONTENT-ADDRESSED (#3656) — `name@<16 hex of SHA-256 over the bytes
@@ -1039,6 +1056,9 @@ public sealed class ModuleLandingService : IDisposable
         // with no reader. It writes exactly when the fallback moved.
         if (!keepsNewerHead || !entry.Equals(displaced))
             ModuleActivationSidecar.WriteEntry(baseDirectory, entry);
+        // Bytes landed (head or shelf), so a refusal marker from an earlier landing of this module
+        // no longer describes the state (#4083).
+        ModuleActivationSidecar.ClearRefused(baseDirectory, name);
         // A HELD landing does not raise the restart signal: a restart cannot activate it (boot runs
         // the same link probe on the same bytes and parks the entry again), so "restart required"
         // would be a prompt no restart can clear. The platform update that DOES carry the types
@@ -1249,6 +1269,7 @@ public sealed class ModuleLandingService : IDisposable
         // An uninstalled module has no head to have measured (#3650); a marker left behind would
         // be inert (its generation is gone) but is one more thing to explain.
         ModuleActivationSidecar.ClearUnloadable(baseDirectory, name);
+        ModuleActivationSidecar.ClearRefused(baseDirectory, name);
 
         // Best-effort immediate delete: on a shared volume the files of a LOADED module refuse
         // deletion (SMB keeps them open) — that is fine, the cleared pointers above make the

--- a/src/MeshWeaver.PluginCatalog/ModuleLinkObservation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleLinkObservation.cs
@@ -54,7 +54,9 @@ public static class ModuleLinkObservation
                 continue;
             var verdict = ModulePlatformLink.Check(package.LandedModulePath, surface);
             links[package.Name] = verdict;
-            if (verdict.State != ModuleLinkState.Linkable)
+            // Anything but a clean Linkable is worth a line — a hard verdict, an unknown, or a
+            // Linkable that carries roll-forward version drift (#4083, reported and never a hold).
+            if (verdict.State != ModuleLinkState.Linkable || !verdict.Advisories.IsDefaultOrEmpty)
                 logger?.LogInformation(
                     "[ReleaseGate] {Package}: landed module {Module} against the published surface "
                     + "of {Identity}: {Report}",

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -99,6 +99,28 @@ public sealed record ModuleActivationReport(
     /// </summary>
     public ImmutableList<ModuleFallback> Fallbacks { get; init; } = [];
 
+    /// <summary>
+    /// 🚨 #4083 — the modules whose LAST LANDING WAS REFUSED here: the bytes could not bind on
+    /// this platform (a higher assembly version than the platform provides, a missing type), so
+    /// nothing landed and the previous generation — or nothing — keeps serving. Before this row
+    /// the only trace was a warning in a pod log. Derived from the per-module refusal marker
+    /// (<see cref="ModuleActivationSidecar.RefusedLanding"/>), which the refusing landing writes
+    /// and the next landing that lands anything clears. Init-only, for the same
+    /// binary-compatibility reason as the rows above.
+    /// </summary>
+    public ImmutableList<ModuleRefusal> Refused { get; init; } = [];
+
+    /// <summary>Whether anything was refused at landing.</summary>
+    public bool HasRefused => !IsUndetermined && !Refused.IsEmpty;
+
+    /// <summary>The refusal row for the module the install record at <paramref name="packagePath"/>
+    /// asked to land, or null.</summary>
+    public ModuleRefusal? RefusalForPackage(string? packagePath) =>
+        IsUndetermined || string.IsNullOrWhiteSpace(packagePath)
+            ? null
+            : Refused.FirstOrDefault(r => string.Equals(
+                r.PackagePath, packagePath, StringComparison.OrdinalIgnoreCase));
+
     /// <summary>True when the state is KNOWN and a module runs its previous generation.</summary>
     public bool HasFallbacks => !IsUndetermined && !Fallbacks.IsEmpty;
 
@@ -185,7 +207,8 @@ public sealed record ModuleActivationReport(
               + (HasDeferred ? "; " + DescribeDeferred(Deferred) : string.Empty)
               + (HasQuarantined ? "; " + DescribeQuarantined(Quarantined) : string.Empty)
               + (HasFallbacks ? "; " + DescribeFallbacks(Fallbacks) : string.Empty)
-              + (HasFloorAdvisories ? "; " + DescribeFloorAdvisories(FloorAdvisories) : string.Empty);
+              + (HasFloorAdvisories ? "; " + DescribeFloorAdvisories(FloorAdvisories) : string.Empty)
+              + (HasRefused ? "; " + DescribeRefused(Refused) : string.Empty);
 
     /// <summary>
     /// One human-readable line naming the modules that run their PREVIOUS generation (#3649) or
@@ -213,6 +236,20 @@ public sealed record ModuleActivationReport(
             + "and working, behind the set; no restart changes that, a build that loads here does: "
             + string.Join("; ", rows.Take(Math.Max(1, maxNamed)))
             + (rows.Length > maxNamed ? $"; …(+{rows.Length - maxNamed})" : string.Empty);
+    }
+
+    /// <summary>The refusal sentence for operators (#4083): each module by name with its status
+    /// line — <c>MeshWeaver.AI (1.9.0): held: references YamlDotNet 18.1.0.0, platform provides
+    /// 16.3.0.0</c>.</summary>
+    public static string DescribeRefused(IReadOnlyCollection<ModuleRefusal> refused, int maxNamed = 10)
+    {
+        var named = refused.Take(maxNamed)
+            .Select(r => $"{r.Name}{(string.IsNullOrWhiteSpace(r.Version) ? "" : $" ({r.Version})")}: {r.Reason}");
+        return $"{refused.Count} module(s) REFUSED at landing — nothing of them landed, the previous "
+               + "generation (if any) keeps serving, and a restart changes nothing; they install when "
+               + "this platform updates: "
+               + string.Join("; ", named)
+               + (refused.Count > maxNamed ? $" … +{refused.Count - maxNamed}" : string.Empty);
     }
 
     /// <summary>
@@ -289,6 +326,19 @@ public sealed record ModuleActivationReport(
             + (names.Length > maxNamed ? $", …(+{names.Length - maxNamed})" : string.Empty);
     }
 }
+
+/// <summary>One module whose last landing was refused here (#4083) — the row the package card
+/// and <c>/health</c> render from the refusal marker.</summary>
+/// <param name="Name">The module's assembly simple name.</param>
+/// <param name="PackagePath">The mesh path of the install record that asked, when recorded.</param>
+/// <param name="Version">The refused package version, when known.</param>
+/// <param name="Reason">The status line: <c>held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0</c>.</param>
+/// <param name="RefusedAt">When.</param>
+/// <param name="Needs">What it needs, as data for a localized line (<c>YamlDotNet 18.1.0.0</c>), or null.</param>
+/// <param name="Provides">What this platform provides (<c>16.3.0.0</c>), or null for a type refusal.</param>
+public sealed record ModuleRefusal(
+    string Name, string? PackagePath, string? Version, string Reason, DateTimeOffset RefusedAt,
+    string? Needs, string? Provides);
 
 /// <summary>
 /// One module's declared-floor ADVISORY (#3648): what its author claimed about the platform it
@@ -597,6 +647,12 @@ public sealed class PendingModuleActivations(string moduleRoot)
             Quarantined = quarantined,
             Fallbacks = fallbackRows.ToImmutable(),
             FloorAdvisories = floorAdvisories,
+            // #4083 — every module whose last landing was refused, from its own marker; a refused
+            // first install has no entry, so the markers are the denominator here, not the list.
+            Refused = [.. ModuleActivationSidecar.ReadRefusals(ModuleRootPath)
+                .Select(pair => new ModuleRefusal(
+                    pair.Key, pair.Value.PackagePath, pair.Value.Version, pair.Value.Reason,
+                    pair.Value.RefusedAt, pair.Value.Needs, pair.Value.Provides))],
             MeshModuleSet = ModuleSetStore.Describe(sets)
                 + (setNotes.Count > 0 ? " — " + string.Join("; ", setNotes) : string.Empty),
         };

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -252,7 +252,9 @@ public static class ReleaseAvailability
     /// across the roll, so its bytes were linked against the target's surface
     /// (<see cref="ReleaseArtifacts.ModuleLinks"/>): <c>Unlinkable</c> HOLDS as
     /// <see cref="PackageAvailabilityKind.ModuleUnloadable"/>, naming the module and the missing
-    /// types; <c>Linkable</c> clears; <c>Indeterminate</c> — or no measurement at all, which is
+    /// types, and so does <c>BindingConflict</c> (#4083), naming the assembly versions the target
+    /// cannot bind; <c>Linkable</c> clears, its roll-forward version drift on the advisories;
+    /// <c>Indeterminate</c> — or no measurement at all, which is
     /// what a publication without <c>platform-surface.json</c> yields — is REPORTED as an advisory
     /// and decides nothing.</description></item>
     /// </list>
@@ -305,7 +307,33 @@ public static class ReleaseAvailability
 
         return link.State switch
         {
-            ModuleLinkState.Linkable => (null, null),
+            // Linkable clears — and carries the version drift that rolls FORWARD as an advisory
+            // (#4083): on record, deciding nothing.
+            ModuleLinkState.Linkable => (null,
+                link.Advisories.IsDefaultOrEmpty
+                    ? null
+                    : $"{package.Name}: its landed module {package.ModuleName} links on "
+                      + $"{Describe(target)} with assembly version skew the loader rolls forward "
+                      + "— reported, never a hold: " + string.Join("; ", link.Advisories)),
+            // 🚨 The FileLoadException shape (#4083): the landed generation references an assembly
+            // the target carries at a LOWER version (or under another public key token) than the
+            // module's bytes were bound to. The target's copy is what loads there, and .NET never
+            // binds a reference to a lower version — a definite incompatibility, the same hold as
+            // Unlinkable. The 2026-09-11 shape: MeshWeaver.AI bound to YamlDotNet 18.1.0.0 on an
+            // image carrying 16.3.0.0 crash-looped every new pod at hub construction.
+            ModuleLinkState.BindingConflict => (
+                new PackageAvailability(
+                    package.Name,
+                    PackageAvailabilityKind.ModuleUnloadable,
+                    $"its landed module {package.ModuleName} cannot load on {Describe(target)} "
+                    + $"(framework identity {target.FrameworkIdentity}): no build of it is published "
+                    + "for that identity, and the landed generation references "
+                    + string.Join(", ", link.BindingConflicts)
+                    + " — the target's copy is what the loader binds, and a reference to a higher "
+                    + "version than the platform carries throws FileLoadException the first time "
+                    + "any code path touches the assembly. The roll is held until a build of the "
+                    + "module for this platform is published, or the module is uninstalled"),
+                null),
             ModuleLinkState.Unlinkable => (
                 new PackageAvailability(
                     package.Name,
@@ -615,8 +643,11 @@ public enum PackageAvailabilityKind
     /// 🚨 <b>THE hold on the module lane (#3651).</b> The package's landed module generation —
     /// which keeps running across the roll because no build of it is published for the target
     /// identity — references a type the target's platform surface does not carry
-    /// (<see cref="ModuleLinkState.Unlinkable"/>). Loading it there throws
-    /// <c>TypeLoadException</c> at the first render that touches it (#3538). MEASURED on the bytes,
+    /// (<see cref="ModuleLinkState.Unlinkable"/>), or an assembly the target carries at a LOWER
+    /// version or under another public key token than the bytes were bound to
+    /// (<see cref="ModuleLinkState.BindingConflict"/>, #4083). Loading it there throws
+    /// <c>TypeLoadException</c> at the first render that touches it (#3538), or
+    /// <c>FileLoadException</c> the first time the assembly is touched. MEASURED on the bytes,
     /// never declared; a definite incompatibility, like <see cref="SealedSetInconsistent"/>. The
     /// reason names the module and the missing types. Appended, never inserted.
     /// </summary>

--- a/test/Memex.Portal.Shared.Test/ModuleLinkVersionTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleLinkVersionTest.cs
@@ -1,0 +1,482 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.PluginCatalog;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>The link probe compares assembly VERSIONS, asymmetrically (#4083).</b>
+///
+/// <para><b>The incident these reproduce.</b> On 2026-09-11 core #4012 bumped YamlDotNet
+/// 16.3.0 → 18.1.0. <c>MeshWeaver.AI</c> references YamlDotNet directly and versionless, was built
+/// on an image carrying 18, and landed through the registry on portal pods whose image shipped 16.
+/// The probe said <c>Linkable</c> — every type name the module uses exists in both majors — and
+/// every new pod crash-looped at hub construction on
+/// <c>FileLoadException 0x80131040</c>: the platform's 16.3.0.0 copy is what the loader binds, and
+/// .NET never binds a reference to a LOWER version than it asks for.</para>
+///
+/// <para><b>Two causes, both pinned here.</b> (a) the bundle shipped its own YamlDotNet, so the
+/// reference was excluded from the denominator under the "built together" rule — a premise that is
+/// false exactly when the platform carries the same simple name, because the platform's copy wins;
+/// (b) no version was ever compared, and <c>ModuleLinkState</c> had no state to put a
+/// <c>FileLoadException</c> verdict in.</para>
+///
+/// <para><b>The rule is asymmetric on purpose.</b> A reference HIGHER than the platform's copy is
+/// refused by the loader and is therefore a hard verdict (<see cref="ModuleLinkState.BindingConflict"/>);
+/// a reference LOWER than the platform's copy rolls forward and is an ADVISORY — patch drift is
+/// ordinary, and a gate that reds on it is switched off within the week. A public key token
+/// mismatch under the same name is hard whatever the versions. A surface that records no version
+/// is UNKNOWN, and unknown is an advisory, never a verdict.</para>
+///
+/// <para><b>What makes these able to FAIL.</b> Every one compiles REAL assemblies with Roslyn —
+/// two stand-in <c>YamlDotNet</c> builds with identical type names and different manifest versions,
+/// exactly the 09-11 shape — and drives the REAL probe, the REAL surface document and the REAL
+/// landing service. Restoring the closure short-circuit flips
+/// <see cref="TheIncidentShape_AModuleBoundToYamlDotNet18_OnAPlatformCarrying16_CannotBind"/>;
+/// dropping the version comparison flips every hard verdict below; making the comparison symmetric
+/// flips <see cref="AReferenceBelowThePlatformsVersion_IsLinkable_WithAnAdvisory"/>.</para>
+/// </summary>
+public class ModuleLinkVersionTest : IDisposable
+{
+    /// <summary>The third-party assembly of the incident. The stand-ins carry a type the real one
+    /// has too, so on the RUNNING process the type walk passes and only the version can refuse.</summary>
+    private const string Yaml = "YamlDotNet";
+    private const string YamlType = "YamlDotNet.Serialization.Deserializer";
+    private const string Identity = "s4083surface00000000000000000000";
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-4083-" + Guid.NewGuid().ToString("N"));
+
+    private readonly ModuleLandingService landing;
+
+    public ModuleLinkVersionTest()
+    {
+        Directory.CreateDirectory(root);
+        landing = new ModuleLandingService(baseDirectory: root);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        landing.Dispose();
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ───────────────────────────────────────────────── the incident, against a file surface
+
+    /// <summary>
+    /// 🚨 <b>THE repro of 2026-09-11.</b> A module compiled against YamlDotNet 18.1.0.0, shipping
+    /// its own copy (so <c>YamlDotNet</c> is in its closure), checked against a platform whose
+    /// YamlDotNet is 16.3.0.0 with IDENTICAL type names. Type-name existence says fine; the loader
+    /// says <c>FileLoadException</c>. The verdict must be the hard one, name the assembly and both
+    /// versions, and <c>MayLoad</c> must be false — both against the file surface (the running
+    /// direction) and against the published document read back (the roll-gate direction).
+    /// </summary>
+    [Fact]
+    public void TheIncidentShape_AModuleBoundToYamlDotNet18_OnAPlatformCarrying16_CannotBind()
+    {
+        var platform = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("16.3.0.0"))]);
+        var module = ModuleAgainst(YamlStandIn("18.1.0.0"), "MeshWeaver.Test.AiPack");
+        var closure = Closure("MeshWeaver.Test.AiPack", Yaml);
+
+        var onFiles = ModulePlatformLink.Check(module, "MeshWeaver.Test.AiPack", closure, platform);
+        var onDocument = ModulePlatformLink.Check(module, "MeshWeaver.Test.AiPack", closure,
+            ModulePlatformSurface.FromJson(platform.ToJson(Identity)));
+
+        foreach (var verdict in new[] { onFiles, onDocument })
+        {
+            Assert.Equal(ModuleLinkState.BindingConflict, verdict.State);
+            Assert.False(verdict.MayLoad);
+            var conflict = Assert.Single(verdict.BindingConflicts);
+            Assert.StartsWith(Yaml + " 18.1.0.0", conflict, StringComparison.Ordinal);
+            Assert.Contains("16.3.0.0", conflict, StringComparison.Ordinal);
+            Assert.Contains("FileLoadException", verdict.Report(), StringComparison.Ordinal);
+            Assert.Empty(verdict.MissingTypes);
+            Assert.True(verdict.ComparedAssemblyReferences > 0, verdict.Report());
+        }
+        // The document reaches the same verdict as the files: the roll gate and the boot probe
+        // cannot disagree about this.
+        Assert.Equal(onFiles.BindingConflicts, onDocument.BindingConflicts);
+    }
+
+    /// <summary>
+    /// The other direction of the same skew: a module bound to 16.3.0.0 on a platform carrying
+    /// 18.1.0.0 binds — the loader rolls forward — and the drift is on the verdict as an ADVISORY.
+    /// Never a refusal: patch drift is ordinary, and this is the arm a symmetric comparison gets
+    /// wrong.
+    /// </summary>
+    [Fact]
+    public void AReferenceBelowThePlatformsVersion_IsLinkable_WithAnAdvisory()
+    {
+        var platform = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("18.1.0.0"))]);
+        var module = ModuleAgainst(YamlStandIn("16.3.0.0"), "MeshWeaver.Test.OlderAiPack");
+
+        var verdict = ModulePlatformLink.Check(
+            module, "MeshWeaver.Test.OlderAiPack", Closure("MeshWeaver.Test.OlderAiPack", Yaml), platform);
+
+        Assert.Equal(ModuleLinkState.Linkable, verdict.State);
+        Assert.True(verdict.MayLoad);
+        Assert.Empty(verdict.BindingConflicts);
+        var advisory = Assert.Single(verdict.Advisories);
+        Assert.StartsWith(Yaml + ":", advisory, StringComparison.Ordinal);
+        Assert.Contains("16.3.0.0", advisory, StringComparison.Ordinal);
+        Assert.Contains("18.1.0.0", advisory, StringComparison.Ordinal);
+        Assert.Contains("rolls forward", advisory, StringComparison.Ordinal);
+        Assert.Contains("Advisory", verdict.Report(), StringComparison.Ordinal);
+    }
+
+    /// <summary>Equal versions: as today — Linkable, nothing to report.</summary>
+    [Fact]
+    public void AnEqualVersion_IsLinkable_WithNothingToReport()
+    {
+        var platform = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("16.3.0.0"))]);
+        var module = ModuleAgainst(YamlStandIn("16.3.0.0"), "MeshWeaver.Test.SameAiPack");
+
+        var verdict = ModulePlatformLink.Check(
+            module, "MeshWeaver.Test.SameAiPack", Closure("MeshWeaver.Test.SameAiPack", Yaml), platform);
+
+        Assert.Equal(ModuleLinkState.Linkable, verdict.State);
+        Assert.Empty(verdict.BindingConflicts);
+        Assert.Empty(verdict.Advisories);
+        Assert.Equal(1, verdict.ComparedAssemblyReferences);
+    }
+
+    /// <summary>
+    /// The same simple name under a DIFFERENT public key token is a different assembly to the
+    /// loader, whatever the versions say — hard, in both version directions.
+    /// </summary>
+    [Fact]
+    public void APublicKeyTokenMismatch_IsABindingConflict_WhateverTheVersions()
+    {
+        var keyA = typeof(object).Assembly.GetName().GetPublicKey()!;
+        var keyB = typeof(Compilation).Assembly.GetName().GetPublicKey()!;
+        Assert.True(keyA.Length > 0 && keyB.Length > 0 && !keyA.SequenceEqual(keyB),
+            "precondition: two distinct real public keys to sign the stand-ins with");
+
+        var platform = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("16.3.0.0", keyA))]);
+        var module = ModuleAgainst(YamlStandIn("16.3.0.0", keyB), "MeshWeaver.Test.KeyedAiPack");
+
+        var verdict = ModulePlatformLink.Check(
+            module, "MeshWeaver.Test.KeyedAiPack", Closure("MeshWeaver.Test.KeyedAiPack", Yaml), platform);
+
+        Assert.Equal(ModuleLinkState.BindingConflict, verdict.State);
+        var conflict = Assert.Single(verdict.BindingConflicts);
+        Assert.Contains("public key token", conflict, StringComparison.Ordinal);
+        Assert.Contains(Yaml, conflict, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 A surface that records NO versions — the document every bake wrote before #4083 — cannot
+    /// answer a version question, and "unknown" is an ADVISORY, never a hard verdict: the roll gate
+    /// would otherwise hold every roll on a publication that simply predates the section. Even the
+    /// incident shape is Linkable-with-advisory against such a document.
+    /// </summary>
+    [Fact]
+    public void ASurfaceWithoutVersions_IsAdvisoryOnly_NeverHard()
+    {
+        var withVersions = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("16.3.0.0"))]).ToJson(Identity);
+        var document = JsonNode.Parse(withVersions)!.AsObject();
+        Assert.True(document.Remove("identities"), "precondition: the document carried identities to strip");
+        var legacy = ModulePlatformSurface.FromJson(document.ToJsonString());
+        Assert.Null(legacy.IdentityOf(Yaml));
+        Assert.True(legacy.Carries(Yaml));
+
+        var module = ModuleAgainst(YamlStandIn("18.1.0.0"), "MeshWeaver.Test.LegacyAiPack");
+        var verdict = ModulePlatformLink.Check(
+            module, "MeshWeaver.Test.LegacyAiPack", Closure("MeshWeaver.Test.LegacyAiPack", Yaml), legacy);
+
+        Assert.Equal(ModuleLinkState.Linkable, verdict.State);
+        Assert.Empty(verdict.BindingConflicts);
+        var advisory = Assert.Single(verdict.Advisories);
+        Assert.Contains("records no version", advisory, StringComparison.Ordinal);
+        Assert.Contains("18.1.0.0", advisory, StringComparison.Ordinal);
+    }
+
+    // ───────────────────────────────────────────── the closure rule, and its one exception
+
+    /// <summary>
+    /// 🚨 Cause (a): a copy travelling in the module's own bundle no longer hides a reference the
+    /// platform carries. The SAME module bytes, the same surface — with <c>YamlDotNet</c> in the
+    /// closure (the bundle ships it) and without — reach the same hard verdict, because the
+    /// platform's copy is what loads either way.
+    /// </summary>
+    [Fact]
+    public void TheBundlesOwnCopy_DoesNotHideAPlatformCarriedAssembly()
+    {
+        var platform = ModulePlatformSurface.OfFiles([Write(Yaml, YamlStandIn("16.3.0.0"))]);
+        var module = ModuleAgainst(YamlStandIn("18.1.0.0"), "MeshWeaver.Test.ShippingAiPack");
+
+        var shipping = ModulePlatformLink.Check(module, "MeshWeaver.Test.ShippingAiPack",
+            Closure("MeshWeaver.Test.ShippingAiPack", Yaml), platform);
+        var consuming = ModulePlatformLink.Check(module, "MeshWeaver.Test.ShippingAiPack",
+            Closure("MeshWeaver.Test.ShippingAiPack"), platform);
+
+        Assert.True(platform.IsPlatformBound(Yaml));
+        Assert.Equal(ModuleLinkState.BindingConflict, shipping.State);
+        Assert.Equal(ModuleLinkState.BindingConflict, consuming.State);
+        Assert.Equal(consuming.BindingConflicts, shipping.BindingConflicts);
+    }
+
+    /// <summary>
+    /// The exception that keeps the rule honest: a sibling the surface carries ONLY because a
+    /// superseded generation of this same module landed it earlier is NOT platform-bound — the
+    /// next boot binds the sibling this bundle brings, not the one it replaces. So a module
+    /// re-landing its own siblings, with a new type on the new sibling, stays Linkable. The
+    /// contrast (the sibling NOT in the closure — some other module's, which the loader would
+    /// resolve from the landed directory) is measured and refused, which shows the predicate is
+    /// what does the work.
+    /// </summary>
+    [Fact]
+    public void AClosureSiblingCarriedOnlyByALandedDirectory_IsStillTheModulesOwnBusiness()
+    {
+        const string sibling = "MeshWeaver.Test.OwnSibling";
+        var older = Emit(sibling, "16.0.0.0", "namespace MeshWeaver.Test; public static class OldApi { public static int A => 1; }");
+        var newer = Emit(sibling, "16.0.0.0", "namespace MeshWeaver.Test; public static class OldApi { public static int A => 1; } public static class NewApi { public static int B => 2; }");
+        var landedDirectory = Path.GetDirectoryName(Write(sibling, older))!;
+        var module = Emit("MeshWeaver.Test.ReLandingPack", "1.0.0.0",
+            "public static class Views { public static int Show() => MeshWeaver.Test.NewApi.B; }",
+            MetadataReference.CreateFromImage(newer));
+        var surface = ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory, landedDirectory);
+        Assert.True(surface.Carries(sibling), "precondition: the landed directory is on the surface");
+        Assert.False(surface.IsPlatformBound(sibling), "a landed directory's copy is not what the platform binds");
+
+        var reLanding = ModulePlatformLink.Check(module, "MeshWeaver.Test.ReLandingPack",
+            Closure("MeshWeaver.Test.ReLandingPack", sibling), surface);
+        var foreign = ModulePlatformLink.Check(module, "MeshWeaver.Test.ReLandingPack",
+            Closure("MeshWeaver.Test.ReLandingPack"), surface);
+
+        Assert.Equal(ModuleLinkState.Linkable, reLanding.State);
+        Assert.Equal(ModuleLinkState.Unlinkable, foreign.State);
+        Assert.Contains(foreign.MissingTypes, m => m.StartsWith("MeshWeaver.Test.NewApi", StringComparison.Ordinal));
+    }
+
+    // ────────────────────────────────── both directions of the incident, on the real paths
+
+    /// <summary>
+    /// Direction (ii), the landing path, on the RUNNING process: this test process carries the
+    /// real YamlDotNet in its application directory; a module bound to a stand-in at 99.0.0.0 —
+    /// shipping that stand-in beside it, as the 09-11 bundle did — is REFUSED at landing, before
+    /// any byte touches the disk, with a sentence that names the assembly and the exception.
+    /// </summary>
+    [Fact]
+    public async Task AModuleBoundAboveTheRunningPlatformsVersion_IsRefusedAtLanding()
+    {
+        var running = ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
+        Assert.True(running.Carries(Yaml), "precondition: this process's application directory carries YamlDotNet");
+        Assert.True(running.IsPlatformBound(Yaml));
+        var carried = running.IdentityOf(Yaml);
+        Assert.NotNull(carried?.Version);
+        var above = new Version(carried!.Version!.Major + 1, 0, 0, 0).ToString(4);
+
+        const string name = "MeshWeaver.Test.LandingAiPack";
+        var standIn = YamlStandIn(above);
+        var refusal = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await landing.LandModule(name, [(name + ".dll", ModuleAgainst(standIn, name)), (Yaml + ".dll", standIn)])
+                .Timeout(TestTimeouts.Convergence).Await());
+
+        Assert.Contains(Yaml + " " + above, refusal.Message, StringComparison.Ordinal);
+        Assert.Contains("FileLoadException", refusal.Message, StringComparison.Ordinal);
+        Assert.Empty(ModuleActivationSidecar.Read(root).Entries);
+    }
+
+    /// <summary>The positive control on the same path: a module bound BELOW the running copy's
+    /// version lands — the loader rolls forward, and the drift is a report, not a refusal.</summary>
+    [Fact]
+    public async Task AModuleBoundBelowTheRunningPlatformsVersion_Lands()
+    {
+        var running = ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
+        Assert.True(running.Carries(Yaml), "precondition: this process's application directory carries YamlDotNet");
+
+        const string name = "MeshWeaver.Test.RollingForwardAiPack";
+        var standIn = YamlStandIn("1.0.0.0");
+        await landing.LandModule(name, [(name + ".dll", ModuleAgainst(standIn, name)), (Yaml + ".dll", standIn)])
+            .Timeout(TestTimeouts.Convergence).Await();
+
+        var entry = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal(name, entry.Name);
+        Assert.True(entry.Enabled);
+    }
+
+    /// <summary>
+    /// The boot probe's shape (<c>Check(path, surface)</c>, the closure being the DLLs beside the
+    /// entry): the module's own YamlDotNet copy sits beside it on disk and the running process
+    /// carries the real one — the verdict is the hard one, and it is what
+    /// <c>MeshBuilder.TryLoad</c> parks the generation on.
+    /// </summary>
+    [Fact]
+    public void ALandedGenerationBoundAboveTheRunningPlatformsVersion_IsParkedAtBoot()
+    {
+        var running = ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
+        Assert.True(running.Carries(Yaml), "precondition: this process's application directory carries YamlDotNet");
+        var above = new Version(running.IdentityOf(Yaml)!.Version!.Major + 1, 0, 0, 0).ToString(4);
+
+        const string name = "MeshWeaver.Test.BootAiPack";
+        var standIn = YamlStandIn(above);
+        var entry = Write(name, ModuleAgainst(standIn, name));
+        File.WriteAllBytes(Path.Combine(Path.GetDirectoryName(entry)!, Yaml + ".dll"), standIn);
+
+        var verdict = ModulePlatformLink.Check(entry, running);
+
+        Assert.Equal(ModuleLinkState.BindingConflict, verdict.State);
+        Assert.False(verdict.MayLoad);
+        var parked = IncompatibleModule.FromLinkRefusal(entry, verdict);
+        Assert.Contains(Yaml + " " + above, parked.Report(), StringComparison.Ordinal);
+        Assert.True(parked.RefusedBeforeLoad);
+    }
+
+    // ──────────────────────────────────────────── the loader itself, as the rule's control
+
+    /// <summary>
+    /// 🚨 The rule is the LOADER's, measured — not a policy. An UNSIGNED dependency at 1.0.0.0
+    /// already loaded in a context, and a consumer whose bytes ask for 9.0.0.0: the loaded copy is
+    /// REFUSED — the first call that touches it throws, never returns the copy's answer. The
+    /// spelling of the refusal is the context's: in the Default context, where the copy is the
+    /// TPA's, it is <see cref="FileLoadException"/> <c>0x80131040</c> (the 09-11 pod logs); in a
+    /// custom context the refused candidate is skipped, nothing else is found, and it is
+    /// <see cref="FileNotFoundException"/> naming the 9.0.0.0 request. The other way round
+    /// (9.0.0.0 loaded, 1.0.0.0 asked for) binds and runs. The probe's asymmetry is exactly this,
+    /// and a strong name is not what triggers it — which is why the comparison applies to every
+    /// carried assembly and not only to signed ones.
+    /// </summary>
+    [Fact]
+    public void TheLoaderRefusesAHigherReference_AndRollsForwardALowerOne_UnsignedIncluded()
+    {
+        const string dep = "MeshWeaver.Test.VersionedDep";
+        var v1 = Emit(dep, "1.0.0.0", "namespace MeshWeaver.Test; public static class Api { public static int Answer() => 42; }");
+        var v9 = Emit(dep, "9.0.0.0", "namespace MeshWeaver.Test; public static class Api { public static int Answer() => 42; }");
+        var askingFor9 = Emit("MeshWeaver.Test.AskingFor9", "1.0.0.0",
+            "public static class View { public static int Render() => MeshWeaver.Test.Api.Answer(); }",
+            MetadataReference.CreateFromImage(v9));
+        var askingFor1 = Emit("MeshWeaver.Test.AskingFor1", "1.0.0.0",
+            "public static class View { public static int Render() => MeshWeaver.Test.Api.Answer(); }",
+            MetadataReference.CreateFromImage(v1));
+
+        var refused = Invoke(v1, askingFor9);
+        var rolledForward = Invoke(v9, askingFor1);
+
+        var refusal = Assert.IsAssignableFrom<Exception>(refused);
+        Assert.True(refusal is FileLoadException or FileNotFoundException,
+            $"the loader must REFUSE the 1.0.0.0 copy for a 9.0.0.0 reference, not answer from it: {refusal}");
+        Assert.Contains("9.0.0.0", refusal.Message, StringComparison.Ordinal);
+        Assert.Equal(42, rolledForward);
+
+        // And the probe agrees with the loader on both, from the same bytes.
+        var above = ModulePlatformLink.Check(askingFor9, "MeshWeaver.Test.AskingFor9",
+            Closure("MeshWeaver.Test.AskingFor9", dep), ModulePlatformSurface.OfFiles([Write(dep, v1)]));
+        var below = ModulePlatformLink.Check(askingFor1, "MeshWeaver.Test.AskingFor1",
+            Closure("MeshWeaver.Test.AskingFor1", dep), ModulePlatformSurface.OfFiles([Write(dep, v9)]));
+        Assert.Equal(ModuleLinkState.BindingConflict, above.State);
+        Assert.Equal(ModuleLinkState.Linkable, below.State);
+        Assert.Single(below.Advisories);
+    }
+
+    /// <summary>Loads <paramref name="dependency"/> into a fresh collectible context, then
+    /// <paramref name="consumer"/>, and invokes <c>View.Render()</c>: the value it returns, or the
+    /// exception the loader threw (unwrapped from reflection's envelope).</summary>
+    private static object? Invoke(byte[] dependency, byte[] consumer)
+    {
+        var context = new System.Runtime.Loader.AssemblyLoadContext(
+            "loader-control-" + Guid.NewGuid().ToString("N"), isCollectible: true);
+        try
+        {
+            using var dependencyStream = new MemoryStream(dependency);
+            context.LoadFromStream(dependencyStream);
+            using var consumerStream = new MemoryStream(consumer);
+            var render = context.LoadFromStream(consumerStream).GetType("View")!.GetMethod("Render")!;
+            try
+            {
+                return render.Invoke(null, null);
+            }
+            catch (Exception exception)
+            {
+                while (exception is System.Reflection.TargetInvocationException { InnerException: { } inner })
+                    exception = inner;
+                return exception;
+            }
+        }
+        finally { context.Unload(); }
+    }
+
+    // ───────────────────────────────────────────────────────────────────────── harness
+
+    private static HashSet<string> Closure(params string[] names) =>
+        new(names, StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>A stand-in <c>YamlDotNet</c> carrying <see cref="YamlType"/> — a type name the
+    /// real one has too — at the given manifest version, optionally signed with a public key
+    /// (public-sign: the key goes into the manifest, no private half needed).</summary>
+    private static byte[] YamlStandIn(string version, byte[]? publicKey = null) =>
+        Emit(Yaml, version, """
+            namespace YamlDotNet.Serialization;
+            public sealed class Deserializer { public T Deserialize<T>(string yaml) => default!; }
+            """, publicKey: publicKey);
+
+    /// <summary>A module compiled against the given stand-in, using <see cref="YamlType"/>.</summary>
+    private static byte[] ModuleAgainst(byte[] yamlStandIn, string moduleName) =>
+        Emit(moduleName, "1.0.0.0", $$"""
+            public static class SkillMarkdown
+            {
+                public static object Parse(string yaml) => new {{YamlType}}().Deserialize<object>(yaml);
+            }
+            """, MetadataReference.CreateFromImage(yamlStandIn), excludeReference: Yaml);
+
+    /// <summary>Compiles one source file against this process's reference set, stamping the
+    /// manifest version and (optionally) a public key.</summary>
+    private static byte[] Emit(
+        string assemblyName, string version, string source,
+        MetadataReference? extra = null, string? excludeReference = null, byte[]? publicKey = null)
+    {
+        var platform = ((string?)AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => p.EndsWith(".dll", StringComparison.OrdinalIgnoreCase) && File.Exists(p))
+            .Where(p => excludeReference is null
+                        || !string.Equals(Path.GetFileNameWithoutExtension(p), excludeReference,
+                            StringComparison.OrdinalIgnoreCase))
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))
+            .ToList();
+        if (extra is not null)
+            platform.Add(extra);
+
+        var options = new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary);
+        if (publicKey is not null)
+            options = options.WithCryptoPublicKey([.. publicKey]).WithPublicSign(true);
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            [
+                CSharpSyntaxTree.ParseText($"[assembly: System.Reflection.AssemblyVersion(\"{version}\")]"),
+                CSharpSyntaxTree.ParseText(source),
+            ],
+            platform,
+            options);
+
+        using var buffer = new MemoryStream();
+        var result = compilation.Emit(buffer);
+        Assert.True(result.Success, string.Join(
+            Environment.NewLine,
+            result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return buffer.ToArray();
+    }
+
+    /// <summary>Writes an assembly into its OWN directory under the test root.</summary>
+    private string Write(string assemblyName, byte[] bytes)
+    {
+        var directory = Path.Combine(root, "emitted", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, assemblyName + ".dll");
+        File.WriteAllBytes(path, bytes);
+        return path;
+    }
+}

--- a/test/Memex.Portal.Shared.Test/ModuleLinkVersionTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleLinkVersionTest.cs
@@ -109,6 +109,13 @@ public class ModuleLinkVersionTest : IDisposable
         // The document reaches the same verdict as the files: the roll gate and the boot probe
         // cannot disagree about this.
         Assert.Equal(onFiles.BindingConflicts, onDocument.BindingConflicts);
+
+        // The status-line form — what the refusal marker, the package card and /health carry.
+        Assert.Equal("held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0", onFiles.HoldSummary());
+        Assert.Equal("YamlDotNet 18.1.0.0", onFiles.Needs());
+        Assert.Equal("16.3.0.0", onFiles.Provides());
+        var conflict18 = Assert.Single(onFiles.Conflicts);
+        Assert.Equal(new AssemblyBindingConflict(Yaml, "18.1.0.0", "16.3.0.0"), conflict18);
     }
 
     /// <summary>
@@ -281,14 +288,46 @@ public class ModuleLinkVersionTest : IDisposable
         var above = new Version(carried!.Version!.Major + 1, 0, 0, 0).ToString(4);
 
         const string name = "MeshWeaver.Test.LandingAiPack";
+        const string packagePath = "InstalledPackages/AI";
         var standIn = YamlStandIn(above);
         var refusal = await Assert.ThrowsAsync<InvalidOperationException>(async () =>
-            await landing.LandModule(name, [(name + ".dll", ModuleAgainst(standIn, name)), (Yaml + ".dll", standIn)])
+            await landing.LandModule(name, [(name + ".dll", ModuleAgainst(standIn, name)), (Yaml + ".dll", standIn)],
+                    packagePath: packagePath, version: "1.9.0")
                 .Timeout(TestTimeouts.Convergence).Await());
 
         Assert.Contains(Yaml + " " + above, refusal.Message, StringComparison.Ordinal);
         Assert.Contains("FileLoadException", refusal.Message, StringComparison.Ordinal);
         Assert.Empty(ModuleActivationSidecar.Read(root).Entries);
+
+        // 🚨 LEGIBLE (#4083): the refusal is on the module's own marker, in the words a person
+        // reads — not only in a log line — and the activation report renders it for the package.
+        var provided = carried!.Version!.ToString(4);
+        var marker = ModuleActivationSidecar.ReadRefused(root, name);
+        Assert.NotNull(marker);
+        Assert.Equal($"held: references {Yaml} {above}, platform provides {provided}", marker.Reason);
+        Assert.Equal($"{Yaml} {above}", marker.Needs);
+        Assert.Equal(provided, marker.Provides);
+        Assert.Equal(packagePath, marker.PackagePath);
+        Assert.Equal("1.9.0", marker.Version);
+
+        var report = new PendingModuleActivations(root).Read();
+        Assert.False(report.IsUndetermined, report.UndeterminedReason);
+        var row = Assert.Single(report.Refused);
+        Assert.Equal(name, row.Name);
+        Assert.Same(row, report.RefusalForPackage(packagePath));
+        Assert.Contains("REFUSED at landing", report.Describe(), StringComparison.Ordinal);
+        Assert.Contains($"{name} (1.9.0): held: references {Yaml} {above}, platform provides {provided}",
+            report.Describe(), StringComparison.Ordinal);
+        Assert.DoesNotContain(report.Unresolvable, p => string.Equals(p.Name, name, StringComparison.Ordinal));
+
+        // A later landing of the same module that LANDS (bound below the platform's copy) clears
+        // the marker: the state it described is gone.
+        var older = YamlStandIn("1.0.0.0");
+        await landing.LandModule(name, [(name + ".dll", ModuleAgainst(older, name)), (Yaml + ".dll", older)],
+                packagePath: packagePath, version: "1.9.1")
+            .Timeout(TestTimeouts.Convergence).Await();
+        Assert.Null(ModuleActivationSidecar.ReadRefused(root, name));
+        Assert.Empty(new PendingModuleActivations(root).Read().Refused);
     }
 
     /// <summary>The positive control on the same path: a module bound BELOW the running copy's

--- a/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformLinkTest.cs
@@ -568,10 +568,15 @@ public class ModulePlatformLinkTest : IDisposable
     // ───────────────────────────────────────────────────────────── harness
 
     /// <summary>Different assembly versions and additive APIs do not remove a referenced type.
-    /// Exercise the real metadata probe with separately compiled contracts in both directions.</summary>
+    /// Exercise the real metadata probe with separately compiled contracts. 🚨 ONE direction since
+    /// #4083: a module built against a LOWER version than the platform runs rolls forward (the
+    /// skew is an advisory); built against a HIGHER one, the loader refuses the bind whatever the
+    /// API looks like — <c>ModuleLinkVersionTest</c> measures that on the loader itself, and
+    /// <see cref="AModuleBuiltAgainstAHigherPlatformVersion_CannotBind_WhateverTheApi"/> below is
+    /// the arm this theory used to assert as Linkable.</summary>
     [Theory]
     [InlineData("1.0.0.0", "9.0.0.0")]
-    [InlineData("9.0.0.0", "1.0.0.0")]
+    [InlineData("1.0.0.0", "1.0.0.0")]
     public void CompatibleApiAcrossPlatformVersions_IsLinkable(string builtVersion, string runningVersion)
     {
         const string contractName = "MeshWeaver.Test.VersionedContract";
@@ -601,6 +606,44 @@ public class ModulePlatformLinkTest : IDisposable
         Assert.True(verdict.CheckedTypeReferences > 0);
         Assert.Contains(contractName, verdict.CheckedAssemblies);
         Assert.Empty(verdict.MissingTypes);
+    }
+
+    /// <summary>
+    /// 🚨 #4083 narrows the 2026-09-09 rule: an API-compatible platform copy at a LOWER manifest
+    /// version than the module was bound to is not something the loader will bind — every type is
+    /// present, and the bind is still <c>FileLoadException</c>. The verdict names the assembly and
+    /// both versions; <c>MayLoad</c> is false.
+    /// </summary>
+    [Fact]
+    public void AModuleBuiltAgainstAHigherPlatformVersion_CannotBind_WhateverTheApi()
+    {
+        const string contractName = "MeshWeaver.Test.VersionedContract";
+        const string moduleName = "MeshWeaver.Test.VersionAheadPack";
+        var builtContract = Emit(contractName, """
+            [assembly: System.Reflection.AssemblyVersion("9.0.0.0")]
+            namespace MeshWeaver.Test;
+            public class StableApi { public int Answer() => 1; }
+            """);
+        var module = Emit(moduleName, """
+            public class View {
+                public int Render(MeshWeaver.Test.StableApi api) => api.Answer();
+            }
+            """, extra: MetadataReference.CreateFromImage(builtContract));
+        var runningContract = Emit(contractName, """
+            [assembly: System.Reflection.AssemblyVersion("1.0.0.0")]
+            namespace MeshWeaver.Test;
+            public class StableApi { public int Answer() => 42; public string Extra() => "new"; }
+            """);
+
+        var verdict = ModulePlatformLink.Check(module, moduleName, new HashSet<string> { moduleName },
+            ModulePlatformSurface.OfFiles([Write(contractName, runningContract)]));
+
+        Assert.Equal(ModuleLinkState.BindingConflict, verdict.State);
+        Assert.False(verdict.MayLoad);
+        Assert.Empty(verdict.MissingTypes);
+        var conflict = Assert.Single(verdict.BindingConflicts);
+        Assert.Contains(contractName + " 9.0.0.0", conflict, StringComparison.Ordinal);
+        Assert.Contains("1.0.0.0", conflict, StringComparison.Ordinal);
     }
 
     /// <summary>The same version can contain incompatible bytes. Version equality must never

--- a/test/Memex.Portal.Shared.Test/ModulePlatformSurfaceJsonTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePlatformSurfaceJsonTest.cs
@@ -57,14 +57,68 @@ public class ModulePlatformSurfaceJsonTest
         Assert.Contains(typeof(MeshNode).FullName!, declaredTypes);
         Assert.Contains(typeof(ModulePlatformSurface).FullName!, declaredTypes);
 
-        // The shape is the documented one, and nothing else.
+        // The shape is the documented one, and nothing else: identity, assemblies, and — since
+        // #4083 — the identities SIBLING, keyed by the same names.
         using var document = JsonDocument.Parse(json);
         Assert.Equal(Identity, document.RootElement.GetProperty("identity").GetString());
         var assemblies = document.RootElement.GetProperty("assemblies");
         Assert.Equal(JsonValueKind.Object, assemblies.ValueKind);
-        Assert.Equal(2, document.RootElement.EnumerateObject().Count());
+        var identities = document.RootElement.GetProperty("identities");
+        Assert.Equal(JsonValueKind.Object, identities.ValueKind);
+        Assert.Equal(3, document.RootElement.EnumerateObject().Count());
         Assert.True(assemblies.EnumerateObject().Count() > 10,
             "a surface of the running process names more than a handful of assemblies");
+        Assert.All(identities.EnumerateObject(),
+            entry => Assert.True(assemblies.TryGetProperty(entry.Name, out _),
+                $"identities names '{entry.Name}', which assemblies does not list"));
+    }
+
+    /// <summary>
+    /// 🚨 The VERSION half of the document (#4083): per assembly, the manifest version and public
+    /// key token the loader binds by, round-tripped exactly — the contract assembly's version is
+    /// the line's pinned <c>3.0.0.0</c>, and the document's identity of it equals the live one.
+    /// Both YamlDotNet majors carry the same type names; only this section can refuse the bind.
+    /// </summary>
+    [Fact]
+    public void ToJson_ThenFromJson_CarriesEveryAssemblysVersionAndPublicKeyToken()
+    {
+        var live = ModulePlatformSurface.OfRunningProcess(AppContext.BaseDirectory);
+        var declared = ModulePlatformSurface.FromJson(live.ToJson(Identity));
+
+        var liveIdentity = live.IdentityOf(ContractAssembly);
+        var declaredIdentity = declared.IdentityOf(ContractAssembly);
+        Assert.NotNull(liveIdentity);
+        Assert.Equal(typeof(MeshNode).Assembly.GetName().Version, liveIdentity.Version);
+        Assert.Equal(liveIdentity, declaredIdentity);
+
+        // A strong-named framework assembly round-trips its token too.
+        var corelib = typeof(object).Assembly.GetName().Name!;
+        Assert.True(live.Carries(corelib));
+        Assert.Equal(PlatformAssemblyIdentity.Of(typeof(object).Assembly.GetName()), declared.IdentityOf(corelib));
+        Assert.NotNull(declared.IdentityOf(corelib)!.PublicKeyToken);
+
+        // And an assembly the document lists no identity for is UNKNOWN, not zero.
+        Assert.Null(declared.IdentityOf("MeshWeaver.NoSuchAssembly"));
+    }
+
+    /// <summary>A document from before #4083 — no <c>identities</c> — still reads, with every
+    /// identity unknown; a malformed section is refused like any other shape defect.</summary>
+    [Fact]
+    public void ADocumentWithoutIdentities_Reads_WithEveryIdentityUnknown()
+    {
+        var legacy = ModulePlatformSurface.FromJson(
+            """{"identity":"x","assemblies":{"MeshWeaver.Something":["MeshWeaver.Something.Thing"]}}""");
+        Assert.True(legacy.Carries("MeshWeaver.Something"));
+        Assert.Null(legacy.IdentityOf("MeshWeaver.Something"));
+
+        var versioned = ModulePlatformSurface.FromJson(
+            """{"identity":"x","assemblies":{"YamlDotNet":["YamlDotNet.Serialization.Deserializer"]},"identities":{"YamlDotNet":{"version":"16.3.0.0","publicKeyToken":"ec19458f3c15af5e"}}}""");
+        Assert.Equal(new PlatformAssemblyIdentity(new Version(16, 3, 0, 0), "ec19458f3c15af5e"), versioned.IdentityOf("YamlDotNet"));
+
+        Assert.ThrowsAny<JsonException>(() => ModulePlatformSurface.FromJson(
+            """{"identity":"x","assemblies":{"A":["A.T"]},"identities":[]}"""));
+        Assert.ThrowsAny<JsonException>(() => ModulePlatformSurface.FromJson(
+            """{"identity":"x","assemblies":{"A":["A.T"]},"identities":{"A":{"version":"not-a-version"}}}"""));
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Text;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.Compiler;
 using MeshWeaver.Fixture;
 using MeshWeaver.Hosting;
@@ -110,6 +111,68 @@ public class ReleaseLinkGateTest : IDisposable
         var link = Assert.Contains("Views", verdict.IsUpdatable ? [] : Links(published, Version, landed));
         Assert.Equal(ModuleLinkState.Unlinkable, link.State);
         Assert.True(link.CheckedTypeReferences > 0, link.Report());
+    }
+
+    /// <summary>
+    /// 🚨 Direction (i) of #4083 — the ROLL candidate: a module already landed, bound to the
+    /// contract at this line's <c>3.0.0.0</c>, measured against a candidate image whose published
+    /// surface carries the same assembly at a LOWER version (every type name present). The
+    /// candidate's copy is what loads there, and the loader refuses the bind — so the roll is
+    /// HELD as <c>ModuleUnloadable</c>, naming the module, both versions and the exception. A
+    /// measured incompatibility, never Indeterminate.
+    /// </summary>
+    [Fact]
+    public void AModuleBoundAboveTheTargetsVersion_HoldsTheRoll_NamingBothVersions()
+    {
+        var bound = typeof(MeshNode).Assembly.GetName().Version!.ToString(4);
+        var published = PublishedRoot(Version, Identity,
+            surface: WithIdentityVersion(ThisPlatformSurface(Identity), ContractAssembly, "1.0.0.0"));
+        var landed = Land(ViewPack, ModuleBindingMeshNode(ViewPack));
+
+        var verdict = Judge(published, Version,
+        [
+            new RequiredPackage("Views", "Views", HasContent: false)
+                { ModuleName = ViewPack, LandedModulePath = landed },
+        ]);
+
+        Assert.False(verdict.IsUpdatable);
+        Assert.False(verdict.IsIndeterminate, "a version the loader refuses is MEASURED, not unknown");
+        var blocker = Assert.Single(verdict.Blockers);
+        Assert.Equal(PackageAvailabilityKind.ModuleUnloadable, blocker.Kind);
+        Assert.Contains(ViewPack, blocker.Reason!, StringComparison.Ordinal);
+        Assert.Contains($"{ContractAssembly} {bound}", blocker.Reason!, StringComparison.Ordinal);
+        Assert.Contains("1.0.0.0", blocker.Reason!, StringComparison.Ordinal);
+        Assert.Contains("FileLoadException", blocker.Reason!, StringComparison.Ordinal);
+        var link = Assert.Contains("Views", Links(published, Version, landed));
+        Assert.Equal(ModuleLinkState.BindingConflict, link.State);
+        Assert.True(link.ComparedAssemblyReferences > 0, link.Report());
+    }
+
+    /// <summary>
+    /// The asymmetry at the roll: a candidate carrying the assembly at a HIGHER version than the
+    /// landed module was bound to rolls forward — the roll CLEARS, and the drift is on the
+    /// verdict's advisories naming the module, so it is on record and decides nothing.
+    /// </summary>
+    [Fact]
+    public void AModuleBoundBelowTheTargetsVersion_Clears_WithTheDriftAsAnAdvisory()
+    {
+        var published = PublishedRoot(Version, Identity,
+            surface: WithIdentityVersion(ThisPlatformSurface(Identity), ContractAssembly, "99.0.0.0"));
+        var landed = Land(ViewPack, ModuleBindingMeshNode(ViewPack));
+
+        var verdict = Judge(published, Version,
+        [
+            new RequiredPackage("Views", "Views", HasContent: false)
+                { ModuleName = ViewPack, LandedModulePath = landed },
+        ]);
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        Assert.Empty(verdict.Blockers);
+        var advisory = Assert.Single(verdict.Advisories);
+        Assert.Contains(ViewPack, advisory, StringComparison.Ordinal);
+        Assert.Contains("99.0.0.0", advisory, StringComparison.Ordinal);
+        Assert.Contains("rolls forward", advisory, StringComparison.Ordinal);
+        Assert.Equal(ModuleLinkState.Linkable, Assert.Contains("Views", Links(published, Version, landed)).State);
     }
 
     /// <summary>The positive control: a landed module that links against the target clears, with
@@ -539,6 +602,15 @@ public class ReleaseLinkGateTest : IDisposable
     private static string OlderPlatformSurface(string identity) =>
         ModulePlatformSurfaceJsonTest.Without(
             ThisPlatformSurface(identity), ContractAssembly, typeof(MeshNode).FullName!);
+
+    /// <summary>The same document with one assembly's recorded VERSION replaced — a platform
+    /// carrying every type name at another manifest version (#4083's shape, seen from the gate).</summary>
+    private static string WithIdentityVersion(string json, string assemblyName, string version)
+    {
+        var node = JsonNode.Parse(json)!.AsObject();
+        node["identities"]![assemblyName]!["version"] = version;
+        return node.ToJsonString();
+    }
 
     // ── fixture: the landed generation ──────────────────────────────────────────────────────────
 

--- a/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
+++ b/test/Memex.Portal.Shared.Test/ReleaseLinkGateTest.cs
@@ -143,6 +143,13 @@ public class ReleaseLinkGateTest : IDisposable
         Assert.Contains($"{ContractAssembly} {bound}", blocker.Reason!, StringComparison.Ordinal);
         Assert.Contains("1.0.0.0", blocker.Reason!, StringComparison.Ordinal);
         Assert.Contains("FileLoadException", blocker.Reason!, StringComparison.Ordinal);
+        // 🚨 LEGIBLE (#4083): HoldReason is the exact string the self-update poller writes onto
+        // Admin/UpdatePolicy.heldReason (SelfUpdateHostedService: `HeldReason = verdict.HoldReason`),
+        // so it must name the module, the reference and BOTH versions on its own.
+        Assert.NotNull(verdict.HoldReason);
+        Assert.Contains(ViewPack, verdict.HoldReason, StringComparison.Ordinal);
+        Assert.Contains($"{ContractAssembly} {bound}", verdict.HoldReason, StringComparison.Ordinal);
+        Assert.Contains("1.0.0.0", verdict.HoldReason, StringComparison.Ordinal);
         var link = Assert.Contains("Views", Links(published, Version, landed));
         Assert.Equal(ModuleLinkState.BindingConflict, link.State);
         Assert.True(link.ComparedAssemblyReferences > 0, link.Report());


### PR DESCRIPTION
Fixes #4083. Phase 2(b) of the fleet CI refactor.

## The incident (2026-09-11, Memex#281)

Core #4012 bumped YamlDotNet 16.3.0 → 18.1.0 in `Directory.Packages.props`. `MeshWeaver.AI` (Plugins) references YamlDotNet directly and versionless, was built on an image carrying 18, and landed through the registry on portal pods whose image shipped 16 → `FileLoadException 0x80131040` at hub construction; every new pod crash-looped. The instance's link probe said `Linkable`.

## The mechanism (all lines `origin/main` = `46459b498`, before this PR)

`src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs`:

- **:569** `if (closure.Contains(assemblyName)) continue;` — the bundle ships YamlDotNet, so every reference into it was excluded under the "built together" rule. That premise is false exactly when the platform carries the same simple name: the platform's already-loaded copy is what the loader binds, the bundle's copy never runs, and the pair that decides is module ↔ platform.
- **:627–:636** `ResolveScope` returned only `AssemblyReference.Name`; `Version` and `PublicKeyToken` were discarded and read nowhere. The comparison was type-name existence (**:600**), and both YamlDotNet majors carry the same type names.
- **:15–:36** `ModuleLinkState` modelled only the `TypeLoadException` shape — no state for a `FileLoadException` verdict to land in.
- **:258** `ToJson` wrote `{ identity, assemblies: { name: [types] } }` — no versions in `platform-surface.json`, so the roll gate could not have asked a version question.
- **:574** the `MeshWeaver.` prefix filter is *not* the cause: it sits inside `if (!surface.Carries(...))`, and a surface from `OfRunningProcess` enumerates every `*.dll` in `/app`, so `Carries("YamlDotNet")` is true on a running portal and that line is never reached.

## The rule — asymmetric on purpose

For every assembly reference of a module whose simple name the platform surface carries (third-party included; `MeshWeaver.*` keep the type-identity rule *and* are compared by version):

| reference vs platform copy | verdict |
|---|---|
| **higher** version | **`BindingConflict`** (new `ModuleLinkState`) — `MayLoad == false`; refused at landing and boot, `ModuleUnloadable` hold at the roll gate |
| **lower** version | `Linkable` + entry on `ModuleLinkVerdict.Advisories` — reported, never a hold |
| equal | as today |
| different **public key token** | **`BindingConflict`** |
| surface records **no version** | `Linkable` + advisory (unknown is never hard) |

Why asymmetric: .NET binding rolls **forward** and never back. A request for 16.3.0.0 binds to a loaded 18.1.0.0; a request for 18.1.0.0 against a loaded 16.3.0.0 is `FileLoadException`. A symmetric equality would red every portal a patch ahead of a module's build — the ordinary state between waves — and the gate would be switched off within the week. The probe refuses only what the loader refuses and reports the rest. (`AssemblyVersion` is pinned `3.0.0.0` per line, so for `MeshWeaver.*` the comparison is a no-op today and starts deciding across lines.)

The bundle's own closure no longer short-circuits a reference whose simple name the platform carries **and whose platform copy is what binds** — `ModulePlatformSurface.IsPlatformBound`: on a running process the trusted platform assemblies + the application directory; every assembly of a published document or a file set. A copy this process loaded from a *landed module directory* is deliberately not platform-bound: a module re-landing its own siblings must be measured against the siblings it brings, not the generation it supersedes (pinned by `AClosureSiblingCarriedOnlyByALandedDirectory_IsStillTheModulesOwnBusiness` — without this discrimination every multi-assembly module upgrade would be a false `Unlinkable`).

Explained in a code comment (`ModulePlatformLink.Check`, the version walk) and in the dated doc section.

## Both directions of the incident

The probe is one function (`ModulePlatformLink.Check`) at every call site, so the new state is honoured everywhere `MayLoad` is read; the two switches that name states explicitly were extended:

- **(i) image is a roll candidate** — `memex/Memex.Portal.Shared/SelfUpdate/ReleaseAvailabilityService.SelectRollTarget → Judge → ModuleLinkObservation.Measure` (`src/MeshWeaver.PluginCatalog/ModuleLinkObservation.cs:55`) links every landed module against the *candidate's* published surface. `ReleaseAvailability.ModuleLane` (`src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs`) now maps `BindingConflict → PackageAvailabilityKind.ModuleUnloadable` (the hold) and a `Linkable` with advisories → a verdict advisory. Before this PR the `_ =>` arm would have *reported* the new state instead of holding.
- **(ii) module lands on the running image** — `src/MeshWeaver.PluginCatalog/ModuleLandingService.cs:736` already probes the incoming bytes (closure and all) against the running surface before anything touches disk and refuses on `MayLoad == false`; the landing path did probe — the closure rule was what hid the reference. No new call was needed there; the fix is in the probe.
- Boot (`src/MeshWeaver.Mesh.Contract/MeshBuilder.cs:636`, `MayLoad`) and prebuilt adoption (`src/MeshWeaver.Hosting/PrebuiltAdoptionPolicy.AfterLink`, explicit `BindingConflict` case → Refuse / CompileInstead) refuse the same way. `IncompatibleModule.FromLinkRefusal` names the first binding conflict as the missing member.

## The surface schema

`platform-surface.json` gains an **`identities`** sibling of `assemblies`, keyed by the same names — per listed assembly the manifest `version` and `publicKeyToken`, read from the assembly's identity (`AssemblyName` of the loaded copy / `AssemblyDefinition.GetAssemblyName()` off the file's metadata) without loading anything:

```json
{ "identity": "s…",
  "assemblies": { "YamlDotNet": ["YamlDotNet.Serialization.Deserializer", "…"] },
  "identities": { "YamlDotNet": { "version": "16.3.0.0", "publicKeyToken": "ec19458f3c15af5e" } } }
```

A sibling rather than a richer `assemblies` value because every reader already shipped (`FromJson`) requires each `assemblies` value to be an array of strings and throws otherwise, but ignores unknown root properties — so old readers read the new file unchanged, and the new reader treats a missing `identities` as "unknown → advisory, never hard". The producer is `ModulePlatformSurface.ToJson` (C#, written by `BakeOutput.WritePlatformSurface` and `mw-plugin-test platform-surface`); `publish-bake-bundles.sh` only uploads the file, so no script change was needed.

## Files

- `src/MeshWeaver.Mesh.Contract/ModulePlatformLink.cs` — the state, `BindingConflicts` / `Advisories` / `ComparedAssemblyReferences` on the verdict, `PlatformAssemblyIdentity`, `IdentityOf` / `IsPlatformBound` on the surface, the `identities` section, the version walk, the closure rule.
- `src/MeshWeaver.Mesh.Contract/IncompatibleModule.cs` — names the conflict.
- `src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs`, `ModuleLinkObservation.cs`; `src/MeshWeaver.Hosting/PrebuiltAdoptionPolicy.cs` — the new state honoured at the roll gate and at adoption (outside the announced file set, but a `switch` that reported the new state as "could not be determined" would have made the roll gate the one place the verdict was soft).
- `src/MeshWeaver.PluginCatalog/ModuleActivation.cs` (refusal marker), `ModuleLandingService.cs` (writes/clears it), `PendingModuleActivations.cs` (`Refused` rows, `Describe`), `CatalogLayoutAreas.cs` (card line), `src/MeshWeaver.Messaging.Hub/Localization/strings.{en,de}.json` (two keys) — the legible hold on the landing path (coordinator item 2).
- `src/MeshWeaver.Documentation/Data/Architecture/ModulePlatformLinkGate.md` — one dated section, nothing else touched.
- Tests: `test/Memex.Portal.Shared.Test/ModuleLinkVersionTest.cs` (new), `ModulePlatformSurfaceJsonTest.cs`, `ReleaseLinkGateTest.cs`, `ModulePlatformLinkTest.cs`.

Not touched: workflows, `AGENTS.md`, skills, `ModuleBuildArchitecture.md`, `.github/scripts/*`.

## Tests

Every touched project built with `dotnet build <project> -c Release -warnaserror`, one project per invocation, each `0 Warning(s) / 0 Error(s)`, artifacts verified fresh (timestamps after the build, new symbols present).

```
$ dotnet test test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj -c Release --no-build \
    --filter "FullyQualifiedName~ModuleLinkVersionTest|FullyQualifiedName~ModulePlatformSurfaceJsonTest|FullyQualifiedName~ReleaseLinkGateTest|FullyQualifiedName~ModulePlatformLinkTest"
Passed!  - Failed:     0, Passed:    61, Skipped:     0, Total:    61, Duration: 10 s - Memex.Portal.Shared.Test.dll (net10.0)

$ dotnet test test/MeshWeaver.Messaging.Hub.Test/MeshWeaver.Messaging.Hub.Test.csproj -c Release --filter "FullyQualifiedName~LocalizationTest"
Passed!  - Failed:     0, Passed:    58, Skipped:     0, Total:    58, Duration: 103 ms - MeshWeaver.Messaging.Hub.Test.dll (net10.0)

$ dotnet test test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj -c Release --filter "FullyQualifiedName~PrebuiltAdoptionPolicyTest"
Passed!  - Failed:     0, Passed:    14, Skipped:     0, Total:    14, Duration: 72 ms - MeshWeaver.Hosting.Test.dll (net10.0)

$ dotnet test test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj -c Release --filter "FullyQualifiedName~BakeOutputTest"
Passed!  - Failed:     0, Passed:     1, Skipped:     0, Total:     1, Duration: 1 s - MeshWeaver.PluginTester.Test.dll (net10.0)
```

New / changed tests:

- `ModuleLinkVersionTest` (new, 11): the 09-11 shape (module bound to a stand-in YamlDotNet 18.1.0.0 vs a surface carrying 16.3.0.0 with identical type names) → `BindingConflict`, on the file surface and on the document read back; lower → `Linkable` + advisory; equal → clean; public key token mismatch → `BindingConflict`; a document without `identities` → advisory only; the closure no longer hides a platform-carried assembly; a closure sibling carried only by a landed directory stays the module's own business (Linkable), while the same sibling outside the closure is measured (Unlinkable); the landing service refuses a module bound above the *real* YamlDotNet in the test process's application directory and lands one bound below it; the boot-shaped `Check(path, surface)` parks the same generation; and the loader itself, driven in an `AssemblyLoadContext`, refuses a 9.0.0.0 request against a loaded unsigned 1.0.0.0 copy and rolls a 1.0.0.0 request forward onto 9.0.0.0 — the empirical control for the asymmetry.
- `ReleaseLinkGateTest`: `AModuleBoundAboveTheTargetsVersion_HoldsTheRoll_NamingBothVersions` (ModuleUnloadable, never Indeterminate) and `AModuleBoundBelowTheTargetsVersion_Clears_WithTheDriftAsAnAdvisory` — the roll-candidate direction through `PublishedBundleCatalogue.Read → ModuleLinkObservation.Measure → ReleaseAvailability.IsUpdatable`.
- `ModulePlatformSurfaceJsonTest`: the document has exactly three root properties now; `identities` round-trips version and token; a legacy document reads with unknown identities; a malformed section is refused.
- `ModulePlatformLinkTest.CompatibleApiAcrossPlatformVersions_IsLinkable`: the `(built 9.0.0.0, running 1.0.0.0)` arm asserted `Linkable` — the 2026-09-09 rule this issue narrows; it is now `AModuleBuiltAgainstAHigherPlatformVersion_CannotBind_WhateverTheApi` (`BindingConflict`), with the loader measurement above as its justification. This is the one existing assertion that changed.

One measured nuance worth knowing: the refusal's *spelling* depends on the context. Against the TPA's copy (Default context — the incident) it is `FileLoadException 0x80131040`; in a custom `AssemblyLoadContext` the refused candidate is skipped and, nothing else being found, it surfaces as `FileNotFoundException` naming the requested version. Either way the lower copy is never bound; the test accepts both.

## Blast radius — the new rule over the registry's published module set (read-only, 2026-09-12)

**Method.** The registry index on memex.meshweaver.cloud (`GET /api/plugins/bundles/index.json`, as the `memex` instance's consumer key from Key Vault `PluginCatalog-RegistryToken` — GETs only) lists 51 bundles, 30 with a compiled module; every module bundle was downloaded (`/api/plugins/bundles/<plugin>/<version>`, the same route the portal lands from) and its `meshweaver/modules/*.dll` unpacked — the entry plus its riding copies, exactly the closure `ModuleLandingService` passes to the probe. The three images were pulled from ACR and `/app` + `/usr/share/dotnet/shared` extracted; the surface is `ModulePlatformSurface.OfFiles(app + shared frameworks)` (every file platform-bound, i.e. the published-document shape). The comparison is this PR's `ModulePlatformLink.Check(entryBytes, module, closure, surface)`, run by a scratch console app against the worktree's built `MeshWeaver.Mesh.Contract.dll` (nothing added to the repo).

| image | runs on | YamlDotNet provided | **held (BindingConflict)** | advisories (lower than provided) |
|---|---|---|---|---|
| `3.0.0-ci.8372` (built 2026-09-11 18:06Z) | memex | 18.0.0.0 | **0 / 30** | 1 — `ContainerRegistry 0.1.2`: `System.Reactive` references 6.1.0.0, platform provides 7.0.0.0 (rolls forward) |
| `3.0.0-ci.8403` (built 2026-09-12 07:36Z) | memex-cloud | 18.0.0.0 | **0 / 30** | 1 — same |
| `3.0.0-ci.8323` (built 2026-09-11 04:50Z — the image that crash-looped) | *positive control* | 16.0.0.0 | **20 / 30** | 0 |

The 20 holds on 8323, each with the offending reference (module-referenced → image-provided):

| module (bundle) | reference |
|---|---|
| `MeshWeaver.AI` (AI 1.9.0) | `YamlDotNet` 18.0.0.0 → 16.0.0.0 **and** `System.Reactive` 7.0.0.0 → 6.1.0.0 |
| `MeshWeaver.Publish` (Publish 1.1.5) | `YamlDotNet` 18.0.0.0 → 16.0.0.0 |
| `MeshWeaver.Azure.Blob`, `MeshWeaver.Blazor.Chat`, `MeshWeaver.Graph.Views` (×2 versions), `MeshWeaver.Courses`, `MeshWeaver.Blazor.EntityViews`, `MeshWeaver.Markdown.Collaboration`, `MeshWeaver.Markdown.Export`, `MeshWeaver.Blazor.Graph`, `MeshWeaver.Hosting.Instance`, `MeshWeaver.Import`, `MeshWeaver.Mcp`, `MeshWeaver.Northwind.Application` (×2), `MeshWeaver.Notifications.Channels`, `MeshWeaver.OgCard`, `MeshWeaver.AI.OpenAI`, `MeshWeaver.Payments.Stripe` | `System.Reactive` 7.0.0.0 → 6.1.0.0 |

**Reading.** The held set on the two images the fleet runs now is **empty** — nothing to file, nothing over-firing. On 8323 every hold is a real incompatibility the fleet *did* run into: core bumped YamlDotNet (#4012) **and** System.Reactive 6.1.0 → 7.0.0 (`0b734ae36`) on 2026-09-11, both after 8323 was built (04:50Z) and before 8372 (18:06Z); every module in the set was rebuilt on the bumped platform, so on an 8323 pod each of those references asks the loader for a version the image does not provide — the `FileLoadException` that took every new pod down (YamlDotNet is the one the pods reached first, at hub construction; Rx would have followed). Neither is an over-fire: `MeshWeaver.AI` and `MeshWeaver.Publish` ship their own YamlDotNet 18 (`closure` contains it) and were `Linkable` under the old closure rule; the Rx references are *not* shipped by the bundles (the platform's copy is the only one) and were `Linkable` because no version was compared. `ContainerRegistry 0.1.2` was built on an older platform (`g131dff…`) and is the advisory arm working as designed.

Also measured, and *not* a finding of this rule: with an `/app`-only surface, 9 modules read `Unlinkable` on every image (`MeshWeaver.AI.*`, `Chat`, `Edu`, `Mcp`, `Notifications` reference `MeshWeaver.AI`; `AI` references `MeshWeaver.Markdown.Collaboration`) — references to **sibling modules** (each missing assembly is absent from the image and from the referencing bundle's own closure, and is shipped by another bundle in the set). A portal's surface adds every landed generation directory (`ModuleLandingService.PlatformSurface`), which resolves them; this is the *not carried* branch, untouched by this PR.

## Legible hold — where a held module shows

| path | surface | text |
|---|---|---|
| (i) roll candidate | **`Admin/UpdatePolicy.heldReason`** — `SelfUpdateHostedService` writes `verdict.HoldReason` verbatim (`memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs:1198`); rendered on the Updates tab | `Views: its landed module MeshWeaver.AI cannot load on 3.0.0-ci.8323 (framework identity …): no build of it is published for that identity, and the landed generation references YamlDotNet 18.0.0.0 (this platform carries 16.0.0.0) — the target's copy is what the loader binds, and a reference to a higher version than the platform carries throws FileLoadException …` — asserted on `verdict.HoldReason` in `AModuleBoundAboveTheTargetsVersion_HoldsTheRoll_NamingBothVersions` (module, reference, both versions) |
| (ii) module landing | **before this PR: a warning log line only** (`PluginBundleClient.cs:410–421` catches the refusal, logs *"landing failed — the module is unchanged"*, returns 0; no entry, no ledger record, nothing on any node). **Now:** the refusing landing writes the module's own **refusal marker** `modules/activation.d/<Name>.refused` (`ModuleActivationSidecar.RefusedLanding`: version, install-record path, reason, needs, provides); `PendingModuleActivations.Read()` lifts it onto `ModuleActivationReport.Refused` → the **package card** (`CatalogLayoutAreas`, ⛔ *Not installed on this platform: it needs YamlDotNet 18.1.0.0, this platform provides 16.3.0.0. It installs when this installation updates to a platform that provides it.* — localized en/de, the assemblies/versions as data) and **`/health`**'s activation report (`Describe()`: *"1 module(s) REFUSED at landing — … MeshWeaver.AI (1.9.0): held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0"*). Cleared by the next landing of that module that lands anything, and by uninstall. | `held: references YamlDotNet 18.1.0.0, platform provides 16.3.0.0` (`ModuleLinkVerdict.HoldSummary()`; a type refusal reads `held: references <type>, which this platform does not carry`) |
| boot | unchanged: the unloadable marker → quarantined on the card / `/health` | the probe's report |

Tests for the text: `TheIncidentShape_…` pins `HoldSummary()`, `Needs()`, `Provides()` and the structured `Conflicts` on the 18-vs-16 shape; `AModuleBoundAboveTheRunningPlatformsVersion_IsRefusedAtLanding` drives the real landing service, reads the marker back (`Reason`, `Needs`, `Provides`, `PackagePath`, `Version`), asserts the report's `Refused` row, `RefusalForPackage`, and `Describe()`, and that a later landing that lands clears it.

## i18n mirror handover

This PR adds two catalog keys (`ui.moduleHeldAtLanding`, `ui.moduleHeldAtLandingTypes`, en + de). The React i18n mirror in MeshWeaver.Plugins compares against a pinned core commit, so the sync is handed over rather than done here:

Mirror-sync: Systemorph/MeshWeaver.Plugins#1716 carries the sync — `npm run sync:i18n -- --ref <the merged core sha of this PR>` after it merges

## Not done / open

- The publish-side check (a bundle about to be published vs the images the fleet runs, #4066) is independent of this and not here.
- Module activation tolerance (why the `FileLoadException` aborted the process instead of parking the module) is a MeshWeaver.Plugins defect, not here.
- Not re-measured on a live pod; the verdict for the 09-11 shape is reproduced from two Roslyn-built `YamlDotNet` stand-ins with identical type names at 16.3.0.0 / 18.1.0.0, and on the real YamlDotNet in the test process's application directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
