### PR TITLE
ci: node-repo-module-pack batches sub-minute module legs — whole-minute rounding was ~12 % of the Plugins bill (phase 3b)

### DIFF
--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""module-pack-batch.py — the module-pack lane's BATCHING of sub-minute matrix legs, and the
+per-module bookkeeping that keeps a batch from becoming a coupling.
+
+(The name on this first line is load-bearing: the module-pack lane fetches this file at the
+caller's `platform-ref` and its `select` job self-tests it on every run.)
+
+WHY THIS EXISTS (measured 2026-09-05..12)
+------------------------------------------
+GitHub bills every job rounded UP to a whole minute. `node-repo-module-pack.yml` fanned out ONE
+job per module, and most of those jobs were shorter than the unit they were billed in:
+
+    MeshWeaver.Plugins  Module bundles / Module bundle   4,975 sampled legs, MEDIAN 1.1 min (p90 8.4)
+    MeshWeaver.Plugins  Module bundles (parent legs)     1,385 legs,          MEDIAN 1.1 min
+    MeshWeaver.Plugins  Module bundles / Module tests    2,935 legs,          MEDIAN 4.0 min (p90 8.2)
+
+Whole-minute rounding on the sub-minute legs was ≈12 % of Plugins' bill (~4,700 billed minutes a
+day) and 25–40 % in Crm / Reinsurance / SocialMedia, whose modules are smaller still. Every leg
+also pays its own checkout, SDK install and cache restores before it does a second of module work.
+
+So the lane now packs (and tests) N modules per leg — `batch-size`, default 6, hard cap 10 — as a
+RUNNER-SHARING DEVICE and nothing more. The observable per-module semantics are unchanged, and
+this script is what makes that structural rather than hoped-for:
+
+  * `chunk`   — a DETERMINISTIC split: the selection sorted by module name, STRIPED into
+                ceil(n/N) legs of ≤N (module i → leg i mod k; see `chunk` for why not contiguous).
+                A selection of ≤N modules is ONE leg; a single-module repository sees exactly the
+                job name, the `module-bundle-<module>` artifact and the receipts it saw before.
+  * the state — one JSON file per leg, one record per module: the matrix entry, the facts each
+                phase produced (version, ledger plan, compiler, bundle path, …) and a status. A
+                phase that fails for ONE module marks THAT module failed with the phase and the
+                reason, and every later phase skips it (`list --ok`); the sibling modules in the
+                leg still pack, test, and — when the call publishes — POST their own bundle after
+                their own suite, exactly as they did in a leg of their own.
+  * `verdict` — the leg's LAST step: one status line per module, in the log and the job summary,
+                and a non-zero exit when any module failed. The leg is red for the same reason a
+                single-module leg was red, and `verify` (`All selected bundles built`) still
+                accounts every module by its OWN receipt — a module that failed dropped none.
+
+What this deliberately does NOT do: it never decides WHAT to build (that is node-repo-scope.py
+and the ledger, upstream in `select`), never talks to the registry or the ledger itself, and
+never hides a failure — `fail` prints a `::error` naming the module and the phase, and `verdict`
+refuses to exit 0 over one.
+
+    python3 module-pack-batch.py --self-test
+    python3 module-pack-batch.py chunk --modules @selection.json --size 6 --github-output "$GITHUB_OUTPUT"
+    python3 module-pack-batch.py --state S init --batch @batch.json
+    python3 module-pack-batch.py --state S list --ok --where decision=build
+    python3 module-pack-batch.py --state S set --module M version=1.2.3 floor=3.1.0
+    python3 module-pack-batch.py --state S get --module M ledger.key
+    python3 module-pack-batch.py --state S fail --module M --phase test --reason "…"
+    python3 module-pack-batch.py --state S slots --max 10 --where bundle!=
+    python3 module-pack-batch.py --state S verdict --summary "$GITHUB_STEP_SUMMARY"
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+# The hard cap on `batch-size`. It is a LITERAL the workflow shares: the bundle artifact
+# `module-bundle-<module>` is a per-module NAME every caller's `module-artifacts` pattern and
+# every ledger record depends on, and `actions/upload-artifact` uploads one name per step — so
+# the lane unrolls exactly this many upload slots, and a batch may never hold more modules.
+MAX_BATCH_SIZE = 10
+DEFAULT_BATCH_SIZE = 6
+# Job names are display text; past this the list is cut and the count says how many are hidden.
+LABEL_MAX = 160
+# The phases a module can fail in — the ledger's own vocabulary (module-build-ledger.py).
+PHASES = ("compile", "workspace", "pack", "test", "publish")
+
+
+def die(msg: str) -> None:
+    print(f"::error::{msg}")
+    sys.exit(1)
+
+
+def load_json_arg(value: str):
+    """`@file` reads the file; anything else is inline JSON."""
+    text = Path(value[1:]).read_text(encoding="utf-8") if value.startswith("@") else value
+    return json.loads(text or "null")
+
+
+# ── chunking ───────────────────────────────────────────────────────────────────────────────────
+
+def batch_id(modules: list[str], index: int, total: int) -> str:
+    """The artifact-name suffix of a batch: the module itself for a singleton (so a single-module
+    repository's artifact names are byte-identical to before batching), else `batch-i-of-k`."""
+    if len(modules) == 1:
+        return modules[0]
+    return f"batch-{index}-of-{total}"
+
+
+def batch_label(modules: list[str], index: int, total: int, label_max: int = LABEL_MAX) -> str:
+    """The job's display name inside `Module bundle (…)` / `Module tests (…)`. A singleton is the
+    module name, unchanged; a batch names every module it carries, cut with a count when long."""
+    if len(modules) == 1:
+        return modules[0]
+    head = f"batch {index}/{total}: "
+    names = ", ".join(modules)
+    if len(head) + len(names) <= label_max:
+        return head + names
+    shown: list[str] = []
+    for m in modules:
+        candidate = ", ".join(shown + [m])
+        if len(head) + len(candidate) + len(f", … +{len(modules) - len(shown) - 1} more") > label_max:
+            break
+        shown.append(m)
+    if not shown:
+        shown = [modules[0]]
+    hidden = len(modules) - len(shown)
+    return head + ", ".join(shown) + (f", … +{hidden} more" if hidden else "")
+
+
+def chunk(entries: list[dict], size: int, label_max: int = LABEL_MAX) -> list[dict]:
+    """Sort by module name, then STRIPE into ceil(n/size) legs of ≤size: module i goes to leg
+    i mod k. Deterministic — the same selection always yields the same legs with the same ids,
+    whatever order the selector emitted it in — and balanced (leg sizes differ by at most one).
+
+    Striped rather than cut into contiguous runs on purpose: alphabetical neighbours are usually
+    a FAMILY (MeshWeaver.AI, MeshWeaver.AI.Anthropic, MeshWeaver.AI.OpenAI, …) whose suite cost is
+    correlated, and every job is hard-cut at 45 minutes — six p90 (8.2 min) suites in one leg
+    would be 49. Spreading a family over the legs is the one thing a chunker with no duration
+    data can do about that; the `batch-size` input is the other.
+    """
+    if not isinstance(size, int) or size < 1 or size > MAX_BATCH_SIZE:
+        raise ValueError(f"batch-size must be an integer from 1 to {MAX_BATCH_SIZE}, got {size!r}")
+    names = [e.get("module") for e in entries]
+    if any(not isinstance(n, str) or not n for n in names):
+        raise ValueError("every matrix entry must carry a non-empty `module`")
+    if len(set(names)) != len(names):
+        dup = sorted({n for n in names if names.count(n) > 1})
+        raise ValueError(f"the selection names a module twice: {', '.join(dup)}")
+    ordered = sorted(entries, key=lambda e: e["module"])
+    total = -(-len(ordered) // size) if ordered else 0
+    runs = [ordered[j::total] for j in range(total)]
+    out = []
+    for i, run in enumerate(runs, start=1):
+        mods = [e["module"] for e in run]
+        out.append({
+            "id": batch_id(mods, i, total),
+            "index": i,
+            "total": total,
+            "label": batch_label(mods, i, total, label_max),
+            "modules": mods,
+            "entries": run,
+        })
+    return out
+
+
+# ── the per-leg state ──────────────────────────────────────────────────────────────────────────
+
+class State:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.doc: dict = {"order": [], "modules": {}}
+
+    def load(self) -> "State":
+        if not self.path.is_file():
+            die(f"no batch state at {self.path} — the leg's first step (`init`) did not run, so "
+                "nothing below it can say which modules it owns. Refusing to guess.")
+        self.doc = json.loads(self.path.read_text(encoding="utf-8"))
+        return self
+
+    def save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self.doc, indent=1, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    def init(self, entries: list[dict]) -> None:
+        names = [e.get("module") for e in entries]
+        if any(not isinstance(n, str) or not n for n in names):
+            die("every entry of the batch must carry a non-empty `module`")
+        if len(set(names)) != len(names):
+            die("the batch names a module twice — the chunker refuses that, so this is not its output")
+        self.doc = {"order": names, "modules": {
+            e["module"]: {"entry": e, "status": "ok", "phase": "", "reason": "", "facts": {}}
+            for e in entries}}
+
+    def record(self, module: str) -> dict:
+        rec = self.doc["modules"].get(module)
+        if rec is None:
+            die(f"module `{module}` is not in this leg's batch ({', '.join(self.doc['order']) or '<empty>'})")
+        return rec
+
+    def get(self, module: str, key: str, default: str = "") -> str:
+        """A fact this leg recorded, else a field of the matrix entry (dotted path allowed, e.g.
+        `ledger.key`). Booleans print as `true`/`false`; null and absent print as the default."""
+        rec = self.record(module)
+        if key in rec["facts"]:
+            return rec["facts"][key]
+        node = rec["entry"]
+        for part in key.split("."):
+            if isinstance(node, dict) and part in node:
+                node = node[part]
+            else:
+                return default
+        if node is None:
+            return default
+        if isinstance(node, bool):
+            return "true" if node else "false"
+        if isinstance(node, (dict, list)):
+            return json.dumps(node, sort_keys=True)
+        return str(node)
+
+    def matches(self, module: str, where: list[str]) -> bool:
+        for cond in where:
+            if "!=" in cond:
+                k, v = cond.split("!=", 1)
+                if self.get(module, k) == v:
+                    return False
+            elif "=" in cond:
+                k, v = cond.split("=", 1)
+                if self.get(module, k) != v:
+                    return False
+            else:
+                die(f"--where wants key=value or key!=value, got {cond!r}")
+        return True
+
+    def select(self, ok: bool | None, where: list[str]) -> list[str]:
+        out = []
+        for m in self.doc["order"]:
+            rec = self.doc["modules"][m]
+            if ok is True and rec["status"] != "ok":
+                continue
+            if ok is False and rec["status"] != "failed":
+                continue
+            if self.matches(m, where):
+                out.append(m)
+        return out
+
+
+# ── commands ───────────────────────────────────────────────────────────────────────────────────
+
+def cmd_chunk(a: argparse.Namespace) -> int:
+    entries = load_json_arg(a.modules) or []
+    if not isinstance(entries, list):
+        die("--modules must be a JSON array of matrix entries")
+    try:
+        size = int(a.size)
+    except ValueError:
+        die(f"inputs.batch-size is {a.size!r}, which is not an integer. The only values are 1 to "
+            f"{MAX_BATCH_SIZE} (default {DEFAULT_BATCH_SIZE}). A batch size that cannot be read "
+            "must never resolve to 'one leg per module' quietly, nor to one giant leg.")
+    try:
+        batches = chunk(entries, size, a.label_max)
+    except ValueError as exc:
+        die(str(exc))
+    count = len(batches)
+    per = ", ".join(f"{b['id']} ({len(b['modules'])})" for b in batches) or "<none>"
+    print(f"batch-size {size}: {len(entries)} module(s) -> {count} leg(s): {per}")
+    for b in batches:
+        print(f"  {b['id']}: {', '.join(b['modules'])}")
+    if a.github_output:
+        with open(a.github_output, "a", encoding="utf-8") as fh:
+            fh.write(f"{a.prefix}batches={json.dumps(batches, separators=(',', ':'))}\n")
+            fh.write(f"{a.prefix}batch-count={count}\n")
+    else:
+        print(json.dumps({"batches": batches, "count": count}))
+    return 0
+
+
+def state_of(a: argparse.Namespace) -> State:
+    if not a.state:
+        die("--state <file> is required before this subcommand")
+    return State(Path(a.state))
+
+
+def cmd_init(a: argparse.Namespace) -> int:
+    batch = load_json_arg(a.batch)
+    entries = batch.get("entries") if isinstance(batch, dict) else batch
+    if not isinstance(entries, list) or not entries:
+        die("init wants the matrix batch object (with `entries`) or a non-empty entries array")
+    st = state_of(a)
+    st.init(entries)
+    st.save()
+    label = batch.get("label") if isinstance(batch, dict) else ""
+    print(f"this leg owns {len(entries)} module(s){' — ' + label if label else ''}:")
+    for m in st.doc["order"]:
+        e = st.doc["modules"][m]["entry"]
+        print(f"  • {m}  (package {e.get('package', '?')}, build {e.get('build') or 'sdk'})")
+    return 0
+
+
+def cmd_list(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    ok = True if a.ok else (False if a.failed else None)
+    for m in st.select(ok, a.where or []):
+        print(m)
+    return 0
+
+
+def cmd_get(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    print(st.get(a.module, a.key, a.default))
+    return 0
+
+
+def cmd_set(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    rec = st.record(a.module)
+    for pair in a.pairs:
+        if "=" not in pair:
+            die(f"set wants KEY=VALUE, got {pair!r}")
+        k, v = pair.split("=", 1)
+        if not k:
+            die(f"set wants a non-empty key, got {pair!r}")
+        rec["facts"][k] = v
+    st.save()
+    return 0
+
+
+def cmd_fail(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    rec = st.record(a.module)
+    if a.phase not in PHASES:
+        die(f"--phase must be one of {', '.join(PHASES)} (the ledger's vocabulary), got {a.phase!r}")
+    if rec["status"] == "failed":
+        # First failure wins: the phase a follower should read is the one that stopped the module.
+        print(f"{a.module}: already failed in {rec['phase']} — keeping that verdict "
+              f"(this later failure in {a.phase}: {a.reason})")
+        return 0
+    rec["status"] = "failed"
+    rec["phase"] = a.phase
+    rec["reason"] = a.reason
+    st.save()
+    print(f"::error title=Module {a.module} failed ({a.phase})::{a.reason}")
+    return 0
+
+
+def cmd_slots(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    mods = st.select(True, a.where or [])
+    if len(mods) > a.max:
+        die(f"{len(mods)} modules for {a.max} slots — the chunker caps a batch at {MAX_BATCH_SIZE} "
+            "and the lane unrolls that many upload steps; this leg holds more than either.")
+    lines = [f"{a.prefix}s{i}={mods[i - 1] if i <= len(mods) else ''}" for i in range(1, a.max + 1)]
+    if a.github_output:
+        with open(a.github_output, "a", encoding="utf-8") as fh:
+            fh.write("\n".join(lines) + "\n")
+    else:
+        print("\n".join(lines))
+    print(f"{len(mods)} of {a.max} slot(s) filled: {', '.join(mods) or '<none>'}")
+    return 0
+
+
+def cmd_paths(a: argparse.Namespace) -> int:
+    """A JSON object module -> fact, for the modules that carry it. One expression for every step
+    that reads the same fact (the bundle path the hand-over, the staging and the receipt share)."""
+    st = state_of(a).load()
+    out = {m: st.get(m, a.key) for m in st.select(True, a.where or []) if st.get(m, a.key)}
+    print(json.dumps(out, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+def cmd_verdict(a: argparse.Namespace) -> int:
+    st = state_of(a).load()
+    rows = []
+    failed = 0
+    for m in st.doc["order"]:
+        rec = st.doc["modules"][m]
+        if rec["status"] == "ok":
+            detail = ", ".join(f"{k}: {v}" for k, v in sorted(rec["facts"].items())
+                               if k in ("version", "decision", "compiler", "tests", "publication"))
+            rows.append((m, "✅ ok", detail))
+        else:
+            failed += 1
+            rows.append((m, f"❌ failed in {rec['phase']}", rec["reason"]))
+    width = max((len(m) for m, _, _ in rows), default=6)
+    print(f"leg verdict — {len(rows) - failed} ok, {failed} failed:")
+    for m, status, detail in rows:
+        print(f"  {m.ljust(width)}  {status}  {detail}")
+    if a.summary:
+        with open(a.summary, "a", encoding="utf-8") as fh:
+            fh.write(f"### Module legs in this batch — {len(rows) - failed} ok, {failed} failed\n\n")
+            fh.write("| module | status | detail |\n|---|---|---|\n")
+            for m, status, detail in rows:
+                fh.write(f"| `{m}` | {status} | {detail.replace('|', '\\|')} |\n")
+            fh.write("\n")
+    if failed:
+        print(f"::error title=Batch leg red::{failed} of {len(rows)} module(s) in this leg failed — "
+              "each is named above with its phase; the others completed independently.")
+        return 1
+    return 0
+
+
+# ── self-test ──────────────────────────────────────────────────────────────────────────────────
+
+def self_test() -> int:
+    import subprocess
+
+    failures: list[str] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        print(f"  {'ok  ' if ok else 'FAIL'} {name}" + (f" — {detail}" if detail and not ok else ""))
+        if not ok:
+            failures.append(name)
+
+    def entry(m: str, **kw) -> dict:
+        return {"package": m.split(".")[-1], "module": m, "project": f"src/{m}/{m}.csproj", **kw}
+
+    print("== chunk: deterministic, sorted, ≤N is one leg, singleton unchanged")
+    sel = [entry("MeshWeaver.Zeta"), entry("MeshWeaver.AI"), entry("MeshWeaver.Maps"),
+           entry("MeshWeaver.Blazor"), entry("MeshWeaver.Mcp"), entry("MeshWeaver.Import"),
+           entry("MeshWeaver.Teams")]
+    b6 = chunk(sel, 6)
+    names = sorted(e["module"] for e in sel)
+    check("7 modules at N=6 → 2 legs", len(b6) == 2, str([b["modules"] for b in b6]))
+    check("sorted by module name, then STRIPED (i mod k), so the legs are balanced 4 + 3",
+          b6[0]["modules"] == names[0::2] and b6[1]["modules"] == names[1::2], str([b["modules"] for b in b6]))
+    check("ids are batch-i-of-k for multi-module legs", [b["id"] for b in b6] == ["batch-1-of-2", "batch-2-of-2"])
+    check("label names every module in the leg", b6[0]["label"] == "batch 1/2: " + ", ".join(names[0::2]), b6[0]["label"])
+    fam = [entry(f"MeshWeaver.AI.{s}") for s in ("Anthropic", "AzureOpenAI", "Gemini", "OpenAI")] + [entry("MeshWeaver.AI")] + [entry(f"MeshWeaver.Z{i}") for i in range(7)]
+    legs = chunk(fam, 6)
+    check("a family of alphabetical neighbours is spread over the legs, never stacked in one",
+          all(sum(m.startswith("MeshWeaver.AI") for m in b["modules"]) <= 3 for b in legs), str([b["modules"] for b in legs]))
+    check("a trailing singleton leg is named by its module",
+          chunk(sel[:7], 6)[1]["id"] == "batch-2-of-2" and chunk([entry("MeshWeaver.A"), entry("MeshWeaver.B")], 1)[1]["id"] == "MeshWeaver.B")
+    check("the same input in another order chunks identically",
+          chunk(list(reversed(sel)), 6) == b6)
+    check("≤N modules is ONE leg", len(chunk(sel, 7)) == 1 and len(chunk(sel, 10)) == 1)
+    one = chunk([entry("MeshWeaver.Social")], 6)
+    check("a single-module repo: one leg, id and label are the module", one[0]["id"] == "MeshWeaver.Social" and one[0]["label"] == "MeshWeaver.Social")
+    check("N=1 is one leg per module, each named by its module",
+          [b["id"] for b in chunk(sel, 1)] == sorted(e["module"] for e in sel))
+    check("an empty selection is zero legs", chunk([], 6) == [])
+    long_names = [entry(f"MeshWeaver.Some.Rather.Long.Module.Name.Number{i:02d}") for i in range(10)]
+    lbl = chunk(long_names, 10)[0]["label"]
+    check("a long label is cut with a count, never past the cap", len(lbl) <= LABEL_MAX and "more" in lbl, lbl)
+    check("every entry is carried verbatim", all(e in sel for b in b6 for e in b["entries"]))
+    for bad, why in ((0, "0"), (11, "11"), ("6", "a string")):
+        try:
+            chunk(sel, bad)  # type: ignore[arg-type]
+            check(f"batch-size {why} is refused", False)
+        except ValueError:
+            check(f"batch-size {why} is refused", True)
+    try:
+        chunk(sel + [entry("MeshWeaver.AI")], 6)
+        check("a duplicate module is refused", False)
+    except ValueError:
+        check("a duplicate module is refused", True)
+
+    print("== state: facts, filters, per-module failure isolation, verdict")
+    with tempfile.TemporaryDirectory() as td:
+        s = Path(td) / "state.json"
+        st = State(s)
+        st.init([entry("MeshWeaver.AI", build="container", ledger={"key": "k1", "decision": "build"}),
+                 entry("MeshWeaver.Maps", test=False),
+                 entry("MeshWeaver.Mcp", ledger={"key": "", "decision": "build"})])
+        st.save()
+        st = State(s).load()
+        check("entry fields read through get", st.get("MeshWeaver.AI", "build") == "container")
+        check("dotted entry paths read through get", st.get("MeshWeaver.AI", "ledger.key") == "k1")
+        check("a boolean false prints as `false`", st.get("MeshWeaver.Maps", "test") == "false")
+        check("an absent field prints the default", st.get("MeshWeaver.Mcp", "build", "sdk") == "sdk" and st.get("MeshWeaver.Mcp", "test") == "")
+        check("an empty ledger key prints empty", st.get("MeshWeaver.Mcp", "ledger.key") == "")
+        st.record("MeshWeaver.AI")["facts"]["decision"] = "build"
+        st.record("MeshWeaver.Maps")["facts"]["decision"] = "reuse"
+        st.record("MeshWeaver.Mcp")["facts"]["decision"] = "build"
+        st.save()
+        check("facts override entry fields and filter", st.select(True, ["decision=build"]) == ["MeshWeaver.AI", "MeshWeaver.Mcp"])
+        check("key!=value filters", st.select(True, ["decision!=build"]) == ["MeshWeaver.Maps"])
+        check("key!= (empty) selects the non-empty", st.select(True, ["ledger.key!="]) == ["MeshWeaver.AI"])
+        check("order is the batch's order", st.select(None, []) == ["MeshWeaver.AI", "MeshWeaver.Maps", "MeshWeaver.Mcp"])
+
+        # The CLI, end to end, the way the workflow drives it.
+        here = str(Path(__file__).resolve())
+
+        def run(*args: str, expect: int = 0) -> str:
+            p = subprocess.run([sys.executable, here, "--state", str(s), *args], capture_output=True, text=True)
+            check(f"`{' '.join(args[:3])}` exits {expect}", p.returncode == expect, p.stdout + p.stderr)
+            return p.stdout + p.stderr
+
+        run("set", "--module", "MeshWeaver.AI", "version=1.2.3", "bundle=/tmp/b/MeshWeaver.AI/x.nupkg")
+        out = run("get", "--module", "MeshWeaver.AI", "version")
+        check("set/get round-trips a fact", out.strip() == "1.2.3", out)
+        out = run("fail", "--module", "MeshWeaver.Maps", "--phase", "test", "--reason", "3 tests failed")
+        check("fail prints a ::error naming module and phase", "::error title=Module MeshWeaver.Maps failed (test)::3 tests failed" in out, out)
+        out = run("list", "--ok")
+        check("a failed module leaves the --ok list; siblings stay", out.split() == ["MeshWeaver.AI", "MeshWeaver.Mcp"], out)
+        out = run("list", "--failed")
+        check("--failed lists it", out.split() == ["MeshWeaver.Maps"], out)
+        out = run("fail", "--module", "MeshWeaver.Maps", "--phase", "publish", "--reason", "later")
+        check("a second failure keeps the FIRST phase", "keeping that verdict" in out and State(s).load().record("MeshWeaver.Maps")["phase"] == "test", out)
+        run("fail", "--module", "MeshWeaver.Maps", "--phase", "bogus", "--reason", "x", expect=1)
+        run("get", "--module", "MeshWeaver.Ghost", "version", expect=1)
+        out = run("slots", "--max", "10", "--where", "bundle!=")
+        check("slots fill s1.. from the --ok modules carrying the fact, rest empty",
+              "s1=MeshWeaver.AI" in out and "s2=\n" in out and "s10=\n" in out, out)
+        run("set", "--module", "MeshWeaver.Mcp", "bundle=/tmp/b/MeshWeaver.Mcp/y.nupkg")
+        out = run("paths", "bundle")
+        check("paths is a module->fact map of the --ok modules", json.loads(out.strip().splitlines()[-1]) == {
+            "MeshWeaver.AI": "/tmp/b/MeshWeaver.AI/x.nupkg", "MeshWeaver.Mcp": "/tmp/b/MeshWeaver.Mcp/y.nupkg"}, out)
+        summary = Path(td) / "summary.md"
+        out = run("verdict", "--summary", str(summary), expect=1)
+        check("verdict reds the leg over one failed module and names it",
+              "1 failed" in out and "MeshWeaver.Maps" in out and "failed in test" in out, out)
+        check("…and writes the per-module table to the summary",
+              "| `MeshWeaver.Maps` | ❌ failed in test | 3 tests failed |" in summary.read_text(encoding="utf-8"))
+        s2 = Path(td) / "green.json"
+        st2 = State(s2)
+        st2.init([entry("MeshWeaver.AI")])
+        st2.save()
+        p = subprocess.run([sys.executable, here, "--state", str(s2), "verdict"], capture_output=True, text=True)
+        check("a leg with no failed module exits 0", p.returncode == 0 and "1 ok, 0 failed" in p.stdout, p.stdout)
+        p = subprocess.run([sys.executable, here, "--state", str(Path(td) / "absent.json"), "list", "--ok"], capture_output=True, text=True)
+        check("a missing state is a red, never an empty list", p.returncode == 1 and "did not run" in p.stdout, p.stdout)
+
+        print("== chunk via the CLI, into GITHUB_OUTPUT")
+        selp = Path(td) / "sel.json"
+        selp.write_text(json.dumps(sel), encoding="utf-8")
+        gho = Path(td) / "gho"
+        p = subprocess.run([sys.executable, here, "chunk", "--modules", f"@{selp}", "--size", "6", "--github-output", str(gho)], capture_output=True, text=True)
+        text = gho.read_text(encoding="utf-8")
+        check("chunk writes batches= and batch-count=", p.returncode == 0 and "batch-count=2\n" in text and text.startswith("batches=["), p.stdout + p.stderr + text)
+        check("the batches= line is one line of JSON (a GITHUB_OUTPUT value)", text.count("\n") == 2)
+        p = subprocess.run([sys.executable, here, "chunk", "--modules", "[]", "--size", "6", "--github-output", str(gho)], capture_output=True, text=True)
+        check("an empty selection writes batch-count=0", p.returncode == 0 and "batch-count=0\n" in gho.read_text(encoding="utf-8"))
+        p = subprocess.run([sys.executable, here, "chunk", "--modules", f"@{selp}", "--size", "12"], capture_output=True, text=True)
+        check("batch-size above the cap is RED", p.returncode == 1 and "1 to 10" in p.stdout, p.stdout)
+        p = subprocess.run([sys.executable, here, "chunk", "--modules", f"@{selp}", "--size", "six"], capture_output=True, text=True)
+        check("an unreadable batch-size is RED, not a default", p.returncode == 1 and "not an integer" in p.stdout, p.stdout)
+
+    print()
+    if failures:
+        print(f"::error::{len(failures)} self-test case(s) FAILED: " + "; ".join(failures))
+        return 1
+    print("module-pack-batch: chunking, the per-module state, failure isolation and the verdict — all green")
+    return 0
+
+
+# ── main ───────────────────────────────────────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--state", help="the leg's state file (every subcommand but chunk)")
+    ap.add_argument("--self-test", action="store_true")
+    sub = ap.add_subparsers(dest="cmd")
+
+    c = sub.add_parser("chunk", help="split a selection into batches of ≤N")
+    c.add_argument("--modules", required=True, help="JSON array of matrix entries, or @file")
+    c.add_argument("--size", required=True, help=f"batch size, 1..{MAX_BATCH_SIZE}")
+    c.add_argument("--label-max", type=int, default=LABEL_MAX)
+    c.add_argument("--github-output", help="append batches=<json> and batch-count=<n> here")
+    c.add_argument("--prefix", default="", help="prefix for the two output names (e.g. test-)")
+
+    i = sub.add_parser("init", help="start a leg's state from its matrix batch")
+    i.add_argument("--batch", required=True, help="the matrix batch object (or its entries), or @file")
+
+    l = sub.add_parser("list", help="module names, in batch order")
+    l.add_argument("--ok", action="store_true", help="only modules that have not failed")
+    l.add_argument("--failed", action="store_true", help="only modules that failed")
+    l.add_argument("--where", action="append", help="key=value or key!=value (repeatable)")
+
+    g = sub.add_parser("get", help="one fact or entry field of one module")
+    g.add_argument("--module", required=True)
+    g.add_argument("key")
+    g.add_argument("--default", default="")
+
+    se = sub.add_parser("set", help="record facts for one module")
+    se.add_argument("--module", required=True)
+    se.add_argument("pairs", nargs="+", metavar="KEY=VALUE")
+
+    f = sub.add_parser("fail", help="mark one module failed in a phase; the leg continues")
+    f.add_argument("--module", required=True)
+    f.add_argument("--phase", required=True)
+    f.add_argument("--reason", required=True)
+
+    sl = sub.add_parser("slots", help="s1..sN outputs for the unrolled per-module upload steps")
+    sl.add_argument("--max", type=int, default=MAX_BATCH_SIZE)
+    sl.add_argument("--where", action="append")
+    sl.add_argument("--github-output")
+    sl.add_argument("--prefix", default="")
+
+    pa = sub.add_parser("paths", help="JSON map module -> fact for the --ok modules that carry it")
+    pa.add_argument("key")
+    pa.add_argument("--where", action="append")
+
+    v = sub.add_parser("verdict", help="per-module status lines; exit 1 if any module failed")
+    v.add_argument("--summary", help="append the table to this file (GITHUB_STEP_SUMMARY)")
+
+    a = ap.parse_args(argv)
+    if a.self_test:
+        return self_test()
+    if not a.cmd:
+        ap.print_help()
+        return 2
+    return {
+        "chunk": cmd_chunk, "init": cmd_init, "list": cmd_list, "get": cmd_get, "set": cmd_set,
+        "fail": cmd_fail, "slots": cmd_slots, "paths": cmd_paths, "verdict": cmd_verdict,
+    }[a.cmd](a)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-module-publication.py
+++ b/.github/scripts/test-module-publication.py
@@ -391,9 +391,13 @@ def main() -> int:  # noqa: C901
     check("a staging step exists as its exact complement", stage is not None
           and "publish-mode == 'staged'" in str(stage.get("if")),
           str(stage.get("if")) if stage else "")
+    # `BUNDLES` since the batched legs (2026-09-12): ONE module -> bundle-path map, read by the
+    # hand-over, the staging and the receipt alike. Asserted non-empty as well as equal, so the
+    # comparison cannot pass on two absent keys.
     check("…and it stages the SAME bytes the hand-over would have posted",
           stage is not None and handover is not None
-          and str(stage.get("env", {}).get("BUNDLE")) == str(handover.get("env", {}).get("BUNDLE")))
+          and bool(stage.get("env", {}).get("BUNDLES"))
+          and str(stage.get("env", {}).get("BUNDLES")) == str(handover.get("env", {}).get("BUNDLES")))
     ledger_published = [s for s in pack["jobs"]["pack"]["steps"] if s.get("name") == "Ledger — Published"]
     check("a staged leg records NO `Published` ledger transition — a staged artifact is not a "
           "publication", len(ledger_published) == 1

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -2,7 +2,9 @@ name: node-repo module pack
 
 # The MODULE half of a mixed package, packed and (on trunk) handed to the registry — reusable from
 # any node repo, because every satellite that owns a module drives the same packer the platform
-# does. One matrix entry per module, so a repo that owns twelve of them does not grow twelve jobs.
+# does. One matrix entry per BATCH of modules (`batch-size`, default 6), so a repo that owns
+# twelve of them does not grow twelve jobs — and does not pay twelve whole billed minutes for
+# twelve sub-minute legs either (see "Batched legs" below).
 #
 # 🚨 The bundle's identity comes from the CONTENT side, never from workflow inputs: the released
 # SemVer from `{package}/manifest.lock` and the landing floor from `{package}/index.json`'s
@@ -315,6 +317,50 @@ name: node-repo module pack
 # Unset, the variable resolves to `ubuntu-latest` and nothing changes. Every current caller — the
 # six satellites and this repo's main-cd — passes nothing and inherits that default. Doc:
 # Doc/Architecture/ModuleBuildArchitecture ("The pipeline, end to end", the 2026-09-12 note).
+#
+# ──────────── Batched legs (`batch-size`, 2026-09-12) ────────────
+# 🚨 GitHub bills every job rounded UP to a whole minute, and most legs of this lane were shorter
+# than the unit they were billed in. Measured 2026-09-05..12 on MeshWeaver.Plugins: 4,975
+# sampled `Module bundles / Module bundle` legs at a MEDIAN of 1.1 min (p90 8.4) across 40
+# variants, 1,385 `Module bundles` parent legs at 1.1 min, 2,935 `Module tests` legs at 4.0 min
+# (p90 8.2). Whole-minute rounding on the sub-minute legs was ≈12 % of Plugins' bill (~4,700
+# billed minutes a day) and 25–40 % in Crm / Reinsurance / SocialMedia. Each leg also paid its
+# own checkout, SDK install and cache restores before a second of module work.
+#
+# So `pack` and `tests` now expand ONE LEG PER BATCH of `batch-size` modules (default 6, hard cap
+# 10 — module-pack-batch.py MAX_BATCH_SIZE, the number of bundle-upload slots the pack job
+# unrolls). `select` chunks the selection DETERMINISTICALLY — sorted by module name, STRIPED into
+# ceil(n/N) legs (module i → leg i mod k, so an alphabetical FAMILY such as MeshWeaver.AI.* is
+# spread over the legs rather than stacked in one — every job is hard-cut at 45 min and six p90
+# 8.2-min suites in one leg would be 49) — so a selection of ≤N modules is one leg and a
+# single-module repository sees
+# exactly the job name (`Module bundle (MeshWeaver.Social)`), the `module-bundle-<module>`
+# artifact and the receipts it saw before.
+#
+# 🚨 A BATCH IS A RUNNER-SHARING DEVICE, NOT A COUPLING. The observable per-module semantics are
+# unchanged and structural, not hoped-for:
+#   * every module still builds, packs, inspects, uploads ITS OWN `module-bundle-<module>`,
+#     runs ITS OWN suite and — when the call publishes — POSTs ITS OWN bundle right after ITS
+#     OWN suite, in that order, with its own ledger transitions;
+#   * a phase that fails for one module marks THAT module failed in that phase
+#     (module-pack-batch.py `fail` — a `::error` naming module and phase) and every later phase
+#     skips it, while the sibling modules in the leg complete, upload, test and publish; the
+#     leg's LAST step prints one status line per module and reds the leg over any failure, so
+#     `verify` reads `pack: failure` for the same reason it did before and still accounts every
+#     module by its OWN receipt (a failed module drops none — same as when its leg was its own
+#     job);
+#   * the per-module artifact NAME that is a cross-repo contract — `module-bundle-<module>`,
+#     recorded by the ledger and globbed by every caller's `module-artifacts` pattern — is kept
+#     by unrolled upload slots; receipts, built markers, staged publications and test evidence
+#     become ONE artifact per batch carrying one file per module, which every consumer already
+#     reads through `<kind>-<lane>-*` + merge-multiple keyed on the `module` INSIDE each file.
+#
+# What changes on the checks wall: the matrix legs are named `Module bundle (batch 1/3:
+# MeshWeaver.AI, …)` / `Module tests (batch …)`. No required context moves — `All selected
+# bundles built` is unchanged — and the fleet's protected-job matchers read the CALLER's job name
+# (`Module bundles`), which is untouched. A caller that wants the old one-leg-per-module shape
+# passes `batch-size: 1`. Doc: Doc/Architecture/ModuleBuildArchitecture ("The pipeline, end to
+# end", the 2026-09-12 batching note).
 
 on:
   workflow_call:
@@ -612,6 +658,20 @@ on:
         required: false
         type: string
         default: ubuntu-latest
+      batch-size:
+        description: >-
+          How many modules ONE `pack` leg (and one `tests` leg) carries — see "Batched legs" at
+          the top of this file. Default 6; 1 restores one leg per module; the hard cap is 10 (the
+          number of bundle-upload slots the pack job unrolls, module-pack-batch.py
+          MAX_BATCH_SIZE). Anything else — a non-integer, 0, 11 — is RED in `select`: a batch
+          size that cannot be read must never resolve to 'one leg per module' quietly, nor to one
+          giant leg. The split is deterministic (sorted by module name, striped over ceil(n/N) legs so
+          an alphabetical family is spread rather than stacked) and a selection of ≤N modules is
+          a single leg; a single-module repository is unchanged. Lower it if a leg approaches the
+          45-minute cap: a publishing leg carries its modules' suites inline.
+        required: false
+        type: number
+        default: 6
     secrets:
       publish-token:
         description: The registry's Plugins:Registry:PublishToken. Required when publish is true.
@@ -706,6 +766,14 @@ jobs:
       # the suites are a lane of their own on a non-publishing run.
       test-modules: ${{ steps.suites.outputs.modules }}
       test-count: ${{ steps.suites.outputs.count }}
+      # The two matrices as the jobs expand them: the selection above and the suite subset,
+      # each cut into batches of `batch-size` by module-pack-batch.py ("Batched legs", top of
+      # this file). `count` / `test-count` above still count MODULES — the `if:` on `pack` and
+      # `tests` and the verifier's accounting are per module, not per leg.
+      batches: ${{ steps.batches.outputs.batches }}
+      batch-count: ${{ steps.batches.outputs.batch-count }}
+      test-batches: ${{ steps.batches.outputs.test-batches }}
+      test-batch-count: ${{ steps.batches.outputs.test-batch-count }}
       count: ${{ steps.scope.outputs.count }}
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
@@ -847,6 +915,7 @@ jobs:
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
           python3 meshweaver/.github/scripts/module-build-key.py --self-test
           python3 meshweaver/.github/scripts/module-build-ledger.py --self-test
+          python3 meshweaver/.github/scripts/module-pack-batch.py --self-test
       - name: Decide which module bundles this diff can reach
         id: scope
         env:
@@ -997,6 +1066,28 @@ jobs:
           echo "modules=$(cat "$RUNNER_TEMP/suites.json")" >> "$GITHUB_OUTPUT"
           echo "count=$count" >> "$GITHUB_OUTPUT"
           echo "$count of $(jq 'length' "$RUNNER_TEMP/final.json") selected module(s) still owe a test run: $(jq -r 'if length == 0 then "<none>" else [.[].module] | join(", ") end' "$RUNNER_TEMP/suites.json")"
+
+      # ───────────── THE LEGS — the two matrices, cut into batches of `batch-size` ─────────────
+      # Deterministic (sorted by module name, runs of ≤N), refusing an unreadable size RED rather
+      # than falling back to either extreme. Printed here so the run's log says which modules
+      # share which leg before any leg starts. See "Batched legs" at the top of this file.
+      - name: Cut the selection into legs
+        id: batches
+        env:
+          BATCH_SIZE: ${{ inputs.batch-size }}
+        run: |
+          set -euo pipefail
+          echo "pack legs:"
+          python3 meshweaver/.github/scripts/module-pack-batch.py chunk \
+            --modules "@$RUNNER_TEMP/final.json" --size "$BATCH_SIZE" --github-output "$GITHUB_OUTPUT"
+          echo "tests legs:"
+          python3 meshweaver/.github/scripts/module-pack-batch.py chunk \
+            --modules "@$RUNNER_TEMP/suites.json" --size "$BATCH_SIZE" --github-output "$GITHUB_OUTPUT" --prefix test-
+          {
+            echo "### Batched legs"
+            echo
+            echo "\`batch-size: $BATCH_SIZE\` — $(jq 'length' "$RUNNER_TEMP/final.json") selected module(s) in $(sed -n 's/^batch-count=//p' "$GITHUB_OUTPUT" | tail -1) pack leg(s); $(jq 'length' "$RUNNER_TEMP/suites.json") suite(s) in $(sed -n 's/^test-batch-count=//p' "$GITHUB_OUTPUT" | tail -1) tests leg(s)."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   # ─────────────────── THE SHARED BUILD ENVIRONMENT, WARMED ONCE ───────────────────
   # "see we update *once at beginning for everyone* and not by module" (maintainer, 2026-08-31).
@@ -1555,8 +1646,30 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # ═══════════ THE PACK LEGS — N MODULES PER RUNNER, ONE VERDICT PER MODULE (2026-09-12) ═══════════
+  # 🚨 A BATCH IS A RUNNER-SHARING DEVICE, NOT A COUPLING. Every step below that used to read
+  # `matrix.entry.<field>` now loops over the modules of `matrix.batch` and runs each module's
+  # work in its own subshell: a module that fails is marked failed IN THAT PHASE by
+  # module-pack-batch.py (`fail`), every later phase skips it (`list --ok`), and the sibling
+  # modules in the leg still build, pack, upload, test and — on a publishing call — POST their own
+  # bundle after their own suite, exactly as they did in a leg of their own. The leg's LAST step
+  # is the verdict: one status line per module, and red when any module failed, so `verify` still
+  # sees `pack: failure` for the same reason it did before and still accounts each module by its
+  # OWN receipt (a failed module drops none). See "Batched legs" at the top of this file for the
+  # measurement this pays for.
+  #
+  # 🚨 THE ONE PER-MODULE ARTIFACT NAME THAT IS A CONTRACT — `module-bundle-<module>` — is kept by
+  # UNROLLING its upload into MAX_BATCH_SIZE slots (`Upload the bundle artifact (slot n)`): the
+  # ledger records that name (`--artifact-name`), the reuse leg downloads by it, and every
+  # caller's `module-artifacts` pattern globs it, so it cannot become one artifact per batch.
+  # `actions/upload-artifact` takes one name per step, so the slots are literal; the chunker caps
+  # `batch-size` at the same number (module-pack-batch.py MAX_BATCH_SIZE) and `slots` refuses a
+  # leg that would overflow them. Receipts, built markers, staged publications and test evidence
+  # are ONE artifact per batch carrying one file per module: every consumer of those already globs
+  # `<kind>-<lane>-*` with `merge-multiple` and keys on the `module` field INSIDE each file (the
+  # verifier refuses a file whose name disagrees with it), so a batch artifact reads identically.
   pack:
-    name: Module bundle (${{ matrix.entry.module }})
+    name: Module bundle (${{ matrix.batch.label }})
     needs: [select, prepare, build-workspace]
     # `runner` — one of the two jobs that honour it; see "Where the heavy legs run" in the header.
     runs-on: ${{ inputs.runner }}
@@ -1580,10 +1693,11 @@ jobs:
     # artifact downloads.)
     if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success' && needs.build-workspace.result == 'success'
     strategy:
-      # One module's failure must not hide the rest — a sweep wants every verdict in one run.
+      # One leg's failure must not hide the rest — a sweep wants every verdict in one run. (Inside a
+      # leg, the same rule holds per MODULE: see the batch state above.)
       fail-fast: false
       matrix:
-        entry: ${{ fromJson(needs.select.outputs.modules) }}
+        batch: ${{ fromJson(needs.select.outputs.batches) }}
     steps:
       # 🚨 A content checkout from ANOTHER repository needs a token that can read it. The caller's
       # GITHUB_TOKEN is scoped to the calling repository alone, so `repository:
@@ -1625,47 +1739,70 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      # ───────────── THIS LEG'S MODULES — enumerated once, from the matrix batch ─────────────
+      # The state file every step below drives; `init` refuses an empty or duplicated batch. The
+      # module list is printed here so a leg's log opens with what it owns.
+      - name: This leg's modules
+        id: batch
+        env:
+          BATCH: ${{ toJSON(matrix.batch) }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/batch"
+          printf '%s' "$BATCH" > "$RUNNER_TEMP/batch/batch.json"
+          # 🚨 THE BATCH'S ONE SOURCE OF TRUTH: which modules this leg owns, what each phase found
+          # out about each of them, and which are still in play. Every per-module step below reads
+          # and writes it through module-pack-batch.py; exported ONCE, here, so no step can point
+          # at another file (a job-level `env:` cannot read `runner.temp`).
+          echo "BATCH_STATE=$RUNNER_TEMP/batch/state.json" >> "$GITHUB_ENV"
+          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
       # ═══════ THE .NET SDK — INSTALLED BECAUSE SOMETHING DECLARED IT, NOT BY REFLEX ═══════
       # 🚨 "make installing dotnet sdk a feature flag" (maintainer, 2026-08-31). The rationale and
       # the anti-trapdoor argument are at the top of this file, under "The .NET SDK is a DECLARED
       # need"; what follows is the decision itself.
       #
       # ONE step, UNCONDITIONAL, that always says which way it went and why. It enumerates the
-      # consumers this job would hand to a runner SDK, applies the caller's policy, and — when the
-      # answer is "none" — makes the absence REAL, because the runner ships an SDK of its own and a
-      # silent fallback to it is the same class of lie as a skipped gate rendering a green tick.
+      # consumers this job would hand to a runner SDK — for EVERY module of the batch — applies the
+      # caller's policy, and, when the answer is "none", makes the absence REAL, because the runner
+      # ships an SDK of its own and a silent fallback to it is the same class of lie as a skipped
+      # gate rendering a green tick.
       - name: Does this job need the .NET SDK?
         id: sdk
         env:
           POLICY: ${{ inputs.dotnet-sdk }}
-          MODE: ${{ matrix.entry.build || 'sdk' }}
-          MODULE: ${{ matrix.entry.module }}
-          PROJECT: ${{ matrix.entry.project }}
-          RUN_TESTS: ${{ matrix.entry.test != false }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           # EVERY consumer this job would hand to a runner SDK, named one by one and evaluated
-          # against this entry — not a summary, an inventory. `build: container` (MeshWeaver#2854)
-          # removes the COMPILER from it and NOTHING ELSE: the container path still reads the
-          # emitted assembly's identity with a `dotnet run` file-based app, the packer is a
-          # `dotnet build` + `dotnet run` in every mode, and a module that ships a test suite is a
-          # `dotnet test` the image's build-project cannot do at all. An omission here is exactly
-          # what would let a converted lane skip an install it needs and then blame the shim four
-          # steps later, so the list is deliberately complete rather than convenient.
+          # against every entry of the batch — not a summary, an inventory. `build: container`
+          # (MeshWeaver#2854) removes the COMPILER from it and NOTHING ELSE: the container path
+          # still reads the emitted assembly's identity with a `dotnet run` file-based app, the
+          # packer is a `dotnet build` + `dotnet run` in every mode, and a module that ships a test
+          # suite is a `dotnet test` the image's build-project cannot do at all. An omission here is
+          # exactly what would let a converted lane skip an install it needs and then blame the
+          # shim four steps later, so the list is deliberately complete rather than convenient.
           consumers=()
-          if [ "$MODE" = "container" ]; then
-            echo "compiler: NOT a consumer — $MODULE declares build=container, so the pinned platform image compiles it"
-            consumers+=("the binding-identity probe — the container path reads ${MODULE}.dll's AssemblyVersion with a 'dotnet run' file-based app")
-          else
-            consumers+=("the compiler for $MODULE — its matrix entry declares build=$MODE, i.e. 'dotnet build' + 'dotnet publish' on this runner")
-          fi
+          compilers=()
+          mapfile -t modules < <(bk list)
+          for MODULE in "${modules[@]}"; do
+            MODE="$(bk get --module "$MODULE" build --default sdk)"
+            PROJECT="$(bk get --module "$MODULE" project)"
+            RUN_TESTS=true; [ "$(bk get --module "$MODULE" test)" != "false" ] || RUN_TESTS=false
+            if [ "$MODE" = "container" ]; then
+              echo "compiler: NOT a consumer — $MODULE declares build=container, so the pinned platform image compiles it"
+              consumers+=("the binding-identity probe — the container path reads ${MODULE}.dll's AssemblyVersion with a 'dotnet run' file-based app")
+            else
+              consumers+=("the compiler for $MODULE — its matrix entry declares build=$MODE, i.e. 'dotnet build' + 'dotnet publish' on this runner")
+            fi
+            compilers+=("$MODULE: $MODE")
+            # Resolved against the tree, exactly as the test step below resolves it, so a module
+            # with no suite does not carry a consumer it does not have.
+            tests="$(dirname "$PROJECT").Test"
+            if [ "$RUN_TESTS" = "true" ] && [ -d "$tests" ]; then
+              consumers+=("the module's own suite — 'dotnet test $tests', a verb the image's build-project does not have at all")
+            fi
+          done
           consumers+=("the module-pack tool — prebuilt once by the prepare job, but 'dotnet <dll>' still takes the runner's dotnet; a pack-module verb inside the image would remove this last every-mode consumer")
-          # Resolved against the tree, exactly as the test step below resolves it, so a module with
-          # no suite does not carry a consumer it does not have.
-          tests="$(dirname "$PROJECT").Test"
-          if [ "$RUN_TESTS" = "true" ] && [ -d "$tests" ]; then
-            consumers+=("the module's own suite — 'dotnet test $tests', a verb the image's build-project does not have at all")
-          fi
           case "$POLICY" in
             install)
               install=true
@@ -1708,7 +1845,7 @@ jobs:
             echo "### $headline"
             echo
             echo "- flag: \`dotnet-sdk: $POLICY\` (default \`install\`)"
-            echo "- compiler for \`$MODULE\`: \`$MODE\`"
+            echo "- compilers in this batch: \`${compilers[*]}\`"
             echo "- declared consumers of a runner SDK:"
             for consumer in ${consumers[@]+"${consumers[@]}"}; do echo "  - $consumer"; done
           } >> "$GITHUB_STEP_SUMMARY"
@@ -1721,101 +1858,138 @@ jobs:
         with:
           dotnet-version: "10.0.x"
 
+      # Per module: the released version and the platform floor from the content half, and the
+      # assertion that the two halves of the mixed package name each other. A module whose floor
+      # the pinned platform cannot satisfy fails HERE — that module only; its siblings go on.
       - name: Read the package version + platform floor from the content half
         id: identity
         env:
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
           PLATFORM_VERSION: ${{ needs.prepare.outputs.platform-version }}
         run: |
           set -euo pipefail
-          version=$(jq -er '.version' "$PACKAGE/manifest.lock")
-          floor=$(jq -er '.content.minMeshVersion' "$PACKAGE/index.json")
-          declared=$(jq -er '.content.module' "$PACKAGE/index.json")
-          if [ "$declared" != "$MODULE" ]; then
-            echo "::error::$PACKAGE/index.json declares content.module='$declared' but this entry packs '$MODULE' — the two halves of the mixed package drifted"
-            exit 1
-          fi
-          # 🚨 THE FLOOR MUST BE SATISFIABLE BY THE PLATFORM THIS BUNDLE IS BUILT AGAINST (#3554).
-          # Unconditional, and RED when the platform version cannot be read at all: "the floor
-          # could not be checked" must never be indistinguishable from "checked and fine" — that
-          # equivalence is what let 42 packages ship floors no image can ever meet, holding every
-          # self-update candidate on both AKS portals with nothing red anywhere. The script is the
-          # platform's own copy at this lane's pin, and its ordering is pinned to
-          # ModulePlatformFloor by ModulePlatformFloorScriptParityTest, so the gate and the landing
-          # gate cannot drift.
-          platform="${PLATFORM_VERSION:-}"
-          if [ -z "$platform" ]; then
-            # No platform IMAGE is pinned, so THE CHECKOUT IS THE PLATFORM — exactly the reading
-            # the bundle-identity block below takes ("g<sha>", #3308). Its version is the LINE it
-            # declares, which is a WEAKER reading than an image's own MESHWEAVER_PLATFORM_VERSION
-            # (a line satisfies floors that no published build of it does), but it is honest and it
-            # is never a skip: a source lane still cannot declare a floor above its own line.
-            props="$GITHUB_WORKSPACE/meshweaver/Directory.Build.props"
-            platform=$(sed -n 's:.*<PlatformVersion[^>]*>\([^<]*\)</PlatformVersion>.*:\1:p' "$props" | head -1)
-            if [ -z "$platform" ]; then
-              echo "::error::no platform image is pinned AND \$(PlatformVersion) could not be read from $props, so $PACKAGE's declared floor '$floor' cannot be checked against anything. A floor that cannot be checked is precisely the silence #3554 is about — pin platform-image + platform-image-digest on the caller, or restore the property."
-              exit 1
-            fi
-            echo "no platform image pinned — checking the floor against the platform checkout's declared line $platform"
-          fi
-          python3 "$GITHUB_WORKSPACE/meshweaver/.github/scripts/check-module-platform-floor.py" \
-            --package "$PACKAGE" --floor "$floor" --platform-version "$platform"
-          echo "version=$version" >> "$GITHUB_OUTPUT"
-          echo "floor=$floor" >> "$GITHUB_OUTPUT"
-          echo "packing $MODULE as $PACKAGE@$version, platform floor $floor"
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            set +e
+            ( set -euo pipefail
+              version=$(jq -er '.version' "$PACKAGE/manifest.lock")
+              floor=$(jq -er '.content.minMeshVersion' "$PACKAGE/index.json")
+              declared=$(jq -er '.content.module' "$PACKAGE/index.json")
+              if [ "$declared" != "$MODULE" ]; then
+                echo "::error::$PACKAGE/index.json declares content.module='$declared' but this entry packs '$MODULE' — the two halves of the mixed package drifted"
+                exit 1
+              fi
+              # 🚨 THE FLOOR MUST BE SATISFIABLE BY THE PLATFORM THIS BUNDLE IS BUILT AGAINST (#3554).
+              # Unconditional, and RED when the platform version cannot be read at all: "the floor
+              # could not be checked" must never be indistinguishable from "checked and fine" — that
+              # equivalence is what let 42 packages ship floors no image can ever meet, holding every
+              # self-update candidate on both AKS portals with nothing red anywhere. The script is the
+              # platform's own copy at this lane's pin, and its ordering is pinned to
+              # ModulePlatformFloor by ModulePlatformFloorScriptParityTest, so the gate and the landing
+              # gate cannot drift.
+              platform="${PLATFORM_VERSION:-}"
+              if [ -z "$platform" ]; then
+                # No platform IMAGE is pinned, so THE CHECKOUT IS THE PLATFORM — exactly the reading
+                # the bundle-identity block below takes ("g<sha>", #3308). Its version is the LINE it
+                # declares, which is a WEAKER reading than an image's own MESHWEAVER_PLATFORM_VERSION
+                # (a line satisfies floors that no published build of it does), but it is honest and it
+                # is never a skip: a source lane still cannot declare a floor above its own line.
+                props="$GITHUB_WORKSPACE/meshweaver/Directory.Build.props"
+                platform=$(sed -n 's:.*<PlatformVersion[^>]*>\([^<]*\)</PlatformVersion>.*:\1:p' "$props" | head -1)
+                if [ -z "$platform" ]; then
+                  echo "::error::no platform image is pinned AND \$(PlatformVersion) could not be read from $props, so $PACKAGE's declared floor '$floor' cannot be checked against anything. A floor that cannot be checked is precisely the silence #3554 is about — pin platform-image + platform-image-digest on the caller, or restore the property."
+                  exit 1
+                fi
+                echo "no platform image pinned — checking the floor against the platform checkout's declared line $platform"
+              fi
+              python3 "$GITHUB_WORKSPACE/meshweaver/.github/scripts/check-module-platform-floor.py" \
+                --package "$PACKAGE" --floor "$floor" --platform-version "$platform"
+              bk set --module "$MODULE" "version=$version" "floor=$floor"
+              echo "packing $MODULE as $PACKAGE@$version, platform floor $floor"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the content half's version/floor could not be read or the floor is unsatisfiable (exit $rc; see above)"
+          done
 
-      # ───────────── THE LEDGER'S PLAN FOR THIS ENTRY — build it, or reuse another run's bundle ─────────────
-      # `select` annotated the entry (`ledger.decision`, `ledger.key`, what is still needed). ONE
-      # step reads it, prints it, and hands the rest of the job three booleans; with the ledger off
-      # the plan is "build, test if the entry says so, publish if the caller says so" — today's leg.
-      # A `reuse` leg downloads the recorded run's bundle artifact (sha256 verified against the
-      # record), runs only the phases the record lacks, and drops the same artifact, marker and
-      # receipt a built leg drops — a caller composing this bundle cannot tell the two apart, and
-      # must not need to. The heartbeat keeps the claim fresh across this job's queue time.
-      - name: Ledger — this entry's plan
+      # ───────────── THE LEDGER'S PLAN FOR EVERY ENTRY — build it, or reuse another run's bundle ─────────────
+      # `select` annotated each entry (`ledger.decision`, `ledger.key`, what is still needed). ONE
+      # step reads them, prints them, and records per module the booleans the rest of the job
+      # branches on; with the ledger off the plan is "build, test if the entry says so, publish if
+      # the caller says so" — today's leg. A `reuse` module downloads the recorded run's bundle
+      # artifact (sha256 verified against the record), runs only the phases the record lacks, and
+      # drops the same artifact, marker and receipt a built module drops — a caller composing this
+      # bundle cannot tell the two apart, and must not need to. The heartbeat keeps the claim fresh
+      # across this job's queue time.
+      #
+      # The step's OUTPUTS are batch-wide "any module still needs …" switches for the steps that
+      # are actions rather than shell (artifact downloads) and for the inline suite / hand-over
+      # steps; inside those, the per-module facts decide again for each module.
+      - name: Ledger — every entry's plan
         id: plan
         env:
           LEDGER: ${{ inputs.ledger }}
-          ENTRY_LEDGER: ${{ toJSON(matrix.entry.ledger) }}
-          ENTRY_REUSE: ${{ toJSON(matrix.entry.reuse) }}
-          RUN_TESTS: ${{ matrix.entry.test != false }}
           PUBLISH: ${{ inputs.publish }}
-          MODULE: ${{ matrix.entry.module }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          decision=build; key=""; need_test="$RUN_TESTS"; need_publish="$PUBLISH"; art_run=""; art_name=""; sha=""; holder=""
-          if [ "$ENTRY_REUSE" != "null" ] && [ -n "$ENTRY_REUSE" ]; then
-            decision=reuse; need_test=false; need_publish=false
-            art_run=$(jq -er '.runId' <<< "$ENTRY_REUSE")
-            art_name=$(jq -er '.name' <<< "$ENTRY_REUSE")
-            holder=$(jq -er '.source' <<< "$ENTRY_REUSE")
-            echo "plan: REUSE unchanged $MODULE from successful publication $holder — no compile, tests or publish owed"
-          elif [ "$LEDGER" = "required" ] && [ "$ENTRY_LEDGER" != "null" ] && [ -n "$ENTRY_LEDGER" ]; then
-            decision=$(jq -r '.decision // "build"' <<< "$ENTRY_LEDGER")
-            key=$(jq -r '.key // ""' <<< "$ENTRY_LEDGER")
-            if [ "$decision" = "reuse" ]; then
-              need_test=$(jq -r 'if .needTest then "true" else "false" end' <<< "$ENTRY_LEDGER")
-              need_publish=$(jq -r 'if .needPublish then "true" else "false" end' <<< "$ENTRY_LEDGER")
-              art_run=$(jq -r '.artifact.runId // ""' <<< "$ENTRY_LEDGER")
-              art_name=$(jq -r '.artifact.name // ""' <<< "$ENTRY_LEDGER")
-              sha=$(jq -r '.bundleSha256 // ""' <<< "$ENTRY_LEDGER")
-              holder=$(jq -r '.holder // ""' <<< "$ENTRY_LEDGER")
-              [ -n "$art_run" ] && [ -n "$art_name" ] || { echo "::error::the ledger said REUSE for $MODULE but named no bundle artifact — nothing to reuse; this is a select-step defect, not a build failure"; exit 1; }
-              echo "plan: REUSE $MODULE from run $art_run ($art_name, sha256 ${sha:-unrecorded}; holder $holder) — tests: $need_test, publish: $need_publish"
-            else
-              echo "plan: BUILD $MODULE (ledger key ${key:-<none>}; $(jq -r 'if .unavailable then "WITHOUT coordination: " + .unavailable else "attempt " + (.attempts|tostring) end' <<< "$ENTRY_LEDGER")) — tests: $need_test, publish: $need_publish"
-              [ -z "$key" ] || python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
-            fi
-          else
-            echo "plan: BUILD $MODULE (ledger off) — tests: $need_test, publish: $need_publish"
-          fi
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            ENTRY_LEDGER="$(bk get --module "$MODULE" ledger --default null)"
+            ENTRY_REUSE="$(bk get --module "$MODULE" reuse --default null)"
+            RUN_TESTS=true; [ "$(bk get --module "$MODULE" test)" != "false" ] || RUN_TESTS=false
+            set +e
+            ( set -euo pipefail
+              decision=build; key=""; need_test="$RUN_TESTS"; need_publish="$PUBLISH"; art_run=""; art_name=""; sha=""; holder=""
+              if [ "$ENTRY_REUSE" != "null" ] && [ -n "$ENTRY_REUSE" ]; then
+                decision=reuse; need_test=false; need_publish=false
+                art_run=$(jq -er '.runId' <<< "$ENTRY_REUSE")
+                art_name=$(jq -er '.name' <<< "$ENTRY_REUSE")
+                holder=$(jq -er '.source' <<< "$ENTRY_REUSE")
+                echo "plan: REUSE unchanged $MODULE from successful publication $holder — no compile, tests or publish owed"
+              elif [ "$LEDGER" = "required" ] && [ "$ENTRY_LEDGER" != "null" ] && [ -n "$ENTRY_LEDGER" ]; then
+                decision=$(jq -r '.decision // "build"' <<< "$ENTRY_LEDGER")
+                key=$(jq -r '.key // ""' <<< "$ENTRY_LEDGER")
+                if [ "$decision" = "reuse" ]; then
+                  need_test=$(jq -r 'if .needTest then "true" else "false" end' <<< "$ENTRY_LEDGER")
+                  need_publish=$(jq -r 'if .needPublish then "true" else "false" end' <<< "$ENTRY_LEDGER")
+                  art_run=$(jq -r '.artifact.runId // ""' <<< "$ENTRY_LEDGER")
+                  art_name=$(jq -r '.artifact.name // ""' <<< "$ENTRY_LEDGER")
+                  sha=$(jq -r '.bundleSha256 // ""' <<< "$ENTRY_LEDGER")
+                  holder=$(jq -r '.holder // ""' <<< "$ENTRY_LEDGER")
+                  [ -n "$art_run" ] && [ -n "$art_name" ] || { echo "::error::the ledger said REUSE for $MODULE but named no bundle artifact — nothing to reuse; this is a select-step defect, not a build failure"; exit 1; }
+                  echo "plan: REUSE $MODULE from run $art_run ($art_name, sha256 ${sha:-unrecorded}; holder $holder) — tests: $need_test, publish: $need_publish"
+                else
+                  echo "plan: BUILD $MODULE (ledger key ${key:-<none>}; $(jq -r 'if .unavailable then "WITHOUT coordination: " + .unavailable else "attempt " + (.attempts|tostring) end' <<< "$ENTRY_LEDGER")) — tests: $need_test, publish: $need_publish"
+                  [ -z "$key" ] || python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
+                fi
+              else
+                echo "plan: BUILD $MODULE (ledger off) — tests: $need_test, publish: $need_publish"
+              fi
+              bk set --module "$MODULE" "decision=$decision" "key=$key" "need_test=$need_test" "need_publish=$need_publish" \
+                "art_run=$art_run" "art_name=$art_name" "sha=$sha" "holder=$holder"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the ledger's plan for this entry could not be read (exit $rc; see above)"
+          done
+          # Batch-wide switches for the steps that cannot loop (artifact downloads) and for the
+          # inline suite / hand-over steps' `if:`. Each is "at least one module still in play
+          # needs it"; the steps themselves decide again per module.
+          any() { [ -n "$(bk list --ok "$@")" ] && echo true || echo false; }
           {
-            echo "decision=$decision"; echo "key=$key"; echo "need_test=$need_test"; echo "need_publish=$need_publish"
-            echo "art_run=$art_run"; echo "art_name=$art_name"; echo "sha=$sha"; echo "holder=$holder"
+            echo "need_test=$(any --where need_test=true)"
+            echo "need_publish=$(any --where need_publish=true)"
+            echo "any_build=$(any --where decision=build)"
+            fetch=false
+            for m in $(bk list --ok --where decision=build); do
+              [ "$(bk get --module "$m" build --default sdk)" != "container" ] || fetch=true
+            done
+            echo "fetch_workspace=$fetch"
           } >> "$GITHUB_OUTPUT"
 
       # 🚨 THE PLATFORM IS THE IMAGE. When the caller pins platform-image-digest, the module is
@@ -1970,30 +2144,23 @@ jobs:
       #
       # ONE step, not two `if:`-guarded ones: two guards can BOTH skip, and a skipped step renders
       # with the same tick as a passed one. This step always runs, always prints the compiler it
-      # used, records it in the receipt, and refuses a mode it does not know.
-      # The tester's extracted /app, cached by DIGEST — one extraction per digest per repo,
-      # every later job restores it in seconds instead of pulling the tester image at all.
+      # used for every module, records it in the receipt, and refuses a mode it does not know.
       # The global workspace build's outputs — every container entry's assemblies, closure
       # manifests and the one build log. Container packs consume THIS; sdk entries ignore it.
       - name: Fetch the global workspace build
-        if: ${{ (matrix.entry.build || 'sdk') == 'container' && steps.plan.outputs.decision == 'build' }}
+        if: ${{ steps.plan.outputs.fetch_workspace == 'true' }}
         uses: actions/download-artifact@v8
         with:
           name: workspace-build-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/workspace-build
-      # 🚨 `if: decision == 'build'` on the build/pack/inspect trio is a MODE SWITCH on the ledger's
-      # plan, not a skip-trapdoor: the reuse leg below runs in their place, is itself unconditional
-      # within its mode, verifies the bytes it fetched, and drops the same artifact/marker/receipt —
-      # so `verify` still counts this entry, and a leg that did neither is still RED there.
+      # 🚨 `decision == build` on the build/pack/inspect trio is a MODE SWITCH on the ledger's
+      # plan, not a skip-trapdoor: the reuse leg below runs in its place for the reuse modules, is
+      # itself unconditional within its mode, verifies the bytes it fetched, and drops the same
+      # artifact/marker/receipt — so `verify` still counts every module, and one that did neither
+      # is still RED there.
       - name: Build the module — and say which compiler produced it
         id: build
-        if: steps.plan.outputs.decision == 'build'
         env:
-          MODE: ${{ matrix.entry.build || 'sdk' }}
-          ACCEPT: ${{ matrix.entry.accept || '' }}
-          PROJECT: ${{ matrix.entry.project }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
           IMAGE: ${{ inputs.platform-image }}
           DIGEST: ${{ inputs.platform-image-digest }}
           TESTER_IMAGE: ${{ inputs.tester-image }}
@@ -2010,160 +2177,175 @@ jobs:
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          # The closure arguments are written HERE and read by the pack step, so the compiler that
-          # ran is the one that says what rides: the SDK path derives the private closure from the
-          # deps.json only it produces (--deps-closure), the container path names the module-owned
-          # siblings it actually emitted (--with). One producer, one reader, no re-derivation.
-          packargs="$RUNNER_TEMP/pack-args"
-          : > "$packargs"
-          case "$MODE" in
-            sdk)
-              compiler="dotnet SDK on the runner"
-              echo "compiler: dotnet SDK $(dotnet --version) on the runner — the LEGACY path"
-              echo "🚧 $MODULE has not been converted to \`memex build project\` yet. Declare"
-              echo "🚧 \`\"build\": \"container\"\` on its \`modules:\` entry once it compiles against the image."
-              dotnet build "$PROJECT" -c Release -warnaserror \
-                -p:MeshWeaverRoot="$GITHUB_WORKSPACE/meshweaver" \
-                -p:Version="$VERSION" \
-                ${REFS:+-p:MeshWeaverRefs=$REFS}
-              # Publish materializes the module's PACKAGE dependencies beside the entry DLL — the
-              # SDK's own answer to the runtime closure (framework-trimmed packages excluded,
-              # everything else included), which --deps-closure selects from. A
-              # -p:CopyLocalLockFileAssemblies=true build was tried first and copied NOTHING on the
-              # CI SDK while copying everything on a dev machine (2026-08-20, 12/14 jobs) — publish
-              # does not depend on that flag at all.
-              # 🚨 The SAME reference set as the build: --no-build re-evaluates the project, and
-              # without -p:MeshWeaverRefs the platform ProjectReferences the build had dropped come
-              # back — publish then copies their outputs, which were never built ("MSB3030: Could
-              # not copy meshweaver/src/MeshWeaver.Graph/bin/Release/net10.0/MeshWeaver.Graph.dll",
-              # Plugins #940).
-              dotnet publish "$PROJECT" -c Release --no-build \
-                -p:MeshWeaverRoot="$GITHUB_WORKSPACE/meshweaver" \
-                -p:Version="$VERSION" \
-                ${REFS:+-p:MeshWeaverRefs=$REFS}
-              packdir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0/publish"
-              printf '%s\n' --deps-closure >> "$packargs"
-              # What resolved this bundle's private closure — recorded, not merely implied. It is
-              # stamped into the built marker below and the verifier REFUSES a marker without it:
-              # "the bundle exists" and "the bundle is composable" must be one claim, not two
-              # facts that happen to be produced by adjacent steps (Plugins#1077).
-              closure_evidence="deps-closure (from the publish deps.json)"
-              ;;
-            container)
-              compiler="memex build project (ONE global workspace build)"
-              # 🚨 LOCAL BUILDS ARE DISCONTINUED ("we want *one* central build *no* per project
-              # build … one global one and finish", maintainer, 2026-09-01). The build-workspace
-              # job compiled every selected container entry in ONE Roslyn workspace inside the
-              # pinned platform container; this job only CONSUMES its artifact. A module missing
-              # from it is RED here — by design there is no local rebuild to slide into, exactly
-              # as there is no SDK fallback.
-              ws="$RUNNER_TEMP/workspace-build"
-              log="$ws/workspace-build.log"
-              packdir="$ws/$MODULE"
-              if [ ! -f "$packdir/$MODULE.dll" ]; then
-                # 🚨 build-workspace now asserts this very file EXISTS for every selected entry
-                # before it uploads (Plugins#1051), so a green build can no longer be a short one.
-                # Reaching here therefore means this job read the WRONG workspace — a sibling
-                # call's artifact (Plugins#1077) or a torn download — not that the build skipped
-                # the module. Still never rebuild locally: that would paper over which artifact
-                # arrived.
-                echo "::error::the global workspace build produced no $MODULE.dll under $packdir — yet build-workspace asserted every selected entry's assembly before uploading. So the workspace this job downloaded is not the one this call built (a sibling call's artifact, or a torn download); the lane key is ${{ needs.select.outputs.lane }}. Local builds are discontinued: fix which artifact arrives, never rebuild here."
-                exit 1
-              fi
-              closure_file="$ws/$MODULE.closure.txt"
-              if [ ! -f "$closure_file" ]; then
-                echo "::error::the global build wrote no closure manifest for $MODULE — without it this job cannot know which in-tree siblings ride THIS bundle (a shared workspace output holds every entry's assemblies side by side, and globbing it would ride every other module)."
-                exit 1
-              fi
-              closure_evidence="$MODULE.closure.txt ($(wc -l < "$closure_file" | tr -d ' ') entr(y|ies)) from the global workspace build"
-              echo "compiler: CONTAINER — consumed from the ONE global workspace build (no docker, no registry, no compile in this job)"
-              # MODULE-OWNED in-tree siblings (from THIS module's closure manifest, never a glob of
-              # the shared output) MUST ride; image-shipped ones must NOT (same-identity duplicate
-              # beside /app's copy — the #143 family). Same script as packer + inspection, and with
-              # the image in hand it MEASURES what that host ships instead of reading the repo's
-              # declared src/platform-shipped.txt (MeshWeaver#3732).
-              own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
-              # WHICH WITNESS ANSWERED, stated once. 🚨 NOT `${PLATFORM_APP:+measured off $PLATFORM_APP}${PLATFORM_APP:-declared by …}`:
-              # `:-` yields the VALUE when the variable is set, so the measured branch printed the path TWICE
-              # ("measured off /tmp/app/tmp/app") — and that is the branch that matters, because it is the one
-              # that says the answer came from the image rather than from a hand-maintained list.
-              witness="declared by src/platform-shipped.txt"
-              [ -z "${PLATFORM_APP:-}" ] || witness="measured off $PLATFORM_APP"
-              while IFS= read -r name; do
-                { [ -n "$name" ] && [ "$name" != "$MODULE" ]; } || continue
-                dir="$ws/$name"
-                [ -d "$dir" ] || continue   # resolved from the image, nothing emitted — nothing to ride
-                case "$name" in
-                  MeshWeaver.*) ;;
-                  *)
-                    echo "::error::the global build emitted '$name' in $MODULE's closure. Only MeshWeaver.* siblings can be classified as platform-carried or module-owned — build $MODULE on the sdk path until this lane can decide."
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where decision=build)
+          [ "${#modules[@]}" -gt 0 ] || echo "no module in this batch is built here — every one is reused from the ledger, or failed before this step (see above)"
+          for MODULE in "${modules[@]}"; do
+            MODE="$(bk get --module "$MODULE" build --default sdk)"
+            PROJECT="$(bk get --module "$MODULE" project)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            # The ledger's vocabulary for where this module stopped, decided by the COMPILER: an
+            # SDK build that fails failed to compile (blocking — same inputs, same result); a
+            # container module cannot fail to compile here, only to be consumed.
+            phase=pack; [ "$MODE" != sdk ] || phase=compile
+            mkdir -p "$RUNNER_TEMP/mods/$MODULE"
+            set +e
+            ( set -euo pipefail
+              # The closure arguments are written HERE and read by the pack step, so the compiler that
+              # ran is the one that says what rides: the SDK path derives the private closure from the
+              # deps.json only it produces (--deps-closure), the container path names the module-owned
+              # siblings it actually emitted (--with). One producer, one reader, no re-derivation.
+              packargs="$RUNNER_TEMP/mods/$MODULE/pack-args"
+              : > "$packargs"
+              case "$MODE" in
+                sdk)
+                  compiler="dotnet SDK on the runner"
+                  echo "compiler: dotnet SDK $(dotnet --version) on the runner — the LEGACY path"
+                  echo "🚧 $MODULE has not been converted to \`memex build project\` yet. Declare"
+                  echo "🚧 \`\"build\": \"container\"\` on its \`modules:\` entry once it compiles against the image."
+                  dotnet build "$PROJECT" -c Release -warnaserror \
+                    -p:MeshWeaverRoot="$GITHUB_WORKSPACE/meshweaver" \
+                    -p:Version="$VERSION" \
+                    ${REFS:+-p:MeshWeaverRefs=$REFS}
+                  # Publish materializes the module's PACKAGE dependencies beside the entry DLL — the
+                  # SDK's own answer to the runtime closure (framework-trimmed packages excluded,
+                  # everything else included), which --deps-closure selects from. A
+                  # -p:CopyLocalLockFileAssemblies=true build was tried first and copied NOTHING on the
+                  # CI SDK while copying everything on a dev machine (2026-08-20, 12/14 jobs) — publish
+                  # does not depend on that flag at all.
+                  # 🚨 The SAME reference set as the build: --no-build re-evaluates the project, and
+                  # without -p:MeshWeaverRefs the platform ProjectReferences the build had dropped come
+                  # back — publish then copies their outputs, which were never built ("MSB3030: Could
+                  # not copy meshweaver/src/MeshWeaver.Graph/bin/Release/net10.0/MeshWeaver.Graph.dll",
+                  # Plugins #940).
+                  dotnet publish "$PROJECT" -c Release --no-build \
+                    -p:MeshWeaverRoot="$GITHUB_WORKSPACE/meshweaver" \
+                    -p:Version="$VERSION" \
+                    ${REFS:+-p:MeshWeaverRefs=$REFS}
+                  packdir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0/publish"
+                  printf '%s\n' --deps-closure >> "$packargs"
+                  # What resolved this bundle's private closure — recorded, not merely implied. It is
+                  # stamped into the built marker below and the verifier REFUSES a marker without it:
+                  # "the bundle exists" and "the bundle is composable" must be one claim, not two
+                  # facts that happen to be produced by adjacent steps (Plugins#1077).
+                  closure_evidence="deps-closure (from the publish deps.json)"
+                  ;;
+                container)
+                  compiler="memex build project (ONE global workspace build)"
+                  # 🚨 LOCAL BUILDS ARE DISCONTINUED ("we want *one* central build *no* per project
+                  # build … one global one and finish", maintainer, 2026-09-01). The build-workspace
+                  # job compiled every selected container entry in ONE Roslyn workspace inside the
+                  # pinned platform container; this job only CONSUMES its artifact. A module missing
+                  # from it is RED here — by design there is no local rebuild to slide into, exactly
+                  # as there is no SDK fallback.
+                  ws="$RUNNER_TEMP/workspace-build"
+                  log="$ws/workspace-build.log"
+                  packdir="$ws/$MODULE"
+                  if [ ! -f "$packdir/$MODULE.dll" ]; then
+                    # 🚨 build-workspace now asserts this very file EXISTS for every selected entry
+                    # before it uploads (Plugins#1051), so a green build can no longer be a short one.
+                    # Reaching here therefore means this job read the WRONG workspace — a sibling
+                    # call's artifact (Plugins#1077) or a torn download — not that the build skipped
+                    # the module. Still never rebuild locally: that would paper over which artifact
+                    # arrived.
+                    echo "::error::the global workspace build produced no $MODULE.dll under $packdir — yet build-workspace asserted every selected entry's assembly before uploading. So the workspace this job downloaded is not the one this call built (a sibling call's artifact, or a torn download); the lane key is ${{ needs.select.outputs.lane }}. Local builds are discontinued: fix which artifact arrives, never rebuild here."
                     exit 1
-                    ;;
-                esac
-                if printf '%s' ";$own;" | grep -qF ";$name;"; then
-                  cp "$dir/$name.dll" "$packdir/"
-                  if [ -f "$dir/$name.pdb" ]; then cp "$dir/$name.pdb" "$packdir/"; fi
-                  printf '%s\n%s\n' --with "$name.dll" >> "$packargs"
-                  echo "closure: $name.dll RIDES — module-owned (its source is in this repo's src/, so it is nowhere in the image's /app)"
-                else
-                  echo "closure: $name.dll does NOT ride — the platform ships it ($witness); bundling it would land a same-identity duplicate beside the host's own copy"
-                fi
-              done < "$closure_file"
-              # The PRIVATE CLOSURE rides: module-libs.txt is the builder-written provenance —
-              # every non-framework assembly this module's own PackageReferences pull in, sourced
-              # from the image's /app and the module-libraries shelf.
-              # 🚨 "The image has it" is NOT a reason to leave one out. The reference image is a
-              # PORTAL, and a portal with a module compiled into it carries that module's private
-              # dependencies too: reading /app as a platform guarantee dropped Microsoft.Agents.AI
-              # out of the AI bundle and threw ReflectionTypeLoadException in every host that was
-              # not that exact image — this repo's bake gate and MeshWeaver.Reinsurance's trunk
-              # (MeshWeaver.Plugins#1043). The SHARED FRAMEWORK is the only sound omission.
-              if [ -f "$packdir/module-libs.txt" ]; then
-                while IFS= read -r ride; do
-                  [ -n "$ride" ] || continue
-                  printf '%s\n%s\n' --with "$ride" >> "$packargs"
-                  echo "closure: $ride RIDES — the module's private closure (deps.json-derived, from the image or the shelf)"
-                done < "$packdir/module-libs.txt"
-              fi
-              echo "closure: NO --deps-closure on the container path — there is no SDK deps.json to derive one from."
-              echo "closure: complete BY RECORD instead — the builder walked the module's own package references over the image's and the shelf's deps.json and copied everything the shared framework does not supply; it refuses BY NAME anything neither supplies, and this lane passes no --extra-refs."
-              # 🚨 THE BINDING IDENTITY, CHECKED (MeshWeaver#143): the expected value is the one
-              # the global builder read out of the image, so it cannot drift from what the portals
-              # run. The global build log carries it once for the whole workspace.
-              platform_version="$(sed -n 's/.*platform AssemblyVersion \([0-9][0-9.]*\).*/\1/p' "$log" | head -1)"
-              if [ -z "$platform_version" ]; then
-                echo "::error::could not read 'platform AssemblyVersion' out of the global build log ($log). The binding-identity check cannot run, and a check that quietly does not run reads exactly like one that passed."
-                exit 1
-              fi
-              printf '%s\n' 'Console.WriteLine(System.Reflection.AssemblyName.GetAssemblyName(args[0]).Version);' > "$RUNNER_TEMP/asmver.cs"
-              module_version="$(DOTNET_NOLOGO=1 dotnet run "$RUNNER_TEMP/asmver.cs" -- "$packdir/$MODULE.dll" | tail -1)"
-              if [ "$module_version" != "$platform_version" ]; then
-                echo "::error::binding identity drift: $MODULE.dll was emitted as AssemblyVersion $module_version, but every MeshWeaver.* assembly in the platform image carries $platform_version — a runtime FileNotFoundException, not a build error (MeshWeaver#143)."
-                exit 1
-              fi
-              echo "identity: $MODULE.dll AssemblyVersion $module_version == the image's $platform_version"
-              ;;
-            *)
-              echo "::error::matrix entry '$MODULE' declares build='$MODE'. The only values are 'container' (memex build project, inside the pinned platform image) and 'sdk' (dotnet build on the runner — the default). A typo must not silently pick either one."
-              exit 1
-              ;;
-          esac
-          # `closure` is never empty by the time we get here: both branches set it, and the only
-          # paths that leave it unset already exited 1 above. The built marker carries it so that
-          # the VERIFIER — not the order the steps happen to sit in — is what asserts this bundle
-          # was composable (Plugins#1077).
-          {
-            echo "compiler=$MODE"
-            echo "packdir=$packdir"
-            echo "closure=$closure_evidence"
-          } >> "$GITHUB_OUTPUT"
-          {
-            echo "### \`$MODULE\` — compiled by **$compiler**"
-            echo
-            echo "- mode: \`$MODE\` (\`container\` = memex build project inside the pinned image; \`sdk\` = dotnet build on the runner)"
-            echo "- pack input: \`$packdir\`"
-            echo "- closure args: \`$( (tr '\n' ' ' < "$packargs") || true )\`"
-          } >> "$GITHUB_STEP_SUMMARY"
+                  fi
+                  closure_file="$ws/$MODULE.closure.txt"
+                  if [ ! -f "$closure_file" ]; then
+                    echo "::error::the global build wrote no closure manifest for $MODULE — without it this job cannot know which in-tree siblings ride THIS bundle (a shared workspace output holds every entry's assemblies side by side, and globbing it would ride every other module)."
+                    exit 1
+                  fi
+                  closure_evidence="$MODULE.closure.txt ($(wc -l < "$closure_file" | tr -d ' ') entr(y|ies)) from the global workspace build"
+                  echo "compiler: CONTAINER — consumed from the ONE global workspace build (no docker, no registry, no compile in this job)"
+                  # MODULE-OWNED in-tree siblings (from THIS module's closure manifest, never a glob of
+                  # the shared output) MUST ride; image-shipped ones must NOT (same-identity duplicate
+                  # beside /app's copy — the #143 family). Same script as packer + inspection, and with
+                  # the image in hand it MEASURES what that host ships instead of reading the repo's
+                  # declared src/platform-shipped.txt (MeshWeaver#3732).
+                  own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
+                  # WHICH WITNESS ANSWERED, stated once. 🚨 NOT `${PLATFORM_APP:+measured off $PLATFORM_APP}${PLATFORM_APP:-declared by …}`:
+                  # `:-` yields the VALUE when the variable is set, so the measured branch printed the path TWICE
+                  # ("measured off /tmp/app/tmp/app") — and that is the branch that matters, because it is the one
+                  # that says the answer came from the image rather than from a hand-maintained list.
+                  witness="declared by src/platform-shipped.txt"
+                  [ -z "${PLATFORM_APP:-}" ] || witness="measured off $PLATFORM_APP"
+                  while IFS= read -r name; do
+                    { [ -n "$name" ] && [ "$name" != "$MODULE" ]; } || continue
+                    dir="$ws/$name"
+                    [ -d "$dir" ] || continue   # resolved from the image, nothing emitted — nothing to ride
+                    case "$name" in
+                      MeshWeaver.*) ;;
+                      *)
+                        echo "::error::the global build emitted '$name' in $MODULE's closure. Only MeshWeaver.* siblings can be classified as platform-carried or module-owned — build $MODULE on the sdk path until this lane can decide."
+                        exit 1
+                        ;;
+                    esac
+                    if printf '%s' ";$own;" | grep -qF ";$name;"; then
+                      cp "$dir/$name.dll" "$packdir/"
+                      if [ -f "$dir/$name.pdb" ]; then cp "$dir/$name.pdb" "$packdir/"; fi
+                      printf '%s\n%s\n' --with "$name.dll" >> "$packargs"
+                      echo "closure: $name.dll RIDES — module-owned (its source is in this repo's src/, so it is nowhere in the image's /app)"
+                    else
+                      echo "closure: $name.dll does NOT ride — the platform ships it ($witness); bundling it would land a same-identity duplicate beside the host's own copy"
+                    fi
+                  done < "$closure_file"
+                  # The PRIVATE CLOSURE rides: module-libs.txt is the builder-written provenance —
+                  # every non-framework assembly this module's own PackageReferences pull in, sourced
+                  # from the image's /app and the module-libraries shelf.
+                  # 🚨 "The image has it" is NOT a reason to leave one out. The reference image is a
+                  # PORTAL, and a portal with a module compiled into it carries that module's private
+                  # dependencies too: reading /app as a platform guarantee dropped Microsoft.Agents.AI
+                  # out of the AI bundle and threw ReflectionTypeLoadException in every host that was
+                  # not that exact image — this repo's bake gate and MeshWeaver.Reinsurance's trunk
+                  # (MeshWeaver.Plugins#1043). The SHARED FRAMEWORK is the only sound omission.
+                  if [ -f "$packdir/module-libs.txt" ]; then
+                    while IFS= read -r ride; do
+                      [ -n "$ride" ] || continue
+                      printf '%s\n%s\n' --with "$ride" >> "$packargs"
+                      echo "closure: $ride RIDES — the module's private closure (deps.json-derived, from the image or the shelf)"
+                    done < "$packdir/module-libs.txt"
+                  fi
+                  echo "closure: NO --deps-closure on the container path — there is no SDK deps.json to derive one from."
+                  echo "closure: complete BY RECORD instead — the builder walked the module's own package references over the image's and the shelf's deps.json and copied everything the shared framework does not supply; it refuses BY NAME anything neither supplies, and this lane passes no --extra-refs."
+                  # 🚨 THE BINDING IDENTITY, CHECKED (MeshWeaver#143): the expected value is the one
+                  # the global builder read out of the image, so it cannot drift from what the portals
+                  # run. The global build log carries it once for the whole workspace.
+                  platform_version="$(sed -n 's/.*platform AssemblyVersion \([0-9][0-9.]*\).*/\1/p' "$log" | head -1)"
+                  if [ -z "$platform_version" ]; then
+                    echo "::error::could not read 'platform AssemblyVersion' out of the global build log ($log). The binding-identity check cannot run, and a check that quietly does not run reads exactly like one that passed."
+                    exit 1
+                  fi
+                  printf '%s\n' 'Console.WriteLine(System.Reflection.AssemblyName.GetAssemblyName(args[0]).Version);' > "$RUNNER_TEMP/asmver.cs"
+                  module_version="$(DOTNET_NOLOGO=1 dotnet run "$RUNNER_TEMP/asmver.cs" -- "$packdir/$MODULE.dll" | tail -1)"
+                  if [ "$module_version" != "$platform_version" ]; then
+                    echo "::error::binding identity drift: $MODULE.dll was emitted as AssemblyVersion $module_version, but every MeshWeaver.* assembly in the platform image carries $platform_version — a runtime FileNotFoundException, not a build error (MeshWeaver#143)."
+                    exit 1
+                  fi
+                  echo "identity: $MODULE.dll AssemblyVersion $module_version == the image's $platform_version"
+                  ;;
+                *)
+                  echo "::error::matrix entry '$MODULE' declares build='$MODE'. The only values are 'container' (memex build project, inside the pinned platform image) and 'sdk' (dotnet build on the runner — the default). A typo must not silently pick either one."
+                  exit 1
+                  ;;
+              esac
+              # `closure` is never empty by the time we get here: both branches set it, and the only
+              # paths that leave it unset already exited 1 above. The built marker carries it so that
+              # the VERIFIER — not the order the steps happen to sit in — is what asserts this bundle
+              # was composable (Plugins#1077).
+              bk set --module "$MODULE" "compiler=$MODE" "packdir=$packdir" "closure=$closure_evidence"
+              {
+                echo "### \`$MODULE\` — compiled by **$compiler**"
+                echo
+                echo "- mode: \`$MODE\` (\`container\` = memex build project inside the pinned image; \`sdk\` = dotnet build on the runner)"
+                echo "- pack input: \`$packdir\`"
+                echo "- closure args: \`$( (tr '\n' ' ' < "$packargs") || true )\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase "$phase" --reason "the $MODE build did not produce a packable output (exit $rc; see above)"
+          done
 
       # ───────────── THE REUSE LEG — another run already built these bytes ─────────────
       # The ledger's record names the run and the artifact; `select` already asked the API that the
@@ -2173,45 +2355,54 @@ jobs:
       # a torn download), never something to pack anyway.
       - name: Reuse the bundle another run built (ledger)
         id: reused
-        if: steps.plan.outputs.decision == 'reuse'
         env:
           GH_TOKEN: ${{ github.token }}
-          ART_RUN: ${{ steps.plan.outputs.art_run }}
-          ART_NAME: ${{ steps.plan.outputs.art_name }}
-          EXPECTED_SHA: ${{ steps.plan.outputs.sha }}
-          HOLDER: ${{ steps.plan.outputs.holder }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/bundles"
-          gh run download "$ART_RUN" -R "$GITHUB_REPOSITORY" -n "$ART_NAME" -D "$RUNNER_TEMP/bundles"
-          bundle="$RUNNER_TEMP/bundles/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
-          if [ ! -f "$bundle" ]; then
-            found=$(find "$RUNNER_TEMP/bundles" -name '*.module.nupkg' | head -1)
-            echo "::error::run $ART_RUN's artifact $ART_NAME carries no MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg (found: ${found:-nothing}) — the ledger record and this checkout's manifest.lock disagree about the version; the key should have differed. Not reusing."
-            exit 1
-          fi
-          actual=$(sha256sum "$bundle" | cut -d' ' -f1)
-          if [ -n "$EXPECTED_SHA" ] && [ "$actual" != "$EXPECTED_SHA" ]; then
-            echo "::error::the downloaded bundle's sha256 $actual is not the ledger's $EXPECTED_SHA (record by $HOLDER) — the bytes are not the ones the record attests. Not reusing."
-            exit 1
-          fi
-          echo "reused: $bundle (sha256 $actual) from run $ART_RUN — built and inspected there ($HOLDER); no compile, no pack, no inspection in this job"
-          echo "path=$bundle" >> "$GITHUB_OUTPUT"
-          {
-            echo "### \`$MODULE\` — **reused** from run $ART_RUN"
-            echo
-            echo "- record: $HOLDER"
-            echo "- sha256: \`$actual\`; source: $HOLDER"
-          } >> "$GITHUB_STEP_SUMMARY"
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where decision=reuse)
+          [ "${#modules[@]}" -gt 0 ] || echo "no module in this batch is reused from the ledger"
+          for MODULE in "${modules[@]}"; do
+            ART_RUN="$(bk get --module "$MODULE" art_run)"
+            ART_NAME="$(bk get --module "$MODULE" art_name)"
+            EXPECTED_SHA="$(bk get --module "$MODULE" sha)"
+            HOLDER="$(bk get --module "$MODULE" holder)"
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            set +e
+            ( set -euo pipefail
+              mkdir -p "$RUNNER_TEMP/bundles/$MODULE"
+              gh run download "$ART_RUN" -R "$GITHUB_REPOSITORY" -n "$ART_NAME" -D "$RUNNER_TEMP/bundles/$MODULE"
+              bundle="$RUNNER_TEMP/bundles/$MODULE/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
+              if [ ! -f "$bundle" ]; then
+                found=$(find "$RUNNER_TEMP/bundles/$MODULE" -name '*.module.nupkg' | head -1)
+                echo "::error::run $ART_RUN's artifact $ART_NAME carries no MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg (found: ${found:-nothing}) — the ledger record and this checkout's manifest.lock disagree about the version; the key should have differed. Not reusing."
+                exit 1
+              fi
+              actual=$(sha256sum "$bundle" | cut -d' ' -f1)
+              if [ -n "$EXPECTED_SHA" ] && [ "$actual" != "$EXPECTED_SHA" ]; then
+                echo "::error::the downloaded bundle's sha256 $actual is not the ledger's $EXPECTED_SHA (record by $HOLDER) — the bytes are not the ones the record attests. Not reusing."
+                exit 1
+              fi
+              echo "reused: $bundle (sha256 $actual) from run $ART_RUN — built and inspected there ($HOLDER); no compile, no pack, no inspection in this job"
+              bk set --module "$MODULE" "bundle=$bundle"
+              {
+                echo "### \`$MODULE\` — **reused** from run $ART_RUN"
+                echo
+                echo "- record: $HOLDER"
+                echo "- sha256: \`$actual\`; source: $HOLDER"
+              } >> "$GITHUB_STEP_SUMMARY"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the ledger's recorded bundle could not be fetched or is not the bytes the record attests (exit $rc; see above)"
+          done
 
       # Published ONCE by the prepare job — `dotnet build` here cost 48–79s in EVERY job (measured
       # across Plugins#1032). A missing artifact fails this download RED rather than quietly
       # rebuilding a maybe-different tool.
       - name: Fetch the module-pack tool (built once by prepare)
-        if: steps.plan.outputs.decision == 'build'
+        if: steps.plan.outputs.any_build == 'true'
         uses: actions/download-artifact@v8
         with:
           name: module-pack-tool-${{ needs.select.outputs.lane }}
@@ -2219,14 +2410,7 @@ jobs:
 
       - name: Pack the module bundle
         id: pack
-        if: steps.plan.outputs.decision == 'build'
         env:
-          PACKDIR: ${{ steps.build.outputs.packdir }}
-          COMPILER: ${{ steps.build.outputs.compiler }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
-          FLOOR: ${{ steps.identity.outputs.floor }}
           # 🚨 THE IDENTITY ANCHOR'S HOME — the SAME expression the build step uses, so the anchor
           # named below and the reference set the bytes were compiled against cannot be two
           # different things. When a platform image is pinned, `platform-refs` is a `docker cp` of
@@ -2240,252 +2424,386 @@ jobs:
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          # 🚨 The closure flags come from the COMPILER THAT RAN, written to a file by the step
-          # above rather than re-derived here — the SDK path derives the private closure from its
-          # own deps.json (--deps-closure), the container path names the module-owned siblings it
-          # emitted (--with). Re-deriving here would be a second opinion about what ships.
-          closure=()
-          while IFS= read -r flag; do closure+=("$flag"); done < "$RUNNER_TEMP/pack-args"
-          # ───────── WHAT THIS BUNDLE WAS BUILT AGAINST, STATED — never omitted (#3211) ─────────
-          # Measured on MeshWeaver.Plugins run 33773265959 (2026-09-03): all 34 bundles packed
-          # "built-against MVID (unrecorded)", sdk and container alike, so #3154's
-          # (version, identity) comparison shipped with nothing to compare on every installation in
-          # the fleet. The cause is WHERE the anchor is, and it moves with the platform:
-          #
-          #   * platform pinned as an IMAGE (`REFS` = the docker cp of its /app, which the sdk build
-          #     passes as MeshWeaverRefs and the container build compiles inside) — the anchor is in
-          #     there, and the module's own output deliberately carries no platform assembly. This
-          #     is every satellite call, and it is the case the packer's default probe cannot see.
-          #   * platform built from SOURCE (`REFS` empty — core's own main-cd call) — the platform
-          #     ProjectReferences are real, so the compiler CAN be built from them. It is built
-          #     below, deliberately, rather than read out of the module's publish output: publish
-          #     copies it only for a module whose reference graph happens to reach it, which two
-          #     of core's four compose entries do not (see the build step's comment).
-          #
-          # Both arms end in a RED with no anchor — neither is a quiet fallback, and the packer
-          # refuses again behind them (including a module-local anchor, refused by name), so a
-          # bundle whose identity is a guess cannot exist.
-          if [ -n "$REFS" ]; then
-            anchor="$REFS/MeshWeaver.Compiler.dll"
-            where="the pinned platform image's extracted /app"
-            if [ ! -f "$anchor" ]; then
-              echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in $where. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."
-              exit 1
-            fi
-            # The image's own compiler, stamped by the build that produced the image, so
-            # FrameworkIdentity.ReadIdentity returns its `g<sha>` — the same token a portal image
-            # reports. Reading it off the DLL is right HERE because the DLL is the platform.
-            identity=(--graph-dll "$anchor")
-          else
-            # 🚨 STATE the identity; never DERIVE it from a DLL this job built (#3308).
-            #
-            # The arm used to `dotnet build` MeshWeaver.Compiler per matrix job and read the MVID
-            # off the result. #3293 built it from the platform tree instead of scavenging it, and
-            # #3306 removed the `-p:Version` that polluted it — and the run STILL stated one
-            # identity per module. Measured on run 33950389008 (2026-09-05, four entries, one
-            # commit, every leg `plan: BUILD`):
-            #
-            #     MeshWeaver.Maps                     0051e7210e4144a6a18620a36e629d84  (1 compiler build)
-            #     MeshWeaver.Payments.Stripe          0051e7210e4144a6a18620a36e629d84  (1 compiler build)
-            #     MeshWeaver.Markdown.Collaboration   6553ea371eab49e4afdd0af20ea7ac59  (2 compiler builds)
-            #     MeshWeaver.AI                       395909c22d3042d4b23fb055337db63b  (2 compiler builds)
-            #
-            # The split is exactly the reference graph: MeshWeaver.AI and
-            # MeshWeaver.Markdown.Collaboration reach MeshWeaver.Compiler transitively, so the
-            # MODULE build compiles it FIRST, into this same output path, carrying the module's
-            # own global properties — and the anchor build that follows finds it up to date and
-            # keeps those bytes. Maps and Payments.Stripe never build it, so their anchor build
-            # compiles it clean and they agree. Removing `-p:Version` from the ANCHOR build could
-            # never fix that: the pollution comes from the module build UPSTREAM, which is
-            # entitled to its own version.
-            #
-            # 🚨 And a derived MVID could not be matched even if it were stable. A portal image is
-            # built with -p:CIRun=true, so AddCommitHashMetadata stamps
-            # AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>") and
-            # FrameworkIdentity.ReadIdentity PREFERS that stamp over the MVID. A consumer
-            # therefore reads `g<sha>` while a source-built bundle stated a 32-hex MVID: never
-            # equal, by construction, so #3154's (version, identity) comparison could never answer
-            # anything but "identity could not be checked".
-            #
-            # So: the platform IS this checkout, and a commit is exactly what the consumer reads.
-            # `--framework-mvid` is the packer's own flag for "the platform's own reading", and
-            # `g<sha>` is one of the three tokens it documents. One identity per platform commit,
-            # identical for every entry in the run, and no compiler build per matrix job at all.
-            # NOT `$(… 2>/dev/null || true)`: that swallows git's message AND its exit status, so a
-            # checkout without .git would reach the check below as a blank string with no trace of
-            # why. The `if !` keeps `set -e` from aborting before the explanation, while git's own
-            # stderr still lands in the log.
-            if ! sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD)"; then
-              echo "::error::cannot read the platform commit at \$GITHUB_WORKSPACE/meshweaver — git rev-parse HEAD failed and its message is above. No platform image is pinned, so the checkout IS the platform and its commit IS the identity every bundle of this run must state (#3308). Nothing here may guess it, so the pack stops."
-              exit 1
-            fi
-            if [ ${#sha} -ne 40 ] || [ -n "${sha//[0-9a-f]/}" ]; then
-              echo "::error::the platform commit at \$GITHUB_WORKSPACE/meshweaver read as '${sha}', which is not a 40-character hex sha. The bundle identity must name a commit a consumer can compare against (#3308), so the pack stops rather than stating something unmatchable."
-              exit 1
-            fi
-            identity=(--framework-mvid "g$sha")
-            where="the platform checkout's own commit (no platform image is pinned, so the platform was built from source)"
-            echo "framework identity for this run: g$sha (stated from the platform checkout, not derived per job)"
-          fi
-          echo "packing $MODULE from $PACKDIR (compiler: $COMPILER); closure flags: ${closure[*]:-<none>}"
-          dotnet "$RUNNER_TEMP/pack-tool/MeshWeaver.Plugin.Build.dll" \
-            module-pack "$PACKDIR" \
-            ${closure[@]+"${closure[@]}"} \
-            --module-name "$MODULE" \
-            --plugin "$PACKAGE" \
-            --package-version "$VERSION" \
-            --min-mesh-version "$FLOOR" \
-            "${identity[@]}" \
-            --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})" \
-            ${PLATFORM_APP:+--platform-app "$PLATFORM_APP"} \
-            --out "$RUNNER_TEMP/bundles"
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where decision=build)
+          [ "${#modules[@]}" -gt 0 ] || { echo "nothing to pack in this batch"; exit 0; }
+          own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
+          for MODULE in "${modules[@]}"; do
+            PACKDIR="$(bk get --module "$MODULE" packdir)"
+            COMPILER="$(bk get --module "$MODULE" compiler)"
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            FLOOR="$(bk get --module "$MODULE" floor)"
+            set +e
+            ( set -euo pipefail
+              # ───────── WHAT THESE BUNDLES WERE BUILT AGAINST, STATED — never omitted (#3211) ─────────
+              # Resolved per module, inside its own subshell (a file test or a `git rev-parse` — nothing
+              # worth sharing), so an absent anchor is THAT module's red, by name, exactly as before.
+              # Measured on MeshWeaver.Plugins run 33773265959 (2026-09-03): all 34 bundles packed
+              # "built-against MVID (unrecorded)", sdk and container alike, so #3154's
+              # (version, identity) comparison shipped with nothing to compare on every installation in
+              # the fleet. The cause is WHERE the anchor is, and it moves with the platform:
+              #
+              #   * platform pinned as an IMAGE (`REFS` = the docker cp of its /app, which the sdk build
+              #     passes as MeshWeaverRefs and the container build compiles inside) — the anchor is in
+              #     there, and the module's own output deliberately carries no platform assembly. This
+              #     is every satellite call, and it is the case the packer's default probe cannot see.
+              #   * platform built from SOURCE (`REFS` empty — core's own main-cd call) — the platform
+              #     ProjectReferences are real, so the compiler CAN be built from them. It is built
+              #     below, deliberately, rather than read out of the module's publish output: publish
+              #     copies it only for a module whose reference graph happens to reach it, which two
+              #     of core's four compose entries do not (see the build step's comment).
+              #
+              # Both arms end in a RED with no anchor — neither is a quiet fallback, and the packer
+              # refuses again behind them (including a module-local anchor, refused by name), so a
+              # bundle whose identity is a guess cannot exist.
+              if [ -n "$REFS" ]; then
+                anchor="$REFS/MeshWeaver.Compiler.dll"
+                where="the pinned platform image's extracted /app"
+                if [ ! -f "$anchor" ]; then
+                  echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in $where. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."
+                  exit 1
+                fi
+                # The image's own compiler, stamped by the build that produced the image, so
+                # FrameworkIdentity.ReadIdentity returns its `g<sha>` — the same token a portal image
+                # reports. Reading it off the DLL is right HERE because the DLL is the platform.
+                identity=(--graph-dll "$anchor")
+              else
+                # 🚨 STATE the identity; never DERIVE it from a DLL this job built (#3308).
+                #
+                # The arm used to `dotnet build` MeshWeaver.Compiler per matrix job and read the MVID
+                # off the result. #3293 built it from the platform tree instead of scavenging it, and
+                # #3306 removed the `-p:Version` that polluted it — and the run STILL stated one
+                # identity per module. Measured on run 33950389008 (2026-09-05, four entries, one
+                # commit, every leg `plan: BUILD`):
+                #
+                #     MeshWeaver.Maps                     0051e7210e4144a6a18620a36e629d84  (1 compiler build)
+                #     MeshWeaver.Payments.Stripe          0051e7210e4144a6a18620a36e629d84  (1 compiler build)
+                #     MeshWeaver.Markdown.Collaboration   6553ea371eab49e4afdd0af20ea7ac59  (2 compiler builds)
+                #     MeshWeaver.AI                       395909c22d3042d4b23fb055337db63b  (2 compiler builds)
+                #
+                # The split is exactly the reference graph: MeshWeaver.AI and
+                # MeshWeaver.Markdown.Collaboration reach MeshWeaver.Compiler transitively, so the
+                # MODULE build compiles it FIRST, into this same output path, carrying the module's
+                # own global properties — and the anchor build that follows finds it up to date and
+                # keeps those bytes. Maps and Payments.Stripe never build it, so their anchor build
+                # compiles it clean and they agree. Removing `-p:Version` from the ANCHOR build could
+                # never fix that: the pollution comes from the module build UPSTREAM, which is
+                # entitled to its own version.
+                #
+                # 🚨 And a derived MVID could not be matched even if it were stable. A portal image is
+                # built with -p:CIRun=true, so AddCommitHashMetadata stamps
+                # AssemblyMetadata("MeshWeaverFrameworkIdentity", "g<sha>") and
+                # FrameworkIdentity.ReadIdentity PREFERS that stamp over the MVID. A consumer
+                # therefore reads `g<sha>` while a source-built bundle stated a 32-hex MVID: never
+                # equal, by construction, so #3154's (version, identity) comparison could never answer
+                # anything but "identity could not be checked".
+                #
+                # So: the platform IS this checkout, and a commit is exactly what the consumer reads.
+                # `--framework-mvid` is the packer's own flag for "the platform's own reading", and
+                # `g<sha>` is one of the three tokens it documents. One identity per platform commit,
+                # identical for every entry in the run, and no compiler build per matrix job at all.
+                # NOT `$(… 2>/dev/null || true)`: that swallows git's message AND its exit status, so a
+                # checkout without .git would reach the check below as a blank string with no trace of
+                # why. The `if !` keeps `set -e` from aborting before the explanation, while git's own
+                # stderr still lands in the log.
+                if ! sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD)"; then
+                  echo "::error::cannot read the platform commit at \$GITHUB_WORKSPACE/meshweaver — git rev-parse HEAD failed and its message is above. No platform image is pinned, so the checkout IS the platform and its commit IS the identity every bundle of this run must state (#3308). Nothing here may guess it, so the pack stops."
+                  exit 1
+                fi
+                if [ ${#sha} -ne 40 ] || [ -n "${sha//[0-9a-f]/}" ]; then
+                  echo "::error::the platform commit at \$GITHUB_WORKSPACE/meshweaver read as '${sha}', which is not a 40-character hex sha. The bundle identity must name a commit a consumer can compare against (#3308), so the pack stops rather than stating something unmatchable."
+                  exit 1
+                fi
+                identity=(--framework-mvid "g$sha")
+                where="the platform checkout's own commit (no platform image is pinned, so the platform was built from source)"
+                echo "framework identity for this run: g$sha (stated from the platform checkout, not derived per job)"
+              fi
+              # 🚨 The closure flags come from the COMPILER THAT RAN, written to a file by the step
+              # above rather than re-derived here — the SDK path derives the private closure from its
+              # own deps.json (--deps-closure), the container path names the module-owned siblings it
+              # emitted (--with). Re-deriving here would be a second opinion about what ships.
+              closure=()
+              while IFS= read -r flag; do closure+=("$flag"); done < "$RUNNER_TEMP/mods/$MODULE/pack-args"
+              echo "packing $MODULE from $PACKDIR (compiler: $COMPILER; identity from $where); closure flags: ${closure[*]:-<none>}"
+              mkdir -p "$RUNNER_TEMP/bundles/$MODULE"
+              dotnet "$RUNNER_TEMP/pack-tool/MeshWeaver.Plugin.Build.dll" \
+                module-pack "$PACKDIR" \
+                ${closure[@]+"${closure[@]}"} \
+                --module-name "$MODULE" \
+                --plugin "$PACKAGE" \
+                --package-version "$VERSION" \
+                --min-mesh-version "$FLOOR" \
+                "${identity[@]}" \
+                --own-platform "$own" \
+                ${PLATFORM_APP:+--platform-app "$PLATFORM_APP"} \
+                --out "$RUNNER_TEMP/bundles/$MODULE"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the packer refused this module (exit $rc; see above)"
+          done
 
       # A bundle that PACKED is not yet a bundle that LANDS: assert the closure and the manifest a
       # consumer's landing gate will read, loudly, instead of trusting the packer's exit code.
       - name: Inspect the bundle (manifest + assemblies)
         id: bundle
-        if: steps.plan.outputs.decision == 'build'
         env:
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          # The staticAssets assertion reads the PROJECT's source tree (wwwroot/, *.razor.css) —
-          # measured missing on the first 31-entry acceptance run: every container inspection died
-          # `PROJECT: unbound variable` AFTER a GREEN build, because only the build step carried it.
-          PROJECT: ${{ matrix.entry.project }}
-          VERSION: ${{ steps.identity.outputs.version }}
-          FLOOR: ${{ steps.identity.outputs.floor }}
-          COMPILER: ${{ steps.build.outputs.compiler }}
-          PACKDIR: ${{ steps.build.outputs.packdir }}
           # The SAME witness the pack used, so this jq cannot disagree with it about what
           # "platform" means (MeshWeaver#3732).
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          bundle="$RUNNER_TEMP/bundles/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
-          test -f "$bundle" || { echo "::error::bundle not found: $bundle"; exit 1; }
-          unzip -o -q "$bundle" -d "$RUNNER_TEMP/inspect-$MODULE"
-          test -f "$RUNNER_TEMP/inspect-$MODULE/meshweaver/modules/$MODULE.dll" \
-            || { echo "::error::entry DLL missing from meshweaver/modules/"; exit 1; }
-          manifest="$RUNNER_TEMP/inspect-$MODULE/meshweaver/manifest.json"
-          jq -e --arg m "$MODULE" '.module.assemblyName == $m' "$manifest" > /dev/null \
-            || { echo "::error::manifest module.assemblyName is not $MODULE"; exit 1; }
-          jq -e --arg d "$MODULE.dll" '.module.assemblies | index($d) != null' "$manifest" > /dev/null \
-            || { echo "::error::manifest module.assemblies misses the entry DLL"; exit 1; }
-          jq -e --arg f "$FLOOR" '.module.minMeshVersion == $f' "$manifest" > /dev/null \
-            || { echo "::error::manifest floor differs from content.minMeshVersion"; exit 1; }
-          # 🚨 THE BUILT-AGAINST IDENTITY, ASSERTED ON THE BYTES — not inferred from the packer's
-          # exit code (#3211). The packer refuses to omit it, so this reads the artifact back and
-          # says so: a manifest with no `frameworkMvid` is a bundle whose consumers can never tell
-          # a rebuild against a new platform from a no-op (#3154's comparison with nothing to
-          # compare), and it must never leave this job.
-          jq -e '(.frameworkMvid // "") | test("^\\S+$")' "$manifest" > /dev/null \
-            || { echo "::error::the bundle states no framework identity (manifest .frameworkMvid is $(jq -c '.frameworkMvid' "$manifest")). It was built against SOMETHING; a bundle that cannot say what parks every consumer in 'up to date, identity could not be checked' forever (#3211). The pack step names the anchor — this manifest did not get it."; exit 1; }
-          echo "built against: $(jq -r '.frameworkMvid' "$manifest")"
-          # A module bundle must NEVER carry a PLATFORM assembly beside its entry — it would
-          # shadow the platform's own binary at the consumer (the same trap-door landing refuses
-          # for the entry DLL). MODULE-OWNED MeshWeaver.* assemblies (their source lives in THIS
-          # repo's src/, so they exist nowhere in /app — Import's DataSetReader family) are the
-          # deliberate exception: for them, NOT riding is the fault. The jq mirrors the pack's
-          # --own-platform set exactly, so the two cannot disagree about what "platform" means.
-          # …EXCEPT the projects the PLATFORM ships: they live in this repo's src/ yet also reach a
-          # portal through the image (the storage backends and transports that moved out with the
-          # hosts, and the modules the image seeds under /app/modules/<Name>/), so a bundle carrying
-          # one would land a same-identity duplicate beside the host's copy. ONE script computes the
-          # set for the pack AND for this check — and with $PLATFORM_APP it MEASURES that set off
-          # the pinned image rather than reading the repo's declared src/platform-shipped.txt, which
-          # went stale in both directions inside one week (MeshWeaver#3732, #3335).
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where decision=build)
+          [ "${#modules[@]}" -gt 0 ] || { echo "nothing to inspect in this batch"; exit 0; }
+          # ONE script computes the set for the pack AND for this check — and with $PLATFORM_APP it
+          # MEASURES that set off the pinned image rather than reading the repo's declared
+          # src/platform-shipped.txt, which went stale in both directions inside one week
+          # (MeshWeaver#3732, #3335). Once per batch: it is a property of the image, not the module.
           own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
-          jq -e --arg m "$MODULE" --arg own "$own" \
-            '($own | split(";")) as $owned
-             | [.module.assemblies[]
-                | select(startswith("MeshWeaver.")
-                    and (. != $m + ".dll") and (. != $m + ".pdb")
-                    and ((rtrimstr(".dll") | rtrimstr(".pdb")) as $n | $owned | index($n) | not))]
-             | length == 0' \
-            "$manifest" > /dev/null \
-            || { echo "::error::bundle carries platform (MeshWeaver.*) assemblies beside the module"; exit 1; }
-          # 🚨 The container path's closure claim, ASSERTED rather than asserted-in-prose. It packs
-          # no --deps-closure because there is no SDK deps.json to derive one from; what makes that
-          # sound is that build-project resolved every reference from the image's /app (it refuses
-          # by name any PackageReference the image does not supply, and this lane passes no
-          # --extra-refs). A NON-MeshWeaver assembly in such a bundle would contradict exactly that
-          # — it could only have come from somewhere this lane cannot account for — so it is a
-          # refusal, not a curiosity. The SDK path is untouched: its private closure legitimately
-          # carries package assemblies.
-          if [ "$COMPILER" = "container" ]; then
-            # A non-MeshWeaver assembly is allowed ONLY with builder provenance: the builder's
-            # module-libs.txt names every ride it derived from the image's and the shelf's
-            # deps.json. Anything else has no accountable closure and must fail — the
-            # 2026-08-19/20 outage shape.
-            # 🚨 FROM THE BUILD STEP'S OWN packdir output — never a hard-coded layout. The global
-            # workspace moved the pack input to workspace-build/<Module>; this path still reading
-            # module-build/ made the allow-list EMPTY and failed all 8 shelf-consuming modules on
-            # the first coherent global-build lap (33472830308) with perfectly correct manifests.
-            shelf_manifest="$PACKDIR/module-libs.txt"
-            allowed="$( [ -f "$shelf_manifest" ] && tr '\n' ';' < "$shelf_manifest" || true )"
-            jq -e --arg allowed "$allowed" \
-              '($allowed | split(";") | map(select(length > 0))) as $shelf
-               | [.module.assemblies[]
-                  | select(startswith("MeshWeaver.") | not)
-                  | select(. as $a | $shelf | index($a) | not)]
-               | length == 0' \
-              "$manifest" > /dev/null \
-              || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly with NO builder provenance (not in the builder's module-libs.txt) — its closure cannot be accounted for, so the pack fails rather than landing a module that faults at first use"; exit 1; }
-            echo "container path: closure is entry + module-owned MeshWeaver siblings + the manifested private closure, as recorded"
-            # 🚨 The STATIC-ASSET half, asserted — because its absence is the one failure with no
-            # symptom at any later gate: the publish 200s, the module lands and loads, every page
-            # renders, only UNSTYLED (#2221's exact signature; PluginBundlePublishAssetsTest names
-            # it). The packer nulls `staticAssets` when the pack input has no wwwroot, and nothing
-            # downstream distinguishes "this module ships no assets" from "the compiler forgot
-            # them" — so this lane distinguishes it HERE, from the source of truth: a project that
-            # has *.razor.css or wwwroot/ in its tree must produce a bundle that declares assets.
-            src_dir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")"
-            if [ -d "$src_dir/wwwroot" ] \
-               || find "$src_dir" -name '*.razor.css' -not -path '*/bin/*' -not -path '*/obj/*' -print -quit | grep -q .; then
-              jq -e '(.module.staticAssets // []) | length > 0' "$manifest" > /dev/null \
-                || { echo "::error::$MODULE has wwwroot/ or *.razor.css in its source tree, but the container-built bundle declares NO staticAssets — it would land, load, and render unstyled with nothing in any log (#2221). The builder must emit wwwroot/ (its .styles.css aggregate included) into the pack input."; exit 1; }
-              echo "container path: staticAssets declared ($(jq '(.module.staticAssets // []) | length' "$manifest") file(s)) for a source tree that has assets"
-            fi
-          fi
-          echo "path=$bundle" >> "$GITHUB_OUTPUT"
-          echo "bundle OK:"; jq . "$manifest"
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            # The staticAssets assertion reads the PROJECT's source tree (wwwroot/, *.razor.css) —
+            # measured missing on the first 31-entry acceptance run: every container inspection died
+            # `PROJECT: unbound variable` AFTER a GREEN build, because only the build step carried it.
+            PROJECT="$(bk get --module "$MODULE" project)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            FLOOR="$(bk get --module "$MODULE" floor)"
+            COMPILER="$(bk get --module "$MODULE" compiler)"
+            PACKDIR="$(bk get --module "$MODULE" packdir)"
+            set +e
+            ( set -euo pipefail
+              bundle="$RUNNER_TEMP/bundles/$MODULE/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
+              test -f "$bundle" || { echo "::error::bundle not found: $bundle"; exit 1; }
+              unzip -o -q "$bundle" -d "$RUNNER_TEMP/inspect-$MODULE"
+              test -f "$RUNNER_TEMP/inspect-$MODULE/meshweaver/modules/$MODULE.dll" \
+                || { echo "::error::entry DLL missing from meshweaver/modules/"; exit 1; }
+              manifest="$RUNNER_TEMP/inspect-$MODULE/meshweaver/manifest.json"
+              jq -e --arg m "$MODULE" '.module.assemblyName == $m' "$manifest" > /dev/null \
+                || { echo "::error::manifest module.assemblyName is not $MODULE"; exit 1; }
+              jq -e --arg d "$MODULE.dll" '.module.assemblies | index($d) != null' "$manifest" > /dev/null \
+                || { echo "::error::manifest module.assemblies misses the entry DLL"; exit 1; }
+              jq -e --arg f "$FLOOR" '.module.minMeshVersion == $f' "$manifest" > /dev/null \
+                || { echo "::error::manifest floor differs from content.minMeshVersion"; exit 1; }
+              # 🚨 THE BUILT-AGAINST IDENTITY, ASSERTED ON THE BYTES — not inferred from the packer's
+              # exit code (#3211). The packer refuses to omit it, so this reads the artifact back and
+              # says so: a manifest with no `frameworkMvid` is a bundle whose consumers can never tell
+              # a rebuild against a new platform from a no-op (#3154's comparison with nothing to
+              # compare), and it must never leave this job.
+              jq -e '(.frameworkMvid // "") | test("^\\S+$")' "$manifest" > /dev/null \
+                || { echo "::error::the bundle states no framework identity (manifest .frameworkMvid is $(jq -c '.frameworkMvid' "$manifest")). It was built against SOMETHING; a bundle that cannot say what parks every consumer in 'up to date, identity could not be checked' forever (#3211). The pack step names the anchor — this manifest did not get it."; exit 1; }
+              echo "built against: $(jq -r '.frameworkMvid' "$manifest")"
+              # A module bundle must NEVER carry a PLATFORM assembly beside its entry — it would
+              # shadow the platform's own binary at the consumer (the same trap-door landing refuses
+              # for the entry DLL). MODULE-OWNED MeshWeaver.* assemblies (their source lives in THIS
+              # repo's src/, so they exist nowhere in /app — Import's DataSetReader family) are the
+              # deliberate exception: for them, NOT riding is the fault. The jq mirrors the pack's
+              # --own-platform set exactly, so the two cannot disagree about what "platform" means.
+              # …EXCEPT the projects the PLATFORM ships: they live in this repo's src/ yet also reach a
+              # portal through the image (the storage backends and transports that moved out with the
+              # hosts, and the modules the image seeds under /app/modules/<Name>/), so a bundle carrying
+              # one would land a same-identity duplicate beside the host's copy.
+              jq -e --arg m "$MODULE" --arg own "$own" \
+                '($own | split(";")) as $owned
+                 | [.module.assemblies[]
+                    | select(startswith("MeshWeaver.")
+                        and (. != $m + ".dll") and (. != $m + ".pdb")
+                        and ((rtrimstr(".dll") | rtrimstr(".pdb")) as $n | $owned | index($n) | not))]
+                 | length == 0' \
+                "$manifest" > /dev/null \
+                || { echo "::error::bundle carries platform (MeshWeaver.*) assemblies beside the module"; exit 1; }
+              # 🚨 The container path's closure claim, ASSERTED rather than asserted-in-prose. It packs
+              # no --deps-closure because there is no SDK deps.json to derive one from; what makes that
+              # sound is that build-project resolved every reference from the image's /app (it refuses
+              # by name any PackageReference the image does not supply, and this lane passes no
+              # --extra-refs). A NON-MeshWeaver assembly in such a bundle would contradict exactly that
+              # — it could only have come from somewhere this lane cannot account for — so it is a
+              # refusal, not a curiosity. The SDK path is untouched: its private closure legitimately
+              # carries package assemblies.
+              if [ "$COMPILER" = "container" ]; then
+                # A non-MeshWeaver assembly is allowed ONLY with builder provenance: the builder's
+                # module-libs.txt names every ride it derived from the image's and the shelf's
+                # deps.json. Anything else has no accountable closure and must fail — the
+                # 2026-08-19/20 outage shape.
+                # 🚨 FROM THE BUILD STEP'S OWN packdir fact — never a hard-coded layout. The global
+                # workspace moved the pack input to workspace-build/<Module>; this path still reading
+                # module-build/ made the allow-list EMPTY and failed all 8 shelf-consuming modules on
+                # the first coherent global-build lap (33472830308) with perfectly correct manifests.
+                shelf_manifest="$PACKDIR/module-libs.txt"
+                allowed="$( [ -f "$shelf_manifest" ] && tr '\n' ';' < "$shelf_manifest" || true )"
+                jq -e --arg allowed "$allowed" \
+                  '($allowed | split(";") | map(select(length > 0))) as $shelf
+                   | [.module.assemblies[]
+                      | select(startswith("MeshWeaver.") | not)
+                      | select(. as $a | $shelf | index($a) | not)]
+                   | length == 0' \
+                  "$manifest" > /dev/null \
+                  || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly with NO builder provenance (not in the builder's module-libs.txt) — its closure cannot be accounted for, so the pack fails rather than landing a module that faults at first use"; exit 1; }
+                echo "container path: closure is entry + module-owned MeshWeaver siblings + the manifested private closure, as recorded"
+                # 🚨 The STATIC-ASSET half, asserted — because its absence is the one failure with no
+                # symptom at any later gate: the publish 200s, the module lands and loads, every page
+                # renders, only UNSTYLED (#2221's exact signature; PluginBundlePublishAssetsTest names
+                # it). The packer nulls `staticAssets` when the pack input has no wwwroot, and nothing
+                # downstream distinguishes "this module ships no assets" from "the compiler forgot
+                # them" — so this lane distinguishes it HERE, from the source of truth: a project that
+                # has *.razor.css or wwwroot/ in its tree must produce a bundle that declares assets.
+                src_dir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")"
+                if [ -d "$src_dir/wwwroot" ] \
+                   || find "$src_dir" -name '*.razor.css' -not -path '*/bin/*' -not -path '*/obj/*' -print -quit | grep -q .; then
+                  jq -e '(.module.staticAssets // []) | length > 0' "$manifest" > /dev/null \
+                    || { echo "::error::$MODULE has wwwroot/ or *.razor.css in its source tree, but the container-built bundle declares NO staticAssets — it would land, load, and render unstyled with nothing in any log (#2221). The builder must emit wwwroot/ (its .styles.css aggregate included) into the pack input."; exit 1; }
+                  echo "container path: staticAssets declared ($(jq '(.module.staticAssets // []) | length' "$manifest") file(s)) for a source tree that has assets"
+                fi
+              fi
+              bk set --module "$MODULE" "bundle=$bundle"
+              echo "bundle OK ($MODULE):"; jq . "$manifest"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the packed bundle failed inspection (exit $rc; see above)"
+          done
+
+      # ───────── THE BUNDLE PATHS — one expression, read by every step that hands bytes over ─────────
+      # `paths` is a JSON map module → the bundle this leg produced for it, whichever leg produced
+      # it (the build leg's packed bundle, or the artifact the reuse leg downloaded and
+      # sha256-verified). The hand-over, the staging and the receipt all read THIS output, so they
+      # cannot disagree about which bytes a module's publication is. The slots `s1..s10` feed the
+      # unrolled bundle uploads below: the modules still in play that carry a bundle, in batch
+      # order; `slots` refuses a leg with more modules than slots (the chunker caps it lower).
+      - name: The bundle paths, and the upload slots
+        id: bundles
+        run: |
+          set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          echo "paths=$(bk paths bundle)" >> "$GITHUB_OUTPUT"
+          bk slots --max 10 --where 'bundle!=' --github-output "$GITHUB_OUTPUT"
 
       # 7 days, not 3: this artifact is what a LATER run downloads when the ledger says the key is
       # already built — the reuse window is exactly its retention (the ledger records the expiry).
-      - name: Upload the bundle artifact
+      # 🚨 TEN LITERAL SLOTS, one per module of the batch: `module-bundle-<module>` is a per-module
+      # NAME the ledger records and every caller's `module-artifacts` pattern globs, and an upload
+      # step carries one name. A slot's `if:` is a mode switch on this leg's own bookkeeping (a
+      # module that failed before its bundle existed has no slot), never on an input or a secret;
+      # `verify` still accounts that module by its missing receipt.
+      - name: Upload the bundle artifact (slot 1)
+        if: steps.bundles.outputs.s1 != ''
         uses: actions/upload-artifact@v7
         with:
-          name: module-bundle-${{ matrix.entry.module }}
-          path: ${{ runner.temp }}/bundles/*.module.nupkg
+          name: module-bundle-${{ steps.bundles.outputs.s1 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s1 }}/*.module.nupkg
           retention-days: 7
           if-no-files-found: error
-      # AFTER the upload, never before: `Built` means "a later run can fetch this bundle", and the
-      # record names the artifact the upload above just created. Carries the PLATFORM's identity as
-      # `prepare` resolved it (#931's producer half: the record says which framework these bytes are for).
+      - name: Upload the bundle artifact (slot 2)
+        if: steps.bundles.outputs.s2 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s2 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s2 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 3)
+        if: steps.bundles.outputs.s3 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s3 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s3 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 4)
+        if: steps.bundles.outputs.s4 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s4 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s4 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 5)
+        if: steps.bundles.outputs.s5 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s5 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s5 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 6)
+        if: steps.bundles.outputs.s6 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s6 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s6 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 7)
+        if: steps.bundles.outputs.s7 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s7 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s7 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 8)
+        if: steps.bundles.outputs.s8 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s8 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s8 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 9)
+        if: steps.bundles.outputs.s9 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s9 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s9 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      - name: Upload the bundle artifact (slot 10)
+        if: steps.bundles.outputs.s10 != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-bundle-${{ steps.bundles.outputs.s10 }}
+          path: ${{ runner.temp }}/bundles/${{ steps.bundles.outputs.s10 }}/*.module.nupkg
+          retention-days: 7
+          if-no-files-found: error
+      # AFTER the uploads, never before: `Built` means "a later run can fetch this bundle", and the
+      # record names the artifact the slot above just created — the uploads carry no
+      # continue-on-error, so reaching this step means every slot that fired succeeded. Carries the
+      # PLATFORM's identity as `prepare` resolved it (#931's producer half: the record says which
+      # framework these bytes are for).
       - name: Ledger — Built
-        if: inputs.ledger == 'required' && steps.plan.outputs.decision == 'build' && steps.plan.outputs.key != ''
+        if: inputs.ledger == 'required'
         env:
-          KEY: ${{ steps.plan.outputs.key }}
-          BUNDLE: ${{ steps.bundle.outputs.path }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
           PLATFORM_IDENTITY: ${{ needs.prepare.outputs.platform-identity }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Built \
-            --bundle "$BUNDLE" --artifact-name "module-bundle-$MODULE" --retention-days 7 \
-            --version "$VERSION" ${PLATFORM_IDENTITY:+--platform-identity "$PLATFORM_IDENTITY"}
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where decision=build --where 'key!=' --where 'bundle!=')
+          for MODULE in "${modules[@]}"; do
+            KEY="$(bk get --module "$MODULE" key)"
+            BUNDLE="$(bk get --module "$MODULE" bundle)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            set +e
+            ( set -euo pipefail
+              python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Built \
+                --bundle "$BUNDLE" --artifact-name "module-bundle-$MODULE" --retention-days 7 \
+                --version "$VERSION" ${PLATFORM_IDENTITY:+--platform-identity "$PLATFORM_IDENTITY"}
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase pack --reason "the ledger refused the Built record (exit $rc; see above)"
+          done
 
       # ───────── THE BUILT MARKER — "this bundle exists AND is composable", from THIS lane ─────────
       # Dropped the moment the bundle artifact is up, BEFORE the tests and the hand-over, so a
       # caller whose gates only COMPOSE this bundle can depend on the workflow's `bundles-built`
       # output instead of this job's result: a red suite here must not read as "bundle missing"
       # there (#2710, Plugins#937). That intent is unchanged — NOTHING about the test run reaches
-      # this marker. The receipt further down stays LAST — it still means the whole leg, tests and
-      # publish included, got here.
+      # this marker. The receipt further down stays per module — it still means the whole leg,
+      # tests and publish included, got there for THAT module.
       #
       # 🚨 WHAT THE MARKER ASSERTS IS NOW WRITTEN DOWN, not inferred from where the step sits.
       # `bundles-built` is the claim a REQUIRED gate composes bundles on, so it must mean "the set
@@ -2499,134 +2817,177 @@ jobs:
       # 🚨 And it carries its LANE. Artifacts are run-wide, so a repo calling this workflow twice
       # (Plugins: floor + rest) puts both calls' evidence in one namespace. The names below are
       # lane-scoped AND the stamp inside is checked, so even a name collision cannot donate one
-      # call's marker to the other's answer (Plugins#1077).
+      # call's marker to the other's answer (Plugins#1077). ONE artifact per batch, one file per
+      # module: the verifier globs `module-built-<lane>-*` with merge-multiple and keys on the
+      # `module` inside each file.
       - name: Drop the built marker
+        id: marker
         env:
           LANE: ${{ needs.select.outputs.lane }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
-          # A reused leg has no compiler of its own: the marker says so, and names the run that did.
-          COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
-          CLOSURE: ${{ steps.plan.outputs.decision == 'reuse' && format('reused from run {0} ({1}, published artifact provenance verified)', steps.plan.outputs.art_run, steps.plan.outputs.art_name) || steps.build.outputs.closure }}
-          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/built"
-          [ -n "$LANE" ]    || { echo "::error::the lane key is empty — the select job did not produce one, so this marker could not be attributed to this call and the verifier would refuse it anyway. Failing here, where it is readable."; exit 1; }
-          [ -n "$CLOSURE" ] || { echo "::error::the build step recorded no closure evidence for $MODULE — the bundle may exist but nothing says it is composable, which is exactly the claim \`bundles-built\` makes. Failing rather than dropping a marker that overstates."; exit 1; }
-          [ -n "$BUNDLE" ]  || { echo "::error::no bundle path from the pack step for $MODULE — there is nothing for this marker to attest."; exit 1; }
-          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
-                --arg v "$VERSION" --arg c "$COMPILER" \
-                --arg cl "$CLOSURE" --arg b "$(basename "$BUNDLE")" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, closure:$cl, bundle:$b}' \
-             > "$RUNNER_TEMP/built/$MODULE.json"
-          cat "$RUNNER_TEMP/built/$MODULE.json"
-      - name: Upload the built marker
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no marker of this leg could be attributed to this call and the verifier would refuse it anyway. Failing here, where it is readable."; exit 1; }
+          any=false
+          mapfile -t modules < <(bk list --ok --where 'bundle!=')
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            BUNDLE="$(bk get --module "$MODULE" bundle)"
+            # A reused module has no compiler of its own: the marker says so, and names the run that did.
+            if [ "$(bk get --module "$MODULE" decision)" = reuse ]; then
+              COMPILER=reused
+              CLOSURE="reused from run $(bk get --module "$MODULE" art_run) ($(bk get --module "$MODULE" art_name), published artifact provenance verified)"
+            else
+              COMPILER="$(bk get --module "$MODULE" compiler)"
+              CLOSURE="$(bk get --module "$MODULE" closure)"
+            fi
+            set +e
+            ( set -euo pipefail
+              [ -n "$CLOSURE" ] || { echo "::error::the build step recorded no closure evidence for $MODULE — the bundle may exist but nothing says it is composable, which is exactly the claim \`bundles-built\` makes. Failing rather than dropping a marker that overstates."; exit 1; }
+              jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
+                    --arg v "$VERSION" --arg c "$COMPILER" \
+                    --arg cl "$CLOSURE" --arg b "$(basename "$BUNDLE")" \
+                 '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, closure:$cl, bundle:$b}' \
+                 > "$RUNNER_TEMP/built/$MODULE.json"
+              cat "$RUNNER_TEMP/built/$MODULE.json"
+            )
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then any=true; else bk fail --module "$MODULE" --phase pack --reason "no built marker could be written (exit $rc; see above)"; fi
+          done
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+      - name: Upload the built markers
+        if: steps.marker.outputs.any == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: module-built-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
+          name: module-built-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}
           path: ${{ runner.temp }}/built/*.json
           retention-days: 1
           if-no-files-found: error
 
-      # ═══════ THE SUITE, INLINE — ON A PUBLISHING RUN ONLY (see the `tests` job below) ═══════
+      # ═══════ THE SUITES, INLINE — ON A PUBLISHING RUN ONLY (see the `tests` job below) ═══════
       # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
       # because the caller's gates compose it — carries test=false from the selection, and its
       # suite is skipped rather than answering a question nobody asked. The AI engine's suite
       # (~13 min, 1,600 tests) ran on every PR that never touched AI until 2026-08-29.
       # `need_test`: the entry's own `test` flag AND, with the ledger on, "no earlier run recorded a
-      # verdict for this key" — a reused Tested/Published bundle is not re-tested.
+      # verdict for this key" — a reused Tested/Published bundle is not re-tested. The step's `if:`
+      # reads the batch-wide switch; each module's own `need_test` fact decides again inside.
       #
       # 🚨 AND ONLY WHEN THIS CALL PUBLISHES. Inline, the suite sits AFTER the bundle upload and
       # BEFORE the hand-over, and the property that buys is exactly one: *a failing suite never
-      # publishes*. That property is worth its cost on a trunk/release-follow run, where the step
-      # below POSTs these bytes to the registry and every installation then reads them. It buys
-      # NOTHING on a run with `publish: false` — the hand-over step's own `if:` cannot fire there,
-      # so there is nothing for the ordering to protect, and the ordering instead costs every
-      # consumer of this call the whole suite: a `needs:` on a `uses:` job waits for the WHOLE
-      # called workflow, so MeshWeaver.Plugins' two required gates, which consume only the bundle
-      # ARTIFACT, waited 12.7 minutes for a MeshWeaver.AI suite they never read (run 33656010754:
-      # the bundle was ready 0.2 min into a 13.4-minute job; the gates started at 32.8 min).
+      # publishes* — PER MODULE: a module whose suite fails here is marked failed and the hand-over
+      # below skips it, while its siblings' suites and hand-overs proceed. That property is worth
+      # its cost on a trunk/release-follow run, where the step below POSTs these bytes to the
+      # registry and every installation then reads them. It buys NOTHING on a run with
+      # `publish: false` — the hand-over step's own `if:` cannot fire there, so there is nothing
+      # for the ordering to protect, and the ordering instead costs every consumer of this call the
+      # whole suite: a `needs:` on a `uses:` job waits for the WHOLE called workflow, so
+      # MeshWeaver.Plugins' two required gates, which consume only the bundle ARTIFACT, waited 12.7
+      # minutes for a MeshWeaver.AI suite they never read (run 33656010754: the bundle was ready
+      # 0.2 min into a 13.4-minute job; the gates started at 32.8 min).
       #
       # So on a non-publishing run the suite moves to the `tests` job below and runs in PARALLEL
       # with prepare → build-workspace → pack instead of after them. The two are mutually
       # exclusive by construction (`inputs.publish` here, `!inputs.publish` there), the leg
-      # RECORDS which of them owned its suite in the receipt, and `verify` refuses a run where
-      # the two disagree — a suite may not silently belong to neither.
+      # RECORDS which of them owned each module's suite in its receipt, and `verify` refuses a
+      # run where the two disagree — a suite may not silently belong to neither.
+      #
+      # 🚨 THE TRAIL A FLAKE LEAVES is captured PER MODULE, right after ITS suite fails — the phase
+      # trace and the dump directory are process-wide files that the next module's suite would
+      # overwrite, so they are copied under test-evidence/<module>/ and cleared before the loop
+      # moves on. A red here on a diff that cannot reach the module is a timing failure of the
+      # mesh under the runner's load, and the failure block alone cannot say where the flow
+      # stopped (seven distinct AI.Test failures, one sentence each — MeshWeaver.Plugins#941):
+      #   • per-test file logs (MESHWEAVER_TEST_FILE_LOGS — Warning level, one file per test);
+      #   • the MonolithMeshTestBase phase trace (/tmp/meshweaver-test-trace.log: INIT/TEST/
+      #     DISPOSE phases per class, pid-tagged — a crash's last lines name the class);
+      #   • the teardown-straggler captures (written beside the test assembly);
+      #   • a mini dump when the host dies on a signal (exit 139 = SIGSEGV = use-after-unload).
+      # None of it changes timing: the file logs are the same records the console gets, and
+      # the dump is written only by a crash.
       - name: Run the module's tests, when it ships any
         id: tests
-        if: ${{ inputs.publish && matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}
+        if: ${{ inputs.publish && steps.plan.outputs.need_test == 'true' }}
         env:
-          PROJECT: ${{ matrix.entry.project }}
-          # 🚨 THE TRAIL A FLAKE LEAVES. A red here on a diff that cannot reach the module is a
-          # timing failure of the mesh under the runner's load, and the failure block alone cannot
-          # say where the flow stopped (seven distinct AI.Test failures, one sentence each —
-          # MeshWeaver.Plugins#941). So the run WRITES the evidence and the step below keeps it:
-          #   • per-test file logs (MESHWEAVER_TEST_FILE_LOGS — Warning level, one file per test);
-          #   • the MonolithMeshTestBase phase trace (/tmp/meshweaver-test-trace.log: INIT/TEST/
-          #     DISPOSE phases per class, pid-tagged — a crash's last lines name the class);
-          #   • the teardown-straggler captures (written beside the test assembly);
-          #   • a mini dump when the host dies on a signal (exit 139 = SIGSEGV = use-after-unload).
-          # None of it changes timing: the file logs are the same records the console gets, and
-          # the dump is written only by a crash.
           MESHWEAVER_TEST_FILE_LOGS: "1"
           DOTNET_DbgEnableMiniDump: "1"
           DOTNET_DbgMiniDumpType: "2"
           DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
         run: |
           set -euo pipefail
-          mkdir -p /tmp/coredumps
-          # A module's tests relocate WITH it (the Approvals precedent). Conventional sibling:
-          # src/<Module>.Test. Absent is fine; present and red is not.
-          tests="$(dirname "$PROJECT").Test"
-          if [ -d "$tests" ]; then
-            # The trx is the ledger's evidence: counts, and the FAILED names a follower is handed.
-            dotnet test "$tests" -c Release -warnaserror \
-              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
-              --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx"
-          else
-            echo "no test project at $tests — nothing to run"
-          fi
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          evidence=false
+          mapfile -t modules < <(bk list --ok --where need_test=true)
+          for MODULE in "${modules[@]}"; do
+            PROJECT="$(bk get --module "$MODULE" project)"
+            mkdir -p /tmp/coredumps
+            rm -f /tmp/meshweaver-test-trace.log /tmp/meshweaver-msg-trace.log /tmp/coredumps/*.dmp
+            set +e
+            ( set -euo pipefail
+              # A module's tests relocate WITH it (the Approvals precedent). Conventional sibling:
+              # src/<Module>.Test. Absent is fine; present and red is not.
+              tests="$(dirname "$PROJECT").Test"
+              if [ -d "$tests" ]; then
+                # The trx is the ledger's evidence: counts, and the FAILED names a follower is handed.
+                dotnet test "$tests" -c Release -warnaserror \
+                  -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
+                  --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx/$MODULE"
+              else
+                echo "no test project at $tests — nothing to run"
+              fi
+            )
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              bk set --module "$MODULE" tested=true
+            else
+              bk fail --module "$MODULE" --phase test --reason "the module's own suite failed (exit $rc; its evidence is under test-evidence/$MODULE)"
+              # Keep the failing suite's evidence — only what a diagnosis needs, only for this module.
+              tests="$(dirname "$PROJECT").Test"
+              out="$RUNNER_TEMP/test-evidence/$MODULE"; mkdir -p "$out"
+              find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
+                cp "$f" "$out/" || true
+              done
+              [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
+              [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
+              if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
+                # The runtime writes a dump 0600; make it readable for the upload.
+                sudo chmod a+r /tmp/coredumps/*.dmp || true
+                cp /tmp/coredumps/*.dmp "$out/" || true
+                dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
+              fi
+              echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s) of evidence for $MODULE:"; ls -la "$out" | head -40
+              evidence=true
+            fi
+          done
+          echo "evidence=$evidence" >> "$GITHUB_OUTPUT"
       - name: Ledger — Tested
-        if: inputs.ledger == 'required' && steps.plan.outputs.key != '' && steps.tests.outcome == 'success'
+        if: inputs.ledger == 'required' && steps.tests.outcome == 'success'
         env:
-          KEY: ${{ steps.plan.outputs.key }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/ledger.trx"
-
-      # 🚨 Only on FAILURE, and only what a diagnosis needs: the failing suite's per-test logs, the
-      # phase trace, the straggler captures and any dump. A green run uploads nothing — the point
-      # is that the ONE red run in five leaves something to read instead of a re-run button.
-      - name: Keep the failing suite's evidence
-        if: ${{ failure() && inputs.publish && matrix.entry.test != false }}
-        env:
-          PROJECT: ${{ matrix.entry.project }}
-        run: |
-          set -uo pipefail
-          tests="$(dirname "$PROJECT").Test"
-          out="$RUNNER_TEMP/test-evidence"; mkdir -p "$out"
-          find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
-            cp "$f" "$out/" || true
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where tested=true --where 'key!=')
+          for MODULE in "${modules[@]}"; do
+            KEY="$(bk get --module "$MODULE" key)"
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
+              || bk fail --module "$MODULE" --phase test --reason "the ledger refused the Tested record (see above)"
           done
-          [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
-          [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
-          if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
-            # The runtime writes a dump 0600; make it readable for the upload.
-            sudo chmod a+r /tmp/coredumps/*.dmp || true
-            cp /tmp/coredumps/*.dmp "$out/" || true
-            dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
-          fi
-          echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s):"; ls -la "$out" | head -40
-      - name: Upload the failing suite's evidence
-        if: ${{ failure() && inputs.publish && matrix.entry.test != false }}
+
+      # 🚨 Only what a diagnosis needs, only for the modules whose suite failed (captured in the
+      # step above, per module). A green batch uploads nothing — the point is that the ONE red run
+      # in five leaves something to read instead of a re-run button.
+      - name: Upload the failing suites' evidence
+        if: ${{ inputs.publish && steps.tests.outputs.evidence == 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-evidence-${{ matrix.entry.module }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: test-evidence-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/test-evidence
           if-no-files-found: ignore
           retention-days: 14
@@ -2636,49 +2997,60 @@ jobs:
       # A caller that never cancels its trunk runs can have two of them build this module at once,
       # finishing in either order — and the registry keeps whatever arrives LAST. So right before the
       # hand-over the leg fetches the trunk tip and asks the SAME scope script the selection uses
-      # whether any newer commit reaches this module's dependency network. If one does, this leg does
-      # not publish: that commit's own run (never cancelled) builds the module from a tree containing
-      # this one. Every uncertainty in the scope script answers FULL — "reached" — which stands this
-      # leg down; that is safe because the newer run takes the same fallback and builds the module.
-      # A trunk that cannot be read is RED: "cannot tell" must never publish as "nothing newer".
+      # whether any newer commit reaches each module's dependency network. If one does, that module
+      # is not published: that commit's own run (never cancelled) builds the module from a tree
+      # containing this one. Every uncertainty in the scope script answers FULL — "reached" — which
+      # stands the module down; that is safe because the newer run takes the same fallback and
+      # builds the module. A trunk that cannot be read is RED for the whole batch: "cannot tell"
+      # must never publish as "nothing newer".
       - name: A newer trunk commit reaches this module? (publish-newest-only)
         id: newer
         if: ${{ inputs.publish && inputs.publish-newest-only && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' }}
         env:
           CONTENT_REPOSITORY: ${{ inputs.content-repository }}
           TRUNK: ${{ github.event.repository.default_branch }}
-          ENTRY: ${{ toJSON(matrix.entry) }}
-          MODULE: ${{ matrix.entry.module }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           [ -z "$CONTENT_REPOSITORY" ] || { echo "::error::publish-newest-only reads THIS repository's trunk, but content-repository is '$CONTENT_REPOSITORY' — a lane packing another repository's content cannot say whether a newer commit of it exists. Turn one of the two off."; exit 1; }
           [ -n "$TRUNK" ] || { echo "::error::the event carries no default branch, so the trunk tip cannot be read — and 'cannot tell' must never publish as 'nothing newer'."; exit 1; }
           git fetch --no-tags --depth=1 origin "+refs/heads/$TRUNK:refs/remotes/origin/$TRUNK"
           mine=$(git rev-parse HEAD)
           tip=$(git rev-parse "refs/remotes/origin/$TRUNK")
-          newer=false
-          if [ "$tip" = "$mine" ]; then
-            echo "this run's commit $mine IS the trunk tip — nothing newer; publishing $MODULE"
-          else
+          changed=""
+          if [ "$tip" != "$mine" ]; then
             # Two trees, no history needed: both commits are present in this shallow clone.
             changed=$(git diff --no-renames --name-only "$mine" "$tip" | paste -sd, -)
-            if [ -z "$changed" ]; then
-              echo "the trunk moved to $tip, but its tree equals this run's — nothing newer reaches $MODULE; publishing"
-            else
-              jq -n --argjson e "$ENTRY" '[$e]' > "$RUNNER_TEMP/newer-entry.json"
-              GITHUB_OUTPUT="$RUNNER_TEMP/newer-scope.out" GITHUB_STEP_SUMMARY=/dev/null \
-                python3 meshweaver/.github/scripts/node-repo-scope.py --for modules --root . \
-                  --modules "@$RUNNER_TEMP/newer-entry.json" --event pull_request \
-                  --changed-list "$changed" > "$RUNNER_TEMP/newer-scope.json"
-              if [ "$(jq -r '.count' "$RUNNER_TEMP/newer-scope.json")" != "0" ]; then
-                newer=true
-                echo "::notice title=Stood down for a newer commit::$MODULE is NOT published from $mine — trunk tip $tip reaches its dependency network ($(jq -r '.reason' "$RUNNER_TEMP/newer-scope.json")), and that commit's own run publishes it."
-              else
-                echo "the trunk moved to $tip, but nothing it changed reaches $MODULE's dependency network — publishing"
-              fi
-            fi
           fi
-          { echo "newer=$newer"; echo "tip=$tip"; } >> "$GITHUB_OUTPUT"
+          mapfile -t modules < <(bk list --ok --where need_publish=true)
+          for MODULE in "${modules[@]}"; do
+            set +e
+            ( set -euo pipefail
+              newer=false
+              if [ "$tip" = "$mine" ]; then
+                echo "this run's commit $mine IS the trunk tip — nothing newer; publishing $MODULE"
+              elif [ -z "$changed" ]; then
+                echo "the trunk moved to $tip, but its tree equals this run's — nothing newer reaches $MODULE; publishing"
+              else
+                mkdir -p "$RUNNER_TEMP/mods/$MODULE"
+                bk get --module "$MODULE" entry --default '{}' | jq '[.]' > "$RUNNER_TEMP/mods/$MODULE/newer-entry.json"
+                GITHUB_OUTPUT="$RUNNER_TEMP/mods/$MODULE/newer-scope.out" GITHUB_STEP_SUMMARY=/dev/null \
+                  python3 meshweaver/.github/scripts/node-repo-scope.py --for modules --root . \
+                    --modules "@$RUNNER_TEMP/mods/$MODULE/newer-entry.json" --event pull_request \
+                    --changed-list "$changed" > "$RUNNER_TEMP/mods/$MODULE/newer-scope.json"
+                if [ "$(jq -r '.count' "$RUNNER_TEMP/mods/$MODULE/newer-scope.json")" != "0" ]; then
+                  newer=true
+                  echo "::notice title=Stood down for a newer commit::$MODULE is NOT published from $mine — trunk tip $tip reaches its dependency network ($(jq -r '.reason' "$RUNNER_TEMP/mods/$MODULE/newer-scope.json")), and that commit's own run publishes it."
+                else
+                  echo "the trunk moved to $tip, but nothing it changed reaches $MODULE's dependency network — publishing"
+                fi
+              fi
+              bk set --module "$MODULE" "newer=$newer" "tip=$tip"
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase publish --reason "could not decide whether a newer trunk commit reaches this module (exit $rc; see above) — 'cannot tell' never publishes"
+          done
 
       # 🚨 The hand-over. Without it a module that has LEFT the platform repo is packed, versioned,
       # inspected — and reaches nobody, because a registry serves only bytes it holds. A missing
@@ -2687,6 +3059,9 @@ jobs:
       # `need_publish`: the caller's `publish` AND, with the ledger on, "no earlier run published this
       # key" — a key the registry already serves at these bytes is not re-handed (Plugins#889: a push
       # publishes every module whose key has no Published record, and only those).
+      #
+      # 🚨 PER MODULE, AFTER ITS OWN SUITE: a module whose suite failed above is no longer in play
+      # and is not POSTed; its siblings are. The batch shares a runner, never a verdict.
       #
       # 🚨 `publish-mode: direct` ONLY. This is the hand-over MeshWeaver#3878 moves: it fires while
       # the run's sibling suites, the portal-host shards, the NodeType compile-check and the
@@ -2698,67 +3073,87 @@ jobs:
       # produce quietly.
       - name: Hand the bundle to the registry
         id: publish
-        if: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' && steps.newer.outputs.newer != 'true' }}
+        if: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.plan.outputs.need_publish == 'true' }}
         env:
           TOKEN: ${{ secrets.publish-token }}
           REGISTRY: ${{ inputs.registry-url }}
           REGISTRY_SOURCE: ${{ inputs.registry-source }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
-          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
+          # The bytes each module's leg produced, whichever leg produced them — the ONE map the
+          # staging step and the receipt read too.
+          BUNDLES: ${{ steps.bundles.outputs.paths }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           if [ -z "${TOKEN:-}" ]; then
-            echo "::error::publish was requested but no publish-token secret was provided — the registry would never receive $MODULE, and this job would have reported success"
+            echo "::error::publish was requested but no publish-token secret was provided — the registry would never receive this batch's modules, and this job would have reported success"
             exit 1
           fi
-          # ───────── THE PUBLISH-SIDE GATE: a bundle that states no framework identity is
-          # ───────── UNPUBLISHABLE (#3211, part 3 of Plugins#931)
-          # 🚨 HERE, on the bytes about to be POSTed, and NOT only in the inspection above — the
-          # inspection runs on the BUILD leg alone, and the reuse leg hands over an artifact an
-          # earlier run packed, which may predate the packer that refuses to omit the field. This
-          # step is the one every published byte passes through, so this is where the refusal binds.
-          #
-          # Why it must be a refusal and not a warning: the registry shelves what arrives
-          # (ModulePublish.Accepted.FrameworkMvid -> ShelveModule) and advertises it per bundle on
-          # /api/plugins/bundles/index.json. A null there is not "unknown for now" — a registry that
-          # states no identity states none next time either, so ModuleUpdateDecision (#3154) answers
-          # SkipUpToDate-and-say-so for that module on every reconcile of every installation,
-          # forever. Unlike an unknown on the LANDED side, one fetch cannot heal it. Publishing such
-          # a bundle is therefore not a smaller good than refusing: it is the defect.
-          # Neither the exit status nor unzip's own stderr is swallowed: "could not check" must
-          # never render as "checked", and the log has to say WHY it could not.
-          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
-            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to publish bytes whose manifest this lane could not check (#3211)"
-            exit 1
-          fi
-          identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
-          if [ -z "$identity" ]; then
-            echo "::error::REFUSING to publish $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). The registry would shelve a null and advertise a null, and every consumer of this module would answer 'already landed — the identity could not be checked' on every reconcile, forever (#3154). A rebuild of unchanged source against a new platform republishes under the SAME version, so the identity is the only thing that tells that rebuild from a no-op. Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll (or state it with --framework-mvid); if these bytes were REUSED from an earlier run, that run packed them before the identity was recorded — rebuild them."
-            exit 1
-          fi
-          echo "publishing $MODULE@$VERSION, built against $identity"
-          code=$(curl -sS -o "$RUNNER_TEMP/publish-$MODULE.json" -w '%{http_code}' \
-            -X POST "$REGISTRY/api/plugins/bundles/$PACKAGE?version=$VERSION&packagePath=$REGISTRY_SOURCE/$PACKAGE" \
-            -H "Authorization: Bearer $TOKEN" \
-            -H "Content-Type: application/octet-stream" \
-            --data-binary "@$BUNDLE")
-          echo "registry answered $code:"; cat "$RUNNER_TEMP/publish-$MODULE.json"; echo
-          case "$code" in
-            2*) echo "$MODULE@$VERSION is now served by $REGISTRY" ;;
-            *)  echo "::error::registry refused $MODULE@$VERSION (HTTP $code)"; exit 1 ;;
-          esac
+          mapfile -t modules < <(bk list --ok --where need_publish=true --where 'newer!=true')
+          [ "${#modules[@]}" -gt 0 ] || echo "no module in this batch owes a hand-over on this run"
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            BUNDLE="$(jq -r --arg m "$MODULE" '.[$m] // empty' <<< "$BUNDLES")"
+            set +e
+            ( set -euo pipefail
+              [ -n "$BUNDLE" ] || { echo "::error::no bundle path recorded for $MODULE — neither the build nor the reuse leg produced one, so there is nothing to hand over."; exit 1; }
+              # ───────── THE PUBLISH-SIDE GATE: a bundle that states no framework identity is
+              # ───────── UNPUBLISHABLE (#3211, part 3 of Plugins#931)
+              # 🚨 HERE, on the bytes about to be POSTed, and NOT only in the inspection above — the
+              # inspection runs on the BUILD leg alone, and the reuse leg hands over an artifact an
+              # earlier run packed, which may predate the packer that refuses to omit the field. This
+              # step is the one every published byte passes through, so this is where the refusal binds.
+              #
+              # Why it must be a refusal and not a warning: the registry shelves what arrives
+              # (ModulePublish.Accepted.FrameworkMvid -> ShelveModule) and advertises it per bundle on
+              # /api/plugins/bundles/index.json. A null there is not "unknown for now" — a registry that
+              # states no identity states none next time either, so ModuleUpdateDecision (#3154) answers
+              # SkipUpToDate-and-say-so for that module on every reconcile of every installation,
+              # forever. Unlike an unknown on the LANDED side, one fetch cannot heal it. Publishing such
+              # a bundle is therefore not a smaller good than refusing: it is the defect.
+              # Neither the exit status nor unzip's own stderr is swallowed: "could not check" must
+              # never render as "checked", and the log has to say WHY it could not.
+              if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+                echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to publish bytes whose manifest this lane could not check (#3211)"
+                exit 1
+              fi
+              identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+              if [ -z "$identity" ]; then
+                echo "::error::REFUSING to publish $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). The registry would shelve a null and advertise a null, and every consumer of this module would answer 'already landed — the identity could not be checked' on every reconcile, forever (#3154). A rebuild of unchanged source against a new platform republishes under the SAME version, so the identity is the only thing that tells that rebuild from a no-op. Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll (or state it with --framework-mvid); if these bytes were REUSED from an earlier run, that run packed them before the identity was recorded — rebuild them."
+                exit 1
+              fi
+              echo "publishing $MODULE@$VERSION, built against $identity"
+              code=$(curl -sS -o "$RUNNER_TEMP/publish-$MODULE.json" -w '%{http_code}' \
+                -X POST "$REGISTRY/api/plugins/bundles/$PACKAGE?version=$VERSION&packagePath=$REGISTRY_SOURCE/$PACKAGE" \
+                -H "Authorization: Bearer $TOKEN" \
+                -H "Content-Type: application/octet-stream" \
+                --data-binary "@$BUNDLE")
+              echo "registry answered $code:"; cat "$RUNNER_TEMP/publish-$MODULE.json"; echo
+              case "$code" in
+                2*) echo "$MODULE@$VERSION is now served by $REGISTRY" ;;
+                *)  echo "::error::registry refused $MODULE@$VERSION (HTTP $code)"; exit 1 ;;
+              esac
+              bk set --module "$MODULE" published=true
+            )
+            rc=$?
+            set -e
+            [ "$rc" -eq 0 ] || bk fail --module "$MODULE" --phase publish --reason "the hand-over to the registry did not happen (exit $rc; see above)"
+          done
       - name: Ledger — Published
-        if: inputs.ledger == 'required' && steps.plan.outputs.key != '' && steps.publish.outcome == 'success'
+        if: inputs.ledger == 'required' && steps.publish.outcome == 'success'
         env:
-          KEY: ${{ steps.plan.outputs.key }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where published=true --where 'key!=')
+          for MODULE in "${modules[@]}"; do
+            KEY="$(bk get --module "$MODULE" key)"
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published \
+              || bk fail --module "$MODULE" --phase publish --reason "the ledger refused the Published record (see above)"
+          done
 
       # ═════════ THE STAGED HAND-OVER — `publish-mode: staged` (MeshWeaver#3878) ═════════
       # 🚨 The exact COMPLEMENT of the hand-over above, on the same input. Under `staged` this leg
@@ -2768,12 +3163,14 @@ jobs:
       # registry hears nothing until every sibling suite, the portal-host shards, the compile-check
       # and the Tests-area gate have reported `success`.
       #
-      # 🚨 EVERY LEG STAGES, INCLUDING ONE THAT OWES NOTHING. A leg whose key the build ledger
+      # 🚨 EVERY MODULE STAGES, INCLUDING ONE THAT OWES NOTHING. A module whose key the build ledger
       # already serves has no hand-over to make — and if it simply staged nothing, "the registry
       # already has these bytes" and "this leg never got here" would be the same absence at the
       # publication lane. So it stages a record that SAYS so, with the reason, and the publication
       # lane accounts for it instead of missing it. Same rule as the receipt below: positive
-      # evidence, never an inference from what is not there.
+      # evidence, never an inference from what is not there. ONE artifact per batch: the
+      # publication lane globs `module-publication-<lane>-*` and reads every
+      # `<module>.publication.json` it finds, resolving each record's bundle beside it.
       #
       # 🚨 And NO ledger transition here. A staged artifact is not a `Published` record (#3878,
       # repair contract 4): the ledger learns of a publication only from the lane that got a 2xx
@@ -2784,57 +3181,69 @@ jobs:
         if: ${{ inputs.publish && inputs.publish-mode == 'staged' }}
         env:
           LANE: ${{ needs.select.outputs.lane }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
           REGISTRY_SOURCE: ${{ inputs.registry-source }}
-          OWED: ${{ steps.plan.outputs.need_publish }}
-          DECISION: ${{ steps.plan.outputs.decision }}
-          HOLDER: ${{ steps.plan.outputs.holder }}
-          LEDGER_KEY: ${{ steps.plan.outputs.key }}
-          # The same expression the receipt and the direct hand-over use: the build leg's packed
-          # bundle, or the artifact the reuse leg downloaded and sha256-verified against the ledger.
-          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
+          # The same map the direct hand-over and the receipt read: the build leg's packed bundle,
+          # or the artifact the reuse leg downloaded and sha256-verified against the ledger.
+          BUNDLES: ${{ steps.bundles.outputs.paths }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/staged"
-          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so this staged publication could not be attributed to this call and the publication lane would refuse it anyway. Failing here, where it is readable."; exit 1; }
-          [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to stage for $MODULE and none to read its framework identity off."; exit 1; }
-          # THE IDENTITY, OFF THE BYTES — never from a step output. The packer's exit code, the
-          # inspection's tick and the value inside the artifact are three different claims, and the
-          # publication lane compares this record against the THIRD one before it POSTs.
-          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
-            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to stage bytes whose manifest this lane could not check (#3211)"
-            exit 1
-          fi
-          identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
-          [ -n "$identity" ] || { echo "::error::REFUSING to stage $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). A registry that shelves a null advertises a null, and every consumer answers 'already landed — the identity could not be checked' on every reconcile, for ever (#3154/#3211). Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll; if these bytes were REUSED, that run packed them before the identity was recorded — rebuild them."; exit 1; }
-          name="$(basename "$BUNDLE")"
-          sha="$(sha256sum "$BUNDLE" | cut -d' ' -f1)"
-          reason=""
-          if [ "$OWED" = "true" ]; then
-            cp "$BUNDLE" "$RUNNER_TEMP/staged/$name"
-            echo "staged $MODULE@$VERSION ($name, sha256 $sha, built against $identity) — the publication lane hands it over once this run's validation is green"
-          else
-            reason="no hand-over owed: the module build ledger already serves this key (decision '$DECISION'${HOLDER:+, holder $HOLDER})"
-            echo "staged $MODULE@$VERSION as NOT OWED — $reason"
-          fi
-          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg v "$VERSION" \
-                --arg src "$REGISTRY_SOURCE" --arg fid "$identity" --arg n "$name" --arg s "$sha" \
-                --arg r "$reason" --arg lk "$LEDGER_KEY" --arg d "$DECISION" \
-                --argjson owed "$([ "$OWED" = "true" ] && echo true || echo false)" \
-                --argjson size "$(wc -c < "$BUNDLE" | tr -d ' ')" \
-             '{lane:$l, package:$p, module:$m, version:$v, registrySource:$src,
-               frameworkIdentity:$fid, owed:$owed, reason:$r,
-               bundle:{name:$n, sha256:$s, size:$size},
-               ledger:{key:$lk, decision:$d}}' \
-             > "$RUNNER_TEMP/staged/$MODULE.publication.json"
-          cat "$RUNNER_TEMP/staged/$MODULE.publication.json"
-      - name: Upload the staged publication
-        if: ${{ inputs.publish && inputs.publish-mode == 'staged' }}
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no staged publication of this leg could be attributed to this call and the publication lane would refuse it anyway. Failing here, where it is readable."; exit 1; }
+          any=false
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            OWED="$(bk get --module "$MODULE" need_publish)"
+            DECISION="$(bk get --module "$MODULE" decision)"
+            HOLDER="$(bk get --module "$MODULE" holder)"
+            LEDGER_KEY="$(bk get --module "$MODULE" key)"
+            BUNDLE="$(jq -r --arg m "$MODULE" '.[$m] // empty' <<< "$BUNDLES")"
+            set +e
+            ( set -euo pipefail
+              [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to stage for $MODULE and none to read its framework identity off."; exit 1; }
+              # THE IDENTITY, OFF THE BYTES — never from a step output. The packer's exit code, the
+              # inspection's tick and the value inside the artifact are three different claims, and the
+              # publication lane compares this record against the THIRD one before it POSTs.
+              if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+                echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to stage bytes whose manifest this lane could not check (#3211)"
+                exit 1
+              fi
+              identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+              [ -n "$identity" ] || { echo "::error::REFUSING to stage $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). A registry that shelves a null advertises a null, and every consumer answers 'already landed — the identity could not be checked' on every reconcile, for ever (#3154/#3211). Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll; if these bytes were REUSED, that run packed them before the identity was recorded — rebuild them."; exit 1; }
+              name="$(basename "$BUNDLE")"
+              sha="$(sha256sum "$BUNDLE" | cut -d' ' -f1)"
+              reason=""
+              if [ "$OWED" = "true" ]; then
+                cp "$BUNDLE" "$RUNNER_TEMP/staged/$name"
+                echo "staged $MODULE@$VERSION ($name, sha256 $sha, built against $identity) — the publication lane hands it over once this run's validation is green"
+              else
+                reason="no hand-over owed: the module build ledger already serves this key (decision '$DECISION'${HOLDER:+, holder $HOLDER})"
+                echo "staged $MODULE@$VERSION as NOT OWED — $reason"
+              fi
+              jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg v "$VERSION" \
+                    --arg src "$REGISTRY_SOURCE" --arg fid "$identity" --arg n "$name" --arg s "$sha" \
+                    --arg r "$reason" --arg lk "$LEDGER_KEY" --arg d "$DECISION" \
+                    --argjson owed "$([ "$OWED" = "true" ] && echo true || echo false)" \
+                    --argjson size "$(wc -c < "$BUNDLE" | tr -d ' ')" \
+                 '{lane:$l, package:$p, module:$m, version:$v, registrySource:$src,
+                   frameworkIdentity:$fid, owed:$owed, reason:$r,
+                   bundle:{name:$n, sha256:$s, size:$size},
+                   ledger:{key:$lk, decision:$d}}' \
+                 > "$RUNNER_TEMP/staged/$MODULE.publication.json"
+              cat "$RUNNER_TEMP/staged/$MODULE.publication.json"
+            )
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then any=true; else bk fail --module "$MODULE" --phase publish --reason "the bundle could not be staged for the publication lane (exit $rc; see above)"; fi
+          done
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+      - name: Upload the staged publications
+        if: ${{ inputs.publish && inputs.publish-mode == 'staged' && steps.stage.outputs.any == 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: module-publication-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
+          name: module-publication-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}
           path: ${{ runner.temp }}/staged
           retention-days: 1
           # An upload that found nothing means this leg staged nothing while reporting success —
@@ -2842,152 +3251,210 @@ jobs:
           # right verdict but the wrong place to discover it. Fail here, where the cause is.
           if-no-files-found: error
 
-      # ───────── THE LEDGER'S VERDICT WHEN THIS LEG DID NOT GET HERE — never a reason for red ─────────
-      # `failure()`: the phase is read off the step outcomes, so the record says WHERE it failed and the
-      # tolerance rule (compile blocks; a test failure blocks from the 2nd attempt; pack/publish never)
-      # is applied by the script. `cancelled()`: the claim is released at once instead of expiring.
-      # Both steps are best-effort by construction — the script exits 0 with a ::warning when the
-      # registry is unavailable, and `|| true` keeps a failed leg's own failure as the job's verdict.
-      - name: Ledger — Failed
-        if: failure() && inputs.ledger == 'required' && steps.plan.outputs.key != ''
+      # ─────────────────────────── THE RECEIPTS ───────────────────────────
+      # 🚨 POSITIVE EVIDENCE THAT A MODULE'S LEG RAN TO THE END. A skipped matrix leg renders with
+      # the same tick as a passed one, so "this module was never packed" and "this module packed
+      # fine" are indistinguishable on the checks wall — and a matrix whose size depends on a diff
+      # makes that failure mode reachable rather than theoretical. `verify` counts these against
+      # the selection and names whatever is missing. A receipt is written ONLY for a module that
+      # is still in play here — every phase above, publish included, got through for it — so a
+      # module that failed in this batch has none and `verify` names it, exactly as when its leg
+      # was its own job. ONE artifact per batch, one file per module: the verifier globs
+      # `module-pack-receipt-<lane>-*` and keys on the `module` inside each file.
+      # 🚨 Lane-stamped and lane-named, for the same reason as the marker: artifacts are run-wide,
+      # and `--declared` alone separates two calls only while their matrices are DISJOINT. The
+      # moment two calls in one run declare the same module — an `always-modules` floor entry that
+      # is also in the other call's list is all it takes — a name-only filter hands one call's
+      # receipt to the other's accounting. The stamp is what makes attribution structural.
+      - name: Drop the receipts
+        id: receipt
         env:
-          KEY: ${{ steps.plan.outputs.key }}
+          LANE: ${{ needs.select.outputs.lane }}
+          PUBLISH: ${{ inputs.publish }}
+          PUBLISH_MODE: ${{ inputs.publish-mode }}
+          # 🚨 THE BYTES EACH MODULE'S LEG PRODUCED, whichever leg produced them (#3310). The same
+          # map as the hand-over and the staging read, so a reuse leg is accounted for exactly like
+          # a build leg. The identity is read off THESE bytes.
+          BUNDLES: ${{ steps.bundles.outputs.paths }}
+        run: |
+          set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mkdir -p "$RUNNER_TEMP/receipts"
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no receipt of this leg could be attributed to this call."; exit 1; }
+          any=false
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            VERSION="$(bk get --module "$MODULE" version)"
+            LEDGER_KEY="$(bk get --module "$MODULE" key)"
+            LEDGER_DECISION="$(bk get --module "$MODULE" decision)"
+            NEWER="$(bk get --module "$MODULE" newer)"
+            if [ "$LEDGER_DECISION" = reuse ]; then COMPILER=reused; else COMPILER="$(bk get --module "$MODULE" compiler)"; fi
+            # 🚨 "THIS LEG POSTED THE BUNDLE", not "this call was asked to publish". Under
+            # `publish-mode: staged` nothing reached the registry from here, and a receipt saying
+            # otherwise would make the lane's own report ("N published to the registry") a claim
+            # about something that has not happened yet.
+            PUBLISHED=false
+            if [ "$PUBLISH" = true ] && [ "$PUBLISH_MODE" = direct ] && [ "$NEWER" != true ]; then PUBLISHED=true; fi
+            # 🚨 WHICH ARM OWNED THIS MODULE'S HAND-OVER, written down rather than inferred from an
+            # `if:` nobody can read after the fact — the same discipline as `TESTS` below. `direct`:
+            # this leg POSTed the bundle itself. `staged`: it staged the bytes for the caller's
+            # publication lane, which hands over after the full source verdict (MeshWeaver#3878).
+            # `superseded`: publish-newest-only stood it down for the trunk tip. `none`: this call
+            # does not publish at all. Two mutually exclusive conditions can BOTH be false; this is
+            # what makes that impossible to do quietly.
+            if [ "$PUBLISH" != true ]; then PUBLICATION=none
+            elif [ "$NEWER" = true ]; then PUBLICATION=superseded
+            else PUBLICATION="$PUBLISH_MODE"; fi
+            # publish-newest-only: the trunk tip whose own run publishes this module instead.
+            SUPERSEDED_BY=""; [ "$NEWER" != true ] || SUPERSEDED_BY="$(bk get --module "$MODULE" tip)"
+            # 🚨 WHICH LANE OWNS THIS MODULE'S SUITE, written down rather than inferred from an `if:`
+            # nobody can read after the fact. `none` — the selection says this entry owes no test run
+            # (a floor-only entry, or a ledger record that already carries a verdict); `inline` — the
+            # step above ran it in this job, which is what a PUBLISHING run does so a red suite can
+            # never publish; `lane` — this call does not publish, so the `tests` job ran it beside
+            # this one. `verify` pairs every `lane` against a test receipt and fails when one is
+            # missing: two mutually exclusive conditions can BOTH be false, and this is what makes
+            # that impossible to do quietly.
+            if [ "$(bk get --module "$MODULE" need_test)" != true ]; then TESTS=none
+            elif [ "$PUBLISH" = true ]; then TESTS=inline
+            else TESTS=lane; fi
+            BUNDLE="$(jq -r --arg m "$MODULE" '.[$m] // empty' <<< "$BUNDLES")"
+            set +e
+            ( set -euo pipefail
+              # ───────── THE FRAMEWORK IDENTITY THIS BUNDLE STATES, ON THE RECEIPT (#3310) ─────────
+              # 🚨 THE ONLY EVIDENCE THAT LETS `verify` SEE THE OUTCOME. #3293 and #3306 made the anchor
+              # correct and their guards assert the lane's TEXT and the anchor's LOCATION — neither can
+              # see a run END UP stating more than one identity, which is what a per-module property
+              # reaching the anchor build produces, silently: the bundle packs, the manifest carries a
+              # well-formed 32-hex value, and every non-blank assertion downstream passes. `verify` is
+              # the only place that sees the whole wave, and this field is what it reads.
+              # Read off the BYTES, never from a step output: the packer's exit code, the inspection's
+              # tick and the value in the artifact are three different claims, and only the third is the
+              # one a consumer will compare against.
+              [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to read $MODULE's framework identity off. A receipt that cannot state the identity would leave a run's bundles disagreeing (#3310) unfalsifiable."; exit 1; }
+              if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+                echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to write a receipt for bytes this lane could not check (#3310)"
+                exit 1
+              fi
+              IDENTITY="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+              [ -n "$IDENTITY" ] || { echo "::error::$MODULE's bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')) — the receipt would attest nothing and 'the run's bundles agree' would be vacuously true for it (#3310). On a BUILD leg the pack step names the anchor and this manifest did not get it; on a REUSE leg these bytes were packed before the identity was recorded — rebuild them."; exit 1; }
+              echo "$MODULE states framework identity $IDENTITY"
+              jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
+                    --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
+                    --argjson pub "$PUBLISHED" --arg pm "$PUBLICATION" \
+                    --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
+                    --arg fid "$IDENTITY" --arg sb "${SUPERSEDED_BY:-}" \
+                 '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, publication:$pm, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}} + (if $sb == "" then {} else {supersededBy:$sb} end)' \
+                 > "$RUNNER_TEMP/receipts/$MODULE.json"
+              bk set --module "$MODULE" "tests=$TESTS" "publication=$PUBLICATION"
+              cat "$RUNNER_TEMP/receipts/$MODULE.json"
+            )
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then any=true; else bk fail --module "$MODULE" --phase pack --reason "no receipt could be written for this module (exit $rc; see above) — verify will name it as unaccounted"; fi
+          done
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+      - name: Upload the receipts
+        if: steps.receipt.outputs.any == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-pack-receipt-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}
+          path: ${{ runner.temp }}/receipts/*.json
+          retention-days: 1
+          if-no-files-found: error
+
+      # ───────── THE LEDGER'S VERDICT FOR EVERY MODULE THAT DID NOT GET HERE — never a reason for red ─────────
+      # `always()`, because the failures it records are PER MODULE and do not fail the step that
+      # found them: each is in the batch state with the phase that stopped it (compile blocks; a
+      # test failure blocks from the 2nd attempt; pack/publish never — the tolerance rule is the
+      # script's). When the LEG itself stopped in a shared step (`job.status` is failure and modules
+      # are still marked in play), every one of those is recorded as a `pack`-phase failure naming
+      # the step outcomes, exactly as the single-module leg did. Both steps are best-effort by
+      # construction — the script exits 0 with a ::warning when the registry is unavailable, and
+      # `|| true` keeps the leg's own verdict as the job's verdict. `cancelled()`: every claim is
+      # released at once instead of expiring.
+      - name: Ledger — Failed
+        if: always() && inputs.ledger == 'required'
+        env:
+          JOB_STATUS: ${{ job.status }}
           BUILD_OUTCOME: ${{ steps.build.outcome }}
           REUSED_OUTCOME: ${{ steps.reused.outcome }}
           PACK_OUTCOME: ${{ steps.pack.outcome }}
           INSPECT_OUTCOME: ${{ steps.bundle.outcome }}
           TESTS_OUTCOME: ${{ steps.tests.outcome }}
           PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
-          # A staging failure is a PUBLISH-phase failure: the bytes exist and are tested, and what
-          # did not happen is the hand-over. Recording it as `pack` would tell a later run to
-          # rebuild something that is already built (MeshWeaver#3878).
           STAGE_OUTCOME: ${{ steps.stage.outcome }}
-          MODE: ${{ matrix.entry.build || 'sdk' }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -uo pipefail
-          phase="pack"
-          if   [ "$TESTS_OUTCOME" = "failure" ]; then phase="test"
-          elif [ "$PUBLISH_OUTCOME" = "failure" ] || [ "$STAGE_OUTCOME" = "failure" ]; then phase="publish"
-          elif [ "$BUILD_OUTCOME" = "failure" ] && [ "$MODE" = "sdk" ]; then phase="compile"
-          elif [ "$BUILD_OUTCOME" = "failure" ] || [ "$PACK_OUTCOME" = "failure" ] || [ "$INSPECT_OUTCOME" = "failure" ] || [ "$REUSED_OUTCOME" = "failure" ]; then phase="pack"
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || { echo "the leg stopped before its modules were enumerated — no claim of this leg to record against"; exit 0; }
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          run="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
+          record() {
+            local MODULE="$1" phase="$2" note="$3" key trx
+            key="$(bk get --module "$MODULE" key)"
+            [ -n "$key" ] || return 0
+            mkdir -p "$RUNNER_TEMP/mods/$MODULE"
+            printf '%s\nstep outcomes — build:%s reused:%s pack:%s inspect:%s tests:%s publish:%s stage:%s (%s)\n' \
+              "$note" "$BUILD_OUTCOME" "$REUSED_OUTCOME" "$PACK_OUTCOME" "$INSPECT_OUTCOME" "$TESTS_OUTCOME" "$PUBLISH_OUTCOME" "$STAGE_OUTCOME" "$run" > "$RUNNER_TEMP/mods/$MODULE/failure.txt"
+            trx="$RUNNER_TEMP/trx/$MODULE/ledger.trx"
+            trxarg=()
+            if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" \
+              --failure-file "$RUNNER_TEMP/mods/$MODULE/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
+          }
+          for MODULE in $(bk list --failed); do
+            phase="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["modules"][sys.argv[2]]["phase"])' "$BATCH_STATE" "$MODULE")"
+            reason="$(python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); print(d["modules"][sys.argv[2]]["reason"])' "$BATCH_STATE" "$MODULE")"
+            record "$MODULE" "$phase" "$reason"
+          done
+          if [ "$JOB_STATUS" = failure ]; then
+            for MODULE in $(bk list --ok); do
+              record "$MODULE" pack "the leg stopped in a shared step before this module's own verdict"
+            done
           fi
-          printf 'step outcomes — build:%s reused:%s pack:%s inspect:%s tests:%s publish:%s stage:%s (%s)\n' \
-            "$BUILD_OUTCOME" "$REUSED_OUTCOME" "$PACK_OUTCOME" "$INSPECT_OUTCOME" "$TESTS_OUTCOME" "$PUBLISH_OUTCOME" "$STAGE_OUTCOME" "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
-          trx="$RUNNER_TEMP/trx/ledger.trx"
-          trxarg=()
-          if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Failed --phase "$phase" \
-            --failure-file "$RUNNER_TEMP/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
       - name: Ledger — released (cancelled)
-        if: cancelled() && inputs.ledger == 'required' && steps.plan.outputs.key != ''
+        if: cancelled() && inputs.ledger == 'required'
         env:
-          KEY: ${{ steps.plan.outputs.key }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
-        run: python3 meshweaver/.github/scripts/module-build-ledger.py release --key "$KEY" || true
-
-      # ─────────────────────────── THE RECEIPT ───────────────────────────
-      # 🚨 POSITIVE EVIDENCE THAT THIS LEG RAN. A skipped matrix leg renders with the same tick as
-      # a passed one, so "this module was never packed" and "this module packed fine" are
-      # indistinguishable on the checks wall — and a matrix whose size depends on a diff makes
-      # that failure mode reachable rather than theoretical. `verify` counts these against the
-      # selection and names whatever is missing. It is the LAST step on purpose: a receipt means
-      # the whole leg, publish included, got here.
-      # 🚨 Lane-stamped and lane-named, for the same reason as the marker: artifacts are run-wide,
-      # and `--declared` alone separates two calls only while their matrices are DISJOINT. The
-      # moment two calls in one run declare the same module — an `always-modules` floor entry that
-      # is also in the other call's list is all it takes — a name-only filter hands one call's
-      # receipt to the other's accounting. The stamp is what makes attribution structural.
-      - name: Drop the receipt
+        run: |
+          set -uo pipefail
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || exit 0
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          for MODULE in $(bk list --where 'key!='); do
+            python3 meshweaver/.github/scripts/module-build-ledger.py release --key "$(bk get --module "$MODULE" key)" || true
+          done
+      # The leg is over for the modules still in play: a record left at Built/Tested (no publish on
+      # this event) is marked finished so a follower stops waiting for a publish that will never
+      # come. Idempotent on a Published record.
+      - name: Ledger — finished
+        if: inputs.ledger == 'required'
         env:
-          LANE: ${{ needs.select.outputs.lane }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          VERSION: ${{ steps.identity.outputs.version }}
-          COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
-          # 🚨 "THIS LEG POSTED THE BUNDLE", not "this call was asked to publish". Under
-          # `publish-mode: staged` nothing reached the registry from here, and a receipt saying
-          # otherwise would make the lane's own report ("N published to the registry") a claim
-          # about something that has not happened yet.
-          PUBLISHED: ${{ inputs.publish && inputs.publish-mode == 'direct' && steps.newer.outputs.newer != 'true' }}
-          # 🚨 WHICH ARM OWNED THIS LEG'S HAND-OVER, written down rather than inferred from an
-          # `if:` nobody can read after the fact — the same discipline as `TESTS` below. `direct`:
-          # this leg POSTed the bundle itself. `staged`: it staged the bytes for the caller's
-          # publication lane, which hands over after the full source verdict (MeshWeaver#3878).
-          # `none`: this call does not publish at all. Two mutually exclusive conditions can BOTH
-          # be false; this is what makes that impossible to do quietly.
-          PUBLICATION: ${{ !inputs.publish && 'none' || (steps.newer.outputs.newer == 'true' && 'superseded' || inputs.publish-mode) }}
-          # publish-newest-only: the trunk tip whose own run publishes this module instead.
-          SUPERSEDED_BY: ${{ steps.newer.outputs.newer == 'true' && steps.newer.outputs.tip || '' }}
-          # 🚨 WHICH LANE OWNS THIS MODULE'S SUITE, written down rather than inferred from an `if:`
-          # nobody can read after the fact. `none` — the selection says this entry owes no test run
-          # (a floor-only entry, or a ledger record that already carries a verdict); `inline` — the
-          # step above ran it in this job, which is what a PUBLISHING run does so a red suite can
-          # never publish; `lane` — this call does not publish, so the `tests` job ran it beside
-          # this one. `verify` pairs every `lane` against a test receipt and fails when one is
-          # missing: two mutually exclusive conditions can BOTH be false, and this is what makes
-          # that impossible to do quietly.
-          TESTS: ${{ steps.plan.outputs.need_test != 'true' && 'none' || (inputs.publish && 'inline' || 'lane') }}
-          LEDGER_KEY: ${{ steps.plan.outputs.key }}
-          LEDGER_DECISION: ${{ steps.plan.outputs.decision }}
-          # 🚨 THE BYTES THIS LEG PRODUCED, whichever leg produced them (#3310). Same expression as
-          # the publish step's: the build leg's packed bundle, or the artifact the reuse leg
-          # downloaded and sha256-verified. The identity is read off THESE bytes, so a reuse leg is
-          # accounted for exactly like a build leg.
-          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          mkdir -p "$RUNNER_TEMP/receipts"
-          [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
-          [ -n "$TESTS" ] || { echo "::error::this leg recorded no owner for $MODULE's suite — a receipt that cannot say whether the suite ran here, ran in the tests lane, or was not owed leaves 'it ran nowhere' reading as green."; exit 1; }
-          [ -n "$PUBLICATION" ] || { echo "::error::this leg recorded no owner for $MODULE's hand-over — a receipt that cannot say whether the bundle was POSTed here, staged for the publication lane, or not published at all leaves 'it reached the registry from nowhere' reading as green (MeshWeaver#3878)."; exit 1; }
-          # ───────── THE FRAMEWORK IDENTITY THIS BUNDLE STATES, ON THE RECEIPT (#3310) ─────────
-          # 🚨 THE ONLY EVIDENCE THAT LETS `verify` SEE THE OUTCOME. #3293 and #3306 made the anchor
-          # correct and their guards assert the lane's TEXT and the anchor's LOCATION — neither can
-          # see a run END UP stating more than one identity, which is what a per-module property
-          # reaching the anchor build produces, silently: the bundle packs, the manifest carries a
-          # well-formed 32-hex value, and every non-blank assertion downstream passes. `verify` is
-          # the only place that sees the whole wave, and this field is what it reads.
-          # Read off the BYTES, never from a step output: the packer's exit code, the inspection's
-          # tick and the value in the artifact are three different claims, and only the third is the
-          # one a consumer will compare against.
-          [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to read $MODULE's framework identity off. A receipt that cannot state the identity would leave a run's bundles disagreeing (#3310) unfalsifiable."; exit 1; }
-          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
-            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to write a receipt for bytes this lane could not check (#3310)"
-            exit 1
-          fi
-          IDENTITY="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
-          [ -n "$IDENTITY" ] || { echo "::error::$MODULE's bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')) — the receipt would attest nothing and 'the run's bundles agree' would be vacuously true for it (#3310). On a BUILD leg the pack step names the anchor and this manifest did not get it; on a REUSE leg these bytes were packed before the identity was recorded — rebuild them."; exit 1; }
-          echo "$MODULE states framework identity $IDENTITY"
-          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
-                --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
-                --argjson pub "$PUBLISHED" --arg pm "$PUBLICATION" \
-                --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
-                --arg fid "$IDENTITY" --arg sb "${SUPERSEDED_BY:-}" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, publication:$pm, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}} + (if $sb == "" then {} else {supersededBy:$sb} end)' \
-             > "$RUNNER_TEMP/receipts/$MODULE.json"
-          cat "$RUNNER_TEMP/receipts/$MODULE.json"
-      - name: Upload the receipt
-        uses: actions/upload-artifact@v7
-        with:
-          name: module-pack-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
-          path: ${{ runner.temp }}/receipts/*.json
-          retention-days: 1
-          if-no-files-found: error
-      # The leg is over: a record left at Built/Tested (no publish on this event) is marked finished so
-      # a follower stops waiting for a publish that will never come. Idempotent on a Published record.
-      - name: Ledger — finished
-        if: inputs.ledger == 'required' && steps.plan.outputs.key != ''
-        env:
-          KEY: ${{ steps.plan.outputs.key }}
-          MW_LEDGER_URL: ${{ inputs.registry-url }}
-          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
-          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
-        run: python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$KEY"
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          for MODULE in $(bk list --ok --where 'key!='); do
+            python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$(bk get --module "$MODULE" key)"
+          done
+
+      # ─────────────────────────── THE VERDICT — one line per module, LAST ───────────────────────────
+      # 🚨 The step that makes a batch a runner-sharing device and not a coupling: every module got
+      # its own verdict above, this prints them side by side (log + job summary) and reds the leg
+      # when ANY module failed — so `verify` reads `pack: failure` for the same reason it did when
+      # each module had a leg of its own, while the modules that succeeded have already uploaded,
+      # published and receipted independently.
+      - name: Every module of this batch has its verdict
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
 
   # ════════ THE MODULE SUITES — A LANE OF THEIR OWN ON A NON-PUBLISHING RUN ════════
   # 🚨 THE MEASUREMENT THIS JOB EXISTS FOR (MeshWeaver.Plugins run 33656010754, a 39-minute PR):
@@ -3026,16 +3493,22 @@ jobs:
   #      repo's protection requires — `needs:` this job and goes RED when it did not succeed. The
   #      name is unchanged and so is what a red suite does to it.
   #   3. A suite that silently ran NOWHERE is caught by receipts, not by reading a condition: the
-  #      pack leg records which lane owns its suite, this job drops a receipt of its own, and
-  #      node-repo-pack-verify.py fails when a delegated module has no test receipt (or a test
-  #      receipt arrives for a module that delegated nothing). Two mutually exclusive `if:`s can
-  #      BOTH be false; the receipts are what make that impossible to do quietly.
+  #      pack leg records which lane owns its suite, this job drops a receipt of its own PER
+  #      MODULE, and node-repo-pack-verify.py fails when a delegated module has no test receipt
+  #      (or a test receipt arrives for a module that delegated nothing). Two mutually exclusive
+  #      `if:`s can BOTH be false; the receipts are what make that impossible to do quietly.
   #
   # `bundles-built` is deliberately untouched: it still answers from the built markers dropped
   # before any suite, so a red suite still does not read as "bundle missing" to a gate that only
   # COMPOSES the bundle (#2710, Plugins#937).
+  #
+  # 🚨 BATCHED like `pack` (2026-09-12, "Batched legs" at the top of this file): one leg runs the
+  # suites of N modules one after another on ONE runner — the checkout and the SDK install are paid
+  # once instead of N times, and the whole-minute rounding once — while each suite keeps its own
+  # verdict: a red suite marks THAT module failed in phase `test`, its evidence is kept under its
+  # own name, its siblings' suites still run, and the leg's last step reds it over any failure.
   tests:
-    name: Module tests (${{ matrix.entry.module }})
+    name: Module tests (${{ matrix.batch.label }})
     # 🚨 `select` ONLY — not prepare, not build-workspace, not pack. The suite is a `dotnet test`
     # against the content checkout with `-p:MeshWeaverRoot=<the platform checkout>`; it consumes
     # no platform image, no workspace build and no bundle. Depending on any of them would put it
@@ -3058,10 +3531,10 @@ jobs:
       # EMPTY on ubuntu-latest, which setup-dotnet reads as unset — the default path is unchanged.
       DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
     strategy:
-      # One module's red suite must not hide the rest — a sweep wants every verdict in one run.
+      # One leg's red suite must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false
       matrix:
-        entry: ${{ fromJson(needs.select.outputs.test-modules) }}
+        batch: ${{ fromJson(needs.select.outputs.test-batches) }}
     steps:
       - name: Resolve the content repository's credential
         id: content-repo
@@ -3097,6 +3570,19 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      - name: This leg's modules
+        env:
+          BATCH: ${{ toJSON(matrix.batch) }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/batch"
+          printf '%s' "$BATCH" > "$RUNNER_TEMP/batch/batch.json"
+          # 🚨 THE BATCH'S ONE SOURCE OF TRUTH: which modules this leg owns, what each phase found
+          # out about each of them, and which are still in play. Every per-module step below reads
+          # and writes it through module-pack-batch.py; exported ONCE, here, so no step can point
+          # at another file (a job-level `env:` cannot read `runner.temp`).
+          echo "BATCH_STATE=$RUNNER_TEMP/batch/state.json" >> "$GITHUB_ENV"
+          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
       # 🚨 UNCONDITIONAL, and the log says why. `dotnet-sdk: by-declaration` exists so a job that
       # compiles nothing on the runner stops installing an SDK by reflex — but this job's ONLY
       # work is `dotnet test`, a verb the platform image's build-project does not have at all. So
@@ -3105,127 +3591,175 @@ jobs:
       - name: The .NET SDK is this job's one declared need
         env:
           POLICY: ${{ inputs.dotnet-sdk }}
-          MODULE: ${{ matrix.entry.module }}
+          MODULES: ${{ join(matrix.batch.modules, ', ') }}
         run: |
           set -euo pipefail
           case "$POLICY" in
             install|by-declaration) ;;
             *) echo "::error::inputs.dotnet-sdk is '$POLICY'. The only values are 'install' (the default) and 'by-declaration'. An unreadable flag must NEVER resolve to 'do not install' — that is a skipped check wearing a green tick."; exit 1 ;;
           esac
-          echo ".NET SDK on the runner: INSTALLED — policy '$POLICY'; this job's one declared consumer is the module's own suite ('dotnet test' for $MODULE), which the pinned platform image cannot run."
+          echo ".NET SDK on the runner: INSTALLED — policy '$POLICY'; this job's one declared consumer is the modules' own suites ('dotnet test' for $MODULES), which the pinned platform image cannot run."
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
       # The same command, the same evidence trail and the same tolerance for a module that ships
       # no suite as the inline step in `pack` — this is a MOVE, not a rewrite. See that step for
-      # what each environment variable buys when a flake has to be diagnosed from the artifacts.
+      # what each environment variable buys when a flake has to be diagnosed from the artifacts,
+      # and for why the evidence is captured per module, right after ITS suite fails.
       - name: Run the module's tests, when it ships any
         id: tests
         env:
-          PROJECT: ${{ matrix.entry.project }}
           MESHWEAVER_TEST_FILE_LOGS: "1"
           DOTNET_DbgEnableMiniDump: "1"
           DOTNET_DbgMiniDumpType: "2"
           DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
         run: |
           set -euo pipefail
-          mkdir -p /tmp/coredumps
-          tests="$(dirname "$PROJECT").Test"
-          if [ -d "$tests" ]; then
-            echo "suite=present" >> "$GITHUB_OUTPUT"
-            dotnet test "$tests" -c Release -warnaserror \
-              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
-              --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx"
-          else
-            echo "suite=absent" >> "$GITHUB_OUTPUT"
-            echo "no test project at $tests — nothing to run"
-          fi
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          evidence=false
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            PROJECT="$(bk get --module "$MODULE" project)"
+            tests="$(dirname "$PROJECT").Test"
+            mkdir -p /tmp/coredumps
+            rm -f /tmp/meshweaver-test-trace.log /tmp/meshweaver-msg-trace.log /tmp/coredumps/*.dmp
+            if [ -d "$tests" ]; then
+              bk set --module "$MODULE" suite=present
+            else
+              bk set --module "$MODULE" suite=absent tested=true
+              echo "no test project at $tests — nothing to run"
+              continue
+            fi
+            set +e
+            ( set -euo pipefail
+              dotnet test "$tests" -c Release -warnaserror \
+                -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
+                --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx/$MODULE"
+            )
+            rc=$?
+            set -e
+            if [ "$rc" -eq 0 ]; then
+              bk set --module "$MODULE" tested=true
+            else
+              bk fail --module "$MODULE" --phase test --reason "the module's own suite failed (exit $rc; its evidence is under test-evidence/$MODULE)"
+              out="$RUNNER_TEMP/test-evidence/$MODULE"; mkdir -p "$out"
+              find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
+                cp "$f" "$out/" || true
+              done
+              [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
+              [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
+              if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
+                sudo chmod a+r /tmp/coredumps/*.dmp || true
+                cp /tmp/coredumps/*.dmp "$out/" || true
+                dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
+              fi
+              echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s) of evidence for $MODULE:"; ls -la "$out" | head -40
+              evidence=true
+            fi
+          done
+          echo "evidence=$evidence" >> "$GITHUB_OUTPUT"
       - name: Ledger — Tested
-        if: inputs.ledger == 'required' && steps.tests.outcome == 'success' && matrix.entry.ledger.key != ''
+        if: inputs.ledger == 'required' && steps.tests.outcome == 'success'
         env:
-          KEY: ${{ matrix.entry.ledger.key }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/ledger.trx"
-      - name: Keep the failing suite's evidence
-        if: ${{ failure() }}
-        env:
-          PROJECT: ${{ matrix.entry.project }}
-        run: |
-          set -uo pipefail
-          tests="$(dirname "$PROJECT").Test"
-          out="$RUNNER_TEMP/test-evidence"; mkdir -p "$out"
-          find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
-            cp "$f" "$out/" || true
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          mapfile -t modules < <(bk list --ok --where tested=true --where 'ledger.key!=')
+          for MODULE in "${modules[@]}"; do
+            KEY="$(bk get --module "$MODULE" ledger.key)"
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
+              || bk fail --module "$MODULE" --phase test --reason "the ledger refused the Tested record (see above)"
           done
-          [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
-          [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
-          if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
-            sudo chmod a+r /tmp/coredumps/*.dmp || true
-            cp /tmp/coredumps/*.dmp "$out/" || true
-            dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
-          fi
-          echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s):"; ls -la "$out" | head -40
-      - name: Upload the failing suite's evidence
-        if: ${{ failure() }}
+      - name: Upload the failing suites' evidence
+        if: ${{ steps.tests.outputs.evidence == 'true' }}
         uses: actions/upload-artifact@v7
         with:
-          name: test-evidence-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}-${{ github.run_id }}-${{ github.run_attempt }}
+          name: test-evidence-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/test-evidence
           if-no-files-found: ignore
           retention-days: 14
           compression-level: 9
-      # ─────────── THE TEST RECEIPT — positive evidence that this suite RAN ───────────
+      # ─────────── THE TEST RECEIPTS — positive evidence that each suite RAN ───────────
       # 🚨 The whole reason the split is allowed to exist. Two mutually exclusive `if:`s can BOTH
       # evaluate false, and a suite that ran in neither lane renders exactly like one that passed.
       # So the pack leg records which lane OWNS its suite (`tests: none|inline|lane` in its
-      # receipt), this job records that the lane actually ran it, and `verify` refuses a run where
-      # the two do not line up — naming the module. Lane-stamped for the same reason as every
-      # other artifact here: artifacts are RUN-WIDE and a repo may call this lane twice.
-      # LAST step on purpose: a receipt means the suite got here green.
+      # receipt), this job records PER MODULE that the lane actually ran it, and `verify` refuses a
+      # run where the two do not line up — naming the module. A receipt is written only for a
+      # module whose suite got to the end green; a failed one has none. Lane-stamped for the same
+      # reason as every other artifact here: artifacts are RUN-WIDE and a repo may call this lane
+      # twice. ONE artifact per batch, one file per module, under the glob `verify` reads.
       - name: Drop the test receipt
+        id: receipt
         env:
           LANE: ${{ needs.select.outputs.lane }}
-          PACKAGE: ${{ matrix.entry.package }}
-          MODULE: ${{ matrix.entry.module }}
-          SUITE: ${{ steps.tests.outputs.suite }}
         run: |
           set -euo pipefail
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/test-receipts"
-          [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call and the verifier would refuse it anyway."; exit 1; }
-          [ -n "$SUITE" ] || { echo "::error::the suite step recorded neither 'present' nor 'absent' for $MODULE — a receipt that cannot say whether a suite existed attests nothing."; exit 1; }
-          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg s "$SUITE" \
-             '{lane:$l, package:$p, module:$m, tests:"lane", suite:$s, result:"passed"}' \
-             > "$RUNNER_TEMP/test-receipts/$MODULE.json"
-          cat "$RUNNER_TEMP/test-receipts/$MODULE.json"
-      - name: Upload the test receipt
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no receipt of this leg could be attributed to this call and the verifier would refuse it anyway."; exit 1; }
+          any=false
+          mapfile -t modules < <(bk list --ok)
+          for MODULE in "${modules[@]}"; do
+            PACKAGE="$(bk get --module "$MODULE" package)"
+            SUITE="$(bk get --module "$MODULE" suite)"
+            [ -n "$SUITE" ] || { echo "::error::the suite step recorded neither 'present' nor 'absent' for $MODULE — a receipt that cannot say whether a suite existed attests nothing."; exit 1; }
+            jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg s "$SUITE" \
+               '{lane:$l, package:$p, module:$m, tests:"lane", suite:$s, result:"passed"}' \
+               > "$RUNNER_TEMP/test-receipts/$MODULE.json"
+            cat "$RUNNER_TEMP/test-receipts/$MODULE.json"
+            any=true
+          done
+          echo "any=$any" >> "$GITHUB_OUTPUT"
+      - name: Upload the test receipts
+        if: steps.receipt.outputs.any == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
+          name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}
           path: ${{ runner.temp }}/test-receipts/*.json
           retention-days: 1
           if-no-files-found: error
-      # Best-effort, exactly as in `pack`: the script exits 0 with a ::warning when the registry is
-      # unavailable, and `|| true` keeps this leg's own failure as the job's verdict.
+      # Best-effort, exactly as in `pack`: `always()` because the failures are per module and did
+      # not fail the step that found them; the script exits 0 with a ::warning when the registry
+      # is unavailable, and `|| true` keeps this leg's own verdict as the job's verdict.
       - name: Ledger — Failed
-        if: failure() && inputs.ledger == 'required' && matrix.entry.ledger.key != ''
+        if: always() && inputs.ledger == 'required'
         env:
-          KEY: ${{ matrix.entry.ledger.key }}
-          MODULE: ${{ matrix.entry.module }}
+          JOB_STATUS: ${{ job.status }}
           MW_LEDGER_URL: ${{ inputs.registry-url }}
           MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -uo pipefail
-          printf 'the module suite failed in the tests lane — %s/%s/actions/runs/%s\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
-          trx="$RUNNER_TEMP/trx/ledger.trx"
-          trxarg=()
-          if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
-          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Failed --phase test \
-            --failure-file "$RUNNER_TEMP/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || { echo "the leg stopped before its modules were enumerated — nothing to record"; exit 0; }
+          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          record() {
+            local MODULE="$1" note="$2" key trx
+            key="$(bk get --module "$MODULE" ledger.key)"
+            [ -n "$key" ] || return 0
+            mkdir -p "$RUNNER_TEMP/mods/$MODULE"
+            printf '%s — %s/%s/actions/runs/%s\n' "$note" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" > "$RUNNER_TEMP/mods/$MODULE/failure.txt"
+            trx="$RUNNER_TEMP/trx/$MODULE/ledger.trx"
+            trxarg=()
+            if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase test \
+              --failure-file "$RUNNER_TEMP/mods/$MODULE/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
+          }
+          for MODULE in $(bk list --failed); do
+            record "$MODULE" "the module suite failed in the tests lane"
+          done
+          if [ "$JOB_STATUS" = failure ]; then
+            for MODULE in $(bk list --ok); do
+              record "$MODULE" "the tests leg stopped in a shared step before this module's suite reached a verdict"
+            done
+          fi
+      # The verdict, LAST — see `pack`: one line per module, red over any failed suite.
+      - name: Every module of this batch has its verdict
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════
   # 🚨 A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -73,6 +73,32 @@ select ─┬─► prepare (ONCE) ──► build (ONE workspace) ──► pac
 > ledger's reuse leg and the `docker cp` fallback when `prepare`'s `platform-refs-<digest>` cache
 > entry has been evicted — fail RED naming the missing tool; neither skips.
 
+**Batched legs (2026-09-12).** GitHub bills every job rounded *up* to a whole minute, and most legs
+of this lane were shorter than the unit they were billed in — measured 2026-09-05..12 on
+MeshWeaver.Plugins: 4,975 sampled `Module bundles / Module bundle` legs at a **median of 1.1 min**
+(p90 8.4), 1,385 `Module bundles` parent legs at 1.1 min, 2,935 `Module tests` legs at 4.0 min (p90
+8.2); whole-minute rounding on the sub-minute legs was ≈12 % of Plugins' bill (~4,700 billed
+minutes a day) and 25–40 % in Crm / Reinsurance / SocialMedia. So `pack` and `tests` now expand
+**one leg per batch** of `batch-size` modules (default 6, hard cap 10) — `select` cuts the
+selection deterministically (sorted by module name, striped over ⌈n/N⌉ legs so an alphabetical
+family such as `MeshWeaver.AI.*` is spread rather than stacked; ≤N modules is one leg, a
+single-module repository is unchanged) with `.github/scripts/module-pack-batch.py`, and the same
+script keeps one state record per module inside the leg. **A batch is a runner-sharing device,
+not a coupling**: every module still builds, packs, uploads its own `module-bundle-<module>`
+(kept as a per-module name — the ledger records it and every caller's `module-artifacts`
+pattern globs it — through unrolled upload slots), runs its own suite, and on a publishing call
+POSTs its own bundle right after its own suite; a phase that fails for one module marks *that*
+module failed in that phase, every later phase skips it, the sibling modules complete and
+publish, and the leg's last step prints one status line per module and reds the leg over any
+failure — so `verify` still reads `pack: failure` and still accounts every module by its own
+receipt (a failed module drops none). Receipts, built markers, staged publications and test
+evidence are one artifact per batch with one file per module, which every consumer already reads
+through `<kind>-<lane>-*` + merge-multiple keyed on the `module` inside each file. No required
+context moves; the fleet's protected-job matchers read the caller's job name (`Module bundles`),
+which is untouched. Arithmetic for Plugins at N=6: the ~40 sub-minute pack legs of a full run go
+from ~40 billed minutes to ~7 (each batch ≈ 6 × 1.1 min of work ≈ 7 min, rounded once), and the
+per-leg checkout + SDK install is paid 7 times instead of 40.
+
 ### Where a module's own suite runs — and why `publish` decides
 
 A `needs:` on a `uses:` job waits for the **whole** called workflow, so anything inside the last

--- a/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
@@ -88,7 +88,8 @@ public class ModuleBuildLedgerLaneGuard
             return i;
         }
 
-        var upload = At("name: module-bundle-${{ matrix.entry.module }}");
+        // The first of the unrolled per-module upload slots (batched legs, 2026-09-12).
+        var upload = At("name: module-bundle-${{ steps.bundles.outputs.s1 }}");
         var built = At("--status Built");
         var tests = At("dotnet test \"$tests\"");
         var tested = At("--status Tested --trx");
@@ -107,9 +108,14 @@ public class ModuleBuildLedgerLaneGuard
         // Tested and Published are gated on the OUTCOME of the step they attest, not on the job's mood.
         Assert.Contains("steps.tests.outcome == 'success'", pack, StringComparison.Ordinal);
         Assert.Contains("steps.publish.outcome == 'success'", pack, StringComparison.Ordinal);
-        // The verdict steps run on failure / cancellation only.
-        Assert.Contains("if: failure() && inputs.ledger == 'required' && steps.plan.outputs.key != ''", pack, StringComparison.Ordinal);
-        Assert.Contains("if: cancelled() && inputs.ledger == 'required' && steps.plan.outputs.key != ''", pack, StringComparison.Ordinal);
+        // The Failed verdict is PER MODULE and the failures it records did not fail the step that
+        // found them (a batched leg isolates each module), so it runs `always()` and reads the
+        // batch state: the modules marked failed, plus — when the LEG itself stopped in a shared
+        // step — the ones still in play. Released runs on cancellation only, for every key.
+        Assert.Contains("if: always() && inputs.ledger == 'required'", pack, StringComparison.Ordinal);
+        Assert.Contains("for MODULE in $(bk list --failed); do", pack, StringComparison.Ordinal);
+        Assert.Contains("if [ \"$JOB_STATUS\" = failure ]; then", pack, StringComparison.Ordinal);
+        Assert.Contains("if: cancelled() && inputs.ledger == 'required'", pack, StringComparison.Ordinal);
         // The reuse leg verifies the bytes against the record and never packs anyway.
         Assert.Contains("gh run download \"$ART_RUN\"", pack, StringComparison.Ordinal);
         Assert.Contains("is not the ledger's $EXPECTED_SHA", pack, StringComparison.Ordinal);
@@ -135,15 +141,17 @@ public class ModuleBuildLedgerLaneGuard
         var tested = tests.IndexOf("--status Tested --trx", StringComparison.Ordinal);
         Assert.True(suite >= 0, "the tests lane must run the module's suite");
         Assert.True(tested > suite, "`Tested` must be recorded AFTER the suite it attests");
-        // Gated on the OUTCOME of the step it attests — never on the job's mood.
-        Assert.Contains("if: inputs.ledger == 'required' && steps.tests.outcome == 'success' && matrix.entry.ledger.key != ''",
+        // Gated on the OUTCOME of the step it attests — never on the job's mood — and, inside,
+        // on each module's own `tested` fact and ledger key (batched legs, 2026-09-12).
+        Assert.Contains("if: inputs.ledger == 'required' && steps.tests.outcome == 'success'",
             tests, StringComparison.Ordinal);
+        Assert.Contains("bk list --ok --where tested=true --where 'ledger.key!='", tests, StringComparison.Ordinal);
         // The suite writes the evidence the ledger records, exactly as the inline one does.
         Assert.Contains("--logger \"trx;LogFileName=ledger.trx\"", tests, StringComparison.Ordinal);
         // The way out: this lane can only fail in one phase, so it names it rather than deriving it.
         Assert.Contains("--status Failed --phase test", tests, StringComparison.Ordinal);
-        Assert.Contains("if: failure() && inputs.ledger == 'required' && matrix.entry.ledger.key != ''",
-            tests, StringComparison.Ordinal);
+        Assert.Contains("if: always() && inputs.ledger == 'required'", tests, StringComparison.Ordinal);
+        Assert.Contains("for MODULE in $(bk list --failed); do", tests, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
@@ -184,7 +184,12 @@ public class ModuleIdentityPublishGuard
         // code, the inspection's tick and the value in the artifact are three different claims,
         // and only the third is what a consumer compares against.
         var receipt = pack[pack.IndexOf("name: Drop the receipt", StringComparison.Ordinal)..];
-        Assert.Contains("BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}",
+        // ONE map of module -> bundle path (`bundles.paths`), the same the hand-over and the staging
+        // read; each module's path is read out of it as `BUNDLE` inside its own loop iteration
+        // (batched legs, 2026-09-12).
+        Assert.Contains("BUNDLES: ${{ steps.bundles.outputs.paths }}",
+            receipt, StringComparison.Ordinal);
+        Assert.Contains("BUNDLE=\"$(jq -r --arg m \"$MODULE\" '.[$m] // empty' <<< \"$BUNDLES\")\"",
             receipt, StringComparison.Ordinal);
         Assert.Contains("unzip -p \"$BUNDLE\" meshweaver/manifest.json", receipt, StringComparison.Ordinal);
         Assert.Contains("jq -r '.frameworkMvid // \"\"' | tr -d '[:space:]'", receipt, StringComparison.Ordinal);

--- a/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
@@ -38,12 +38,18 @@ public class ModuleSuiteLaneGuard
     public void TheInlineSuite_RunsOnlyWhenThisCallPublishes()
     {
         var pack = JobBody("pack");
+        // The step's `if:` reads the batch-wide switch (`need_test` = any module of the leg still
+        // owes a suite); INSIDE it, the loop runs only the modules whose own `need_test` fact is
+        // true — the entry's `test != false` folded in by the plan step. Batched legs, 2026-09-12.
         Assert.Contains(
-            "if: ${{ inputs.publish && matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}",
+            "if: ${{ inputs.publish && steps.plan.outputs.need_test == 'true' }}",
             pack, StringComparison.Ordinal);
+        Assert.Contains("bk list --ok --where need_test=true", pack, StringComparison.Ordinal);
         // Still AFTER the bundle upload and BEFORE the hand-over when it does run: that ordering is
-        // the entire reason a publishing run keeps paying for it.
-        var upload = pack.IndexOf("name: module-bundle-${{ matrix.entry.module }}", StringComparison.Ordinal);
+        // the entire reason a publishing run keeps paying for it. The upload is the first of the
+        // unrolled per-module slots (`module-bundle-<module>` is a per-module NAME every caller's
+        // `module-artifacts` pattern globs, so it cannot become one artifact per batch).
+        var upload = pack.IndexOf("name: module-bundle-${{ steps.bundles.outputs.s1 }}", StringComparison.Ordinal);
         var suite = pack.IndexOf("dotnet test \"$tests\"", StringComparison.Ordinal);
         var publish = pack.IndexOf("-X POST \"$REGISTRY/api/plugins/bundles/$PACKAGE", StringComparison.Ordinal);
         Assert.True(upload >= 0 && suite >= 0 && publish >= 0, "the pack job must still upload, test and publish");
@@ -67,7 +73,8 @@ public class ModuleSuiteLaneGuard
         // A matrix with zero vectors does not evaluate, so the count is asserted the way `pack`
         // asserts its own.
         Assert.Contains("needs.select.outputs.test-count != '0'", tests, StringComparison.Ordinal);
-        Assert.Contains("entry: ${{ fromJson(needs.select.outputs.test-modules) }}", tests, StringComparison.Ordinal);
+        // The matrix is the suite subset cut into batches by `select` (module-pack-batch.py chunk).
+        Assert.Contains("batch: ${{ fromJson(needs.select.outputs.test-batches) }}", tests, StringComparison.Ordinal);
 
         // 🚨 `select` ONLY. Depending on prepare / build-workspace / pack would put the suite back
         // on the very chain this job exists to run beside, and the change would measure as nothing.
@@ -88,16 +95,20 @@ public class ModuleSuiteLaneGuard
         var pack = JobBody("pack");
         // `none` | `inline` | `lane`, written into the receipt rather than inferred afterwards from
         // an `if:` — the pairing below is what makes "it ran nowhere" impossible to do quietly.
-        Assert.Contains(
-            "TESTS: ${{ steps.plan.outputs.need_test != 'true' && 'none' || (inputs.publish && 'inline' || 'lane') }}",
-            pack, StringComparison.Ordinal);
+        // Computed per module in the receipt loop, from the module's own `need_test` fact and the
+        // call's `publish` input — the same three-way rule the `if:` expression used to encode.
+        Assert.Contains("if [ \"$(bk get --module \"$MODULE\" need_test)\" != true ]; then TESTS=none", pack, StringComparison.Ordinal);
+        Assert.Contains("elif [ \"$PUBLISH\" = true ]; then TESTS=inline", pack, StringComparison.Ordinal);
+        Assert.Contains("else TESTS=lane; fi", pack, StringComparison.Ordinal);
         Assert.Contains("tests:$t", pack, StringComparison.Ordinal);
 
         var tests = JobBody("tests");
         Assert.Contains("tests:\"lane\"", tests, StringComparison.Ordinal);
         // Lane-stamped and lane-named, like every other artifact here: artifacts are RUN-WIDE and a
         // repo may call this lane twice in one run.
-        Assert.Contains("name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}",
+        // ONE artifact per batch, one `<module>.json` per module inside it: `verify` globs
+        // `module-tests-receipt-<lane>-*` with merge-multiple and keys on the `module` field.
+        Assert.Contains("name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.batch.id }}",
             tests, StringComparison.Ordinal);
         Assert.Contains("if-no-files-found: error", tests, StringComparison.Ordinal);
         // The receipt means the suite got to the end green, so it is the LAST evidence step.


### PR DESCRIPTION
Phase 3b of the fleet CI refactor (after #4090, the `runner` input). Draft — not ready for review until the maintainer has read the "what changes on the checks wall" and "risks" sections.

## The problem (measured 2026-09-05..12)

GitHub bills every job rounded **up** to a whole minute. `node-repo-module-pack.yml` fanned out one job per module, and most of those jobs were shorter than the unit they were billed in:

| MeshWeaver.Plugins job family | sampled legs | median | p90 | variants |
|---|---|---|---|---|
| `Module bundles / Module bundle` (the `pack` matrix) | 4,975 | **1.1 min** | 8.4 | 40 |
| `Module bundles` parent legs | 1,385 | 1.1 min | — | 51 |
| `Module bundles / Module tests` (the `tests` matrix) | 2,935 | 4.0 min | 8.2 | — |

Whole-minute rounding on the sub-minute legs is ≈12 % of Plugins' bill (~4,700 billed min/day) and 25–40 % in Crm / Reinsurance / SocialMedia, whose modules are smaller still. Every leg also pays its own two checkouts, SDK install, cache restores and tool download before a second of module work.

## Design

`pack` and `tests` now expand **one leg per batch** of `batch-size` modules (new `workflow_call` input, default 6, hard cap 10). A batch is a **runner-sharing device, not a coupling**:

* `select` cuts the selection with the new `.github/scripts/module-pack-batch.py chunk` — **deterministic**: sorted by module name, then **striped** over ⌈n/N⌉ legs (module *i* → leg *i* mod *k*), so legs are balanced and an alphabetical family (`MeshWeaver.AI`, `MeshWeaver.AI.Anthropic`, `MeshWeaver.AI.OpenAI`, …) is spread across legs rather than stacked into one. ≤N modules is one leg; a single-module repository is **unchanged** (same job name `Module bundle (MeshWeaver.Social)`, same `module-bundle-<module>` artifact, same receipt files). `batch-size: 1` restores one leg per module. An unreadable/out-of-range size is RED in `select`, never a silent default.
* Inside a leg, every step that used to read `matrix.entry.<field>` loops over the batch's modules and runs each module's work in its own subshell (`set +e; ( set -euo pipefail; … ); rc=$?; set -e`). The same script keeps **one state record per module** (`init` / `set` / `get` / `list --ok --where …` / `fail --phase` / `slots` / `paths` / `verdict`). A phase that fails for one module marks **that** module failed in that phase (a `::error` naming module + phase), every later phase skips it, and the sibling modules complete — build, pack, inspect, upload, suite, and on a publishing call **POST their own bundle right after their own suite**, in that order, with their own ledger transitions. The leg's **last** step prints one status line per module (log + job summary) and reds the leg over any failure, so `verify` reads `pack: failure` for the same reason it did before.
* Artifacts: `module-bundle-<module>` is a **per-module name that is a cross-repo contract** (the ledger records it as `--artifact-name`, the reuse leg downloads it by name, every caller's `module-artifacts` pattern globs it — Plugins' `module-bundle-MeshWeaver.{AI,…}`, main-cd's compose set). `actions/upload-artifact` takes one name per step, so the pack job **unrolls ten upload slots** (`Upload the bundle artifact (slot n)`, `if: steps.bundles.outputs.sN != ''` — a mode switch on the leg's own bookkeeping) and the chunker caps `batch-size` at the same literal. Receipts, built markers, staged publications and test evidence become **one artifact per batch with one file per module** (`module-pack-receipt-<lane>-batch-2-of-7/MeshWeaver.AI.json`): every consumer already reads them through `<kind>-<lane>-*` + `merge-multiple` and keys on the `module` field **inside** each file (`node-repo-pack-verify.py` refuses a file whose name disagrees with it; `module-publication.py` resolves each record's bundle beside the record), so they read identically. Verified by running the unchanged verifier over a batch's files in the dry-run below.

## Invariants kept (and how each is still structural)

| invariant | before | now |
|---|---|---|
| a failing suite never publishes | step order in one leg | per module: a module whose suite failed is out of `list --ok` before the hand-over loop; siblings still POST |
| `Built` after the upload it names; `Tested` after the suite; `Published` after the 2xx | step order | same step order; each loops over the modules that reached that state (`decision=build`+`bundle!=`, `tested=true`, `published=true`) |
| `Failed` names the phase (compile blocks, test from 2nd attempt, pack/publish never) | derived from step outcomes | recorded at the failure point per module (`fail --phase compile|pack|test|publish`); a leg that stops in a **shared** step records `pack` for the modules still in play (`job.status == failure`) |
| a receipt means the whole leg, publish included, got there | last step | a receipt is written only for a module still in play after staging; a failed module drops none → `verify` names it exactly as before |
| `tests: none|inline|lane` and `publication: none|direct|staged|superseded` on the receipt | `if:` expressions | the same three-way rules, computed per module in the receipt loop |
| `bundles-built` answers from built markers dropped before any suite | — | unchanged (markers per module, uploaded per batch) |
| publish-newest-only stands a module down per module | per leg | trunk fetched once per leg, the scope script asked per module |
| `verify` = `All selected bundles built`, `needs: [select, pack, tests]`, `if: always()` | — | **untouched**; `count`/`test-count` still count modules |
| hop C is pull-based; nothing changes until a caller moves its `uses:` sha | — | unchanged — and the caller must move `platform-ref` with it (the scripts are fetched at `platform-ref`; an older pin fails RED on the missing script, never silently) |

## Names preserved / changed

* Unchanged: `All selected bundles built` (the only context anyone requires), the caller-side job names (`Module bundles`, `Module bundles (floor)`), `module-bundle-<module>`, the receipt/marker/test-receipt file names and their `<kind>-<lane>-*` globs, the `lane` / `selected` / `declared` / `bundles-built` outputs, the `publish` / `stage` / `Ledger — Published` step ids the Python tests read.
* Changed: matrix leg display names — `Module bundle (batch 2/7: MeshWeaver.AI.Anthropic, MeshWeaver.Blazor.Chat, …)` and `Module tests (batch …)`; a singleton leg keeps `Module bundle (<module>)`. Checked every matcher: `supersede-main-runs.py`'s protected regex `^(publish|bake|seal|hand-?over)` matches the **caller** job part (`j.split(" / ", 1)[0]`) — untouched; Plugins' `check-main-runs-not-cancelled.py` evaluates the concurrency expression, not names; `gates-executed` / `tests-ratchet` `needs:` lists do not include the module legs; no branch protection names a matrix leg (Plugins ci.yml: "THE CONTEXT TO REQUIRE IS `Module bundles / All selected bundles built`, never a per-module").
* Per-batch artifact names: `module-built-<lane>-<batch-id>`, `module-pack-receipt-<lane>-<batch-id>`, `module-tests-receipt-<lane>-<batch-id>`, `module-publication-<lane>-<batch-id>`, `test-evidence-<lane>-<batch-id>-<run>-<attempt>`, where `<batch-id>` is `batch-i-of-k` or, for a singleton leg, the module name (so a single-module repo's names are byte-identical).

## Arithmetic (from the numbers above)

Assumptions stated: a full Plugins run has 40 pack legs; a 1.1-min leg is ≈0.6 min fixed per-leg setup (two checkouts, setup-dotnet, cache restores, tool download) + ≈0.5 min module work (the 2026-09-02 measurement: 0.2 min build + pack/inspect/upload); billed = ⌈duration⌉ per leg.

| | N=1 (today) | N=6 (7 legs) | N=10 (4 legs) |
|---|---|---|---|
| pack, at the median, overhead shared | 40 × ⌈1.1⌉ = **80** | 6 × ⌈0.6+6×0.5⌉ + ⌈0.6+4×0.5⌉ = 6×4 + 3 = **27** (−66 %) | 4 × ⌈0.6+10×0.5⌉ = 4×6 = **24** (−70 %) |
| pack, rounding only (durations simply summed) | 80 | 6 × ⌈6.6⌉ + ⌈4.4⌉ = 42 + 5 = **47** (−41 %) | 4 × ⌈11⌉ = **44** (−45 %) |
| tests, at the median (4.0), overhead shared | 40 × 4 = **160** | 6 × ⌈0.6+6×3.4⌉ + ⌈0.6+4×3.4⌉ = 6×21 + 15 = **141** (−12 %) | 4 × ⌈0.6+10×3.4⌉ = 4×35 = **140** (−13 %) |

Per Plugins full run the pack legs go from ~80 to ~27 billed minutes at N=6; across ~15 full runs/day that is roughly the ~12 % (≈600–800 billed min/day of pure rounding) the measurement attributed to the sub-minute legs, plus the shared setup. The tests legs gain little from rounding (median 4.0 is already whole) — their saving is the shared setup only.

## Risks / not done — please read

1. **The 45-minute cap and long suites.** A **publishing** leg carries its modules' suites inline: six p90 (8.4 min) legs in one batch = 50 min > 45; the cap kills the leg and loses the trx. Striping spreads a family but knows no durations. Mitigations available today: `batch-size` per caller (Plugins may want 4 on trunk), and the unchanged rule that a leg reaching 45 is stuck-not-slow. A duration-aware chunker (from the ledger's trx counts or a per-repo weights file) is a follow-up, not in this PR.
2. **The three C# lane guards were edited** (outside the file set the phase brief listed) — unavoidable: they assert exact `matrix.entry.*` strings that no batched lane can contain. Every invariant they encode is kept and re-asserted in its batched form (`ModuleSuiteLaneGuard`, `ModuleBuildLedgerLaneGuard`; `ModuleIdentityPublishGuard` needed no edit). Diff is small and shown in the commit.
3. **`Ledger — Failed` runs `always()`** (not `failure()`) in both jobs, because per-module failures deliberately do not fail the step that finds them; it reads the batch state and, when the leg itself crashed in a shared step, records the still-in-play modules as `pack` failures. Same records as before, one more input.
4. **Not exercised on a real run.** Evidence is: actionlint, the five workflow guards, the two lane-parsing Python tests, `module-pack-batch.py --self-test`, the Documentation.Test guards, and a dry-run that extracts the real `run:` bodies from the assembled YAML and executes them against a fake repo (one broken content half, one red suite) including the unchanged verifier. Nothing runs in the fleet until a satellite moves its `uses:` sha + `platform-ref` to a commit containing this — that is the safety net, and the first mover should be one repo at N=6 with a look at the leg durations.
5. `module-pack-batch.py`'s `chunk` output is a job output (`batches`), which duplicates the `modules` JSON in `GITHUB_OUTPUT` (job outputs are capped at 1 MB in total; Plugins' ~40 annotated entries are tens of KB).

## Verification outputs (verbatim)

```text
== actionlint
actionlint: node-repo-module-pack.yml ok (0 findings)
== check-workflow-timeouts
self-test: every case fired on its defect and stayed silent on its fix
check-workflow-timeouts: 86 job(s) checked, 5 reusable-call job(s) exempt, 0 violation(s), cap=45 min, root=<worktree>
== check-workflow-shell
self-test: all cases passed
1 finding(s): 0 live, 1 allow-listed, 0 stale entr(ies), 0 allow-file error(s)
== check-workflow-yaml-keys
self-test: every case fired on its defect and stayed silent on its fix
check-workflow-yaml-keys: 35 workflow file(s) and 0 composite action(s) checked, 0 violation(s), root=<worktree>
== check-pr-secret-preflight
self-test: every case fired on its defect and stayed silent on its fix
check-pr-secret-preflight: 2 secret(s) reachable on a Dependabot pull request, 2 asserted by a preflight, 0 violation(s), root=<worktree>
== check-workflow-permission-pairing
  27/27 control(s) passed
check-workflow-permission-pairing: 5 caller/lane permission pair(s) resolved, 0 violation(s), root=<worktree>
check-workflow-permission-pairing (fleet): 56 roster caller/lane pair(s) resolved, 0 violation(s), root=<worktree>, roster=<worktree>/.github/lane-caller-grants.yml
== self-tests
module-pack-batch: chunking, the per-module state, failure isolation and the verdict — all green
✓ node-repo-pack-verify self-test: 2 green-run assertions, 10 mutations that must go red, the two sibling-call receipts 
module-publication.py self-test: all cases pass
== lane-parsing tests
test-module-publication: both directions, the staged-evidence refusals, the caller mutations and the pack lane's staged arm — all green
all cases passed against .github/workflows/main-cd.yml steps `release` + `decide` + `verdict` + `heal` (extracted, not copied)
PASS — 2 lane(s), 7 case(s) each: divergent copies are refused and named, identical copies pass and are counted, and BOTH falsification arms behave.
== dry-run (real step bodies against a fake repo)
dry-run: the batched pack and tests step bodies behave per module — all green
== dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror
Passed!  - Failed:     0, Passed:   434, Skipped:     0, Total:   434, Duration: 17 s - MeshWeaver.Documentation.Test.dll (net10.0)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
