### PR TITLE
hosting-kv-ensure: compose the database connection string, keep it if present (Plugins#1721)

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -192,7 +192,7 @@ jobs:
         # through to a REAL az/kubectl on a runner that has one.
         run: |
           set -euo pipefail
-          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl deploy/aks/operator/test/stubs/inline-env/kubectl deploy/aks/operator/test/stubs/kv-rotate/az; do
+          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl deploy/aks/operator/test/stubs/inline-env/kubectl deploy/aks/operator/test/stubs/kv-rotate/az deploy/aks/operator/test/stubs/kv-ensure/az; do
             git ls-files --error-unmatch "$f" >/dev/null 2>&1 || { echo "::error::${f} is not tracked"; git check-ignore -v "$f" || true; exit 1; }
             [ "$(git ls-files -s "$f" | awk '{print $1}')" = "100755" ] || { echo "::error::${f} is not committed executable (mode 100755)"; exit 1; }
           done

--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -116,7 +116,13 @@ rule is in the mesh's pure, unit-tested plan. What the scripts themselves guaran
 - **`run.sh` stops at the first failure**, and the Job's `backoffLimit` is `0`. A half-finished
   teardown is never retried from the top, where it would re-dump over a verified archive.
 - **`hosting-kv-ensure` never overwrites an existing master key.** Regenerating it would make every
-  stored `enc:` value in that instance's database permanently unreadable.
+  stored `enc:` value in that instance's database permanently unreadable. The same rule covers the
+  **database connection string** it composes (MeshWeaver.Plugins#1721): with `--db-connection` the
+  object the record maps `ConnectionStrings__memex` from is written only when ABSENT, from the
+  record's host/port/user/database and the server password it reads from the vault
+  (`--db-password-secret`, `AZ_POSTGRES_PASSWORD_SECRET` on the control record's
+  `operator.environment`) — through `--file`, never an argument, never printed. An existing object
+  is kept as written.
 - **`hosting-export` never prints the URL it mints.** A user-delegation SAS is a bearer credential;
   it goes into a one-shot Secret the mesh reads once and deletes.
 - **`hosting-verify-catalog` proves the plugin mounts took.** An instance with green pods and an

--- a/deploy/aks/operator/bin/hosting-kv-ensure
+++ b/deploy/aks/operator/bin/hosting-kv-ensure
@@ -1,7 +1,19 @@
 #!/usr/bin/env bash
 # hosting-kv-ensure --vault <name> --prefix <prefix> --namespace <ns>
+#                   [--db-connection <vault object> --db-host <fqdn> --db-port <n> --db-user <user>
+#                    --db-name <database> --db-password-secret <vault object>]
 #
 # Make sure the per-instance Key Vault secrets EXIST, and mint the ones only this step can mint.
+#
+# The DATABASE CONNECTION STRING (MeshWeaver.Plugins#1721). The Provision creates the database one
+# step earlier, but the string the portal reads — the object the record maps
+# `ConnectionStrings__memex` from — used to be written by hand (runbook step 3), and a declared
+# vault object the vault does not hold fails the WHOLE CSI mount: every pod in ContainerCreating
+# (Memex#202). With --db-connection the object is COMPOSED here from the record's typed fields and
+# the server's admin password, which this identity reads from the vault (--db-password-secret) and
+# never prints: the string goes into a mode-600 temporary and reaches az through --file, never an
+# argument. An existing object is KEPT, exactly like the master key — a hand-written string with a
+# different user or a rotated password is not this step's to replace.
 #
 # 🚨 IT NEVER OVERWRITES AN EXISTING SECRET, and the master key is why. `Ai-KeyProtection-MasterKey`
 # is the at-rest envelope key: every `enc:` provider key in that instance's database is sealed with
@@ -15,11 +27,18 @@ source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
 HOSTING_CMD="hosting-kv-ensure"
 
 vault="" prefix="" namespace=""
+db_connection="" db_host="" db_port="" db_user="" db_name="" db_password_secret=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --vault)     vault="${2:-}";     shift 2 ;;
-    --prefix)    prefix="${2:-}";    shift 2 ;;
-    --namespace) namespace="${2:-}"; shift 2 ;;
+    --vault)              vault="${2:-}";              shift 2 ;;
+    --prefix)             prefix="${2:-}";             shift 2 ;;
+    --namespace)          namespace="${2:-}";          shift 2 ;;
+    --db-connection)      db_connection="${2:-}";      shift 2 ;;
+    --db-host)            db_host="${2:-}";            shift 2 ;;
+    --db-port)            db_port="${2:-}";            shift 2 ;;
+    --db-user)            db_user="${2:-}";            shift 2 ;;
+    --db-name)            db_name="${2:-}";            shift 2 ;;
+    --db-password-secret) db_password_secret="${2:-}"; shift 2 ;;
     *) hosting::die "unknown argument '$1'" ;;
   esac
 done
@@ -29,6 +48,17 @@ hosting::need_flag namespace "$namespace"
 hosting::safe_name vault "$vault"
 hosting::safe_name namespace "$namespace"
 [ -z "$prefix" ] || hosting::safe_name prefix "$prefix"
+# The connection-string inputs are validated up front, whether or not the object turns out to
+# exist: every one of them is interpolated — into a vault object name, a host, a connection string
+# the portal parses — and a value that is not a plain token refuses BEFORE the vault is read.
+[ -z "$db_connection" ] || hosting::safe_name db-connection "$db_connection"
+[ -z "$db_host" ] || hosting::safe_host db-host "$db_host"
+[ -z "$db_user" ] || hosting::safe_name db-user "$db_user"
+[ -z "$db_name" ] || hosting::safe_name db-name "$db_name"
+[ -z "$db_password_secret" ] || hosting::safe_name db-password-secret "$db_password_secret"
+if [ -n "$db_port" ] && ! [[ "$db_port" =~ ^[0-9]{1,5}$ ]]; then
+  hosting::die "db-port '${db_port}' is not a port number — refusing to compose a connection string from it"
+fi
 
 # The per-instance secrets an instance cannot boot without. Names are the vault's, dash-separated;
 # the SecretProviderClass maps each onto its config key (see secretproviderclass.reference.yaml in
@@ -74,6 +104,53 @@ done
 
 if [ ${#missing[@]} -gt 0 ]; then
   hosting::die "vault ${vault} is missing $(IFS=,; echo "${missing[*]}"). These are ISSUED, not generated — a registry consumer key comes from the registry installation (see the plugin registry docs), and minting a random value here would produce an instance that boots, registers nothing, and shows an empty Store with no error. Create them in the vault, then re-request the action."
+fi
+
+# ── the database connection string ────────────────────────────────────────────────────────────
+# Only when the plan names the object (--db-connection). KEPT when it exists — never rewritten, not
+# even when the record's fields would compose a different string: an operator who changed the
+# user or rotated the password by hand did so on purpose, and the master-key rule applies. Composed
+# only when ABSENT, from the record's fields and the server password read out of the vault.
+if [ -n "$db_connection" ]; then
+  if kv_exists "$db_connection"; then
+    hosting::log "keep    ${db_connection} (exists — never rewritten: it is the string the portal reads)"
+    kept=$((kept + 1))
+    hosting::say kv_db_connection kept
+  else
+    # Every input, or a refusal naming the flag and the one hand command that still works.
+    manual="az keyvault secret set --vault-name ${vault} --name ${db_connection} --file <file holding Host=…;Port=…;Username=…;Password=…;Database=…;SslMode=Require;Trust Server Certificate=true>"
+    for pair in "db-host:$db_host" "db-port:$db_port" "db-user:$db_user" "db-name:$db_name" "db-password-secret:$db_password_secret"; do
+      [ -n "${pair#*:}" ] \
+        || hosting::die "${db_connection} is absent from vault ${vault} and cannot be composed: missing --${pair%%:*}. The plan passes --db-password-secret from AZ_POSTGRES_PASSWORD_SECRET on the control record's operator.environment (the vault object holding the server's admin password, e.g. memex-postgres-password) — set it and re-request the action, or write the object by hand: ${manual}"
+    done
+    hosting::log "create  ${db_connection} (Host=${db_host};Port=${db_port};Username=${db_user};Database=${db_name}; the password is read from ${db_password_secret} and never shown)"
+    if hosting::dry; then
+      created=$((created + 1))
+      hosting::say kv_db_connection would-create
+    else
+      # The password lives in one shell variable, goes into a mode-600 temporary and reaches az
+      # through --file: never an argument (argv is readable by every process in the pod, and
+      # hosting::do would echo it), never a ::hosting:: fact, never a log line.
+      db_password="$(az keyvault secret show --vault-name "$vault" --name "$db_password_secret" --query value -o tsv 2>/dev/null)" \
+        || hosting::die "could not read ${db_password_secret} from vault ${vault} — the server's admin password this identity composes the connection string from. Nothing was written. Grant the operator identity secret GET on it, or write the object by hand: ${manual}"
+      [ -n "$db_password" ] \
+        || hosting::die "vault ${vault} object ${db_password_secret} is EMPTY — a connection string with no password fails at NpgsqlConnector.RawOpen with nothing naming this step. Nothing was written."
+      umask 077
+      db_file="$(mktemp)"
+      trap 'rm -f "$db_file"' EXIT
+      printf 'Host=%s;Port=%s;Username=%s;Password=%s;Database=%s;SslMode=Require;Trust Server Certificate=true' \
+        "$db_host" "$db_port" "$db_user" "$db_password" "$db_name" > "$db_file"
+      unset db_password
+      az keyvault secret set --vault-name "$vault" --name "$db_connection" --file "$db_file" --output none \
+        || hosting::die "could not create ${db_connection} in vault ${vault}. Nothing was written; the hand command is: ${manual}"
+      rm -f "$db_file"
+      kv_exists "$db_connection" \
+        || hosting::die "${db_connection} was written to vault ${vault} but cannot be read back — refusing to report a secret the CSI driver will not find"
+      hosting::log "created ${db_connection} in vault ${vault} (read back by id)"
+      created=$((created + 1))
+      hosting::say kv_db_connection created
+    fi
+  fi
 fi
 
 hosting::log "vault ${vault}: ${created} created, ${kept} already present"

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -325,6 +325,89 @@ case "$_ps_out" in *"pull_secret_verify=true"*) bad "a dry-run pull-secret never
 unset _ps_out _ps_rc _ps_dir _ps_log _ns_line _sec_line
 
 echo
+echo "── hosting-kv-ensure: the connection string is composed, kept, never shown ──"
+# MeshWeaver.Plugins#1721 — the Provision creates the database but the string the portal reads
+# (<prefix>db-connection, mapped as ConnectionStrings__memex) was written by hand, and a declared
+# vault object the vault does not hold fails the whole CSI mount (Memex#202). The stub answers the
+# vault from a state directory and records every argv, so the decisions — compose only when
+# ABSENT, keep when present, read the password by name and never print it — are asserted here.
+KVE_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/kv-ensure" && pwd)"
+kve() {  # kve [env…] -- <args…> — runs against a fresh state dir; sets $_kve_out $_kve_rc $_kve_log $_kve_state
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done; shift
+  _kve_state="$(mktemp -d)"
+  _kve_out="$(env "${envs[@]}" PATH="$KVE_STUBS:$PATH" HOSTING_KVE_STATE="$_kve_state" hosting-kv-ensure "$@" 2>&1)"; _kve_rc=$?
+  _kve_log="$(cat "$_kve_state/az.log" 2>/dev/null || true)"
+}
+KVE_DB=(--db-connection acme-db-connection --db-host pg.postgres.database.azure.com --db-port 5432 --db-user memexadmin --db-name acmedb --db-password-secret memex-postgres-password)
+
+# Absent: composed from the flags and the password read from the vault, written through --file.
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" HOSTING_KVE_PASSWORD_OBJECT=memex-postgres-password \
+  -- --vault Systemorph --prefix acme- --namespace acme "${KVE_DB[@]}"
+[ "$_kve_rc" -eq 0 ] && ok "kv-ensure composes an ABSENT db-connection object" || bad "kv-ensure composes an absent db-connection" "exited ${_kve_rc}: ${_kve_out}"
+_kve_written="$(cat "$_kve_state/set.acme-db-connection" 2>/dev/null || true)"
+if [ "$_kve_written" = "Host=pg.postgres.database.azure.com;Port=5432;Username=memexadmin;Password=fake-server-password-NEVER-PRINTED;Database=acmedb;SslMode=Require;Trust Server Certificate=true" ]; then
+  ok "…in exactly the shape the portal parses (Host;Port;Username;Password;Database;SslMode;Trust Server Certificate)"
+else
+  bad "the composed string has the portal's shape" "wrote: ${_kve_written}"
+fi
+case "$_kve_out" in *NEVER-PRINTED*) bad "kv-ensure never prints the server password" "it did: ${_kve_out}" ;; *) ok "kv-ensure never prints the server password" ;; esac
+case "$_kve_log" in *NEVER-PRINTED*) bad "…and never puts it on an az command line (argv)" "az saw: ${_kve_log}" ;; *) ok "…and never puts it on an az command line (argv)" ;; esac
+case "$_kve_log" in *"secret set --vault-name Systemorph --name acme-db-connection --file "*) ok "the string reaches az through --file" ;; *) bad "the string reaches az through --file" "az saw: ${_kve_log}" ;; esac
+case "$_kve_out" in *"::hosting:: kv_db_connection=created"*) ok "the run reports kv_db_connection=created" ;; *) bad "the run reports created" "said: ${_kve_out}" ;; esac
+case "$_kve_out" in *"::hosting:: kv_created=1"*) ok "…and counts it among the created objects" ;; *) bad "created count" "said: ${_kve_out}" ;; esac
+rm -rf "$_kve_state"
+
+# Present: KEPT — no read of the password, no write — the master-key rule, one object over.
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken acme-db-connection" HOSTING_KVE_PASSWORD_OBJECT=memex-postgres-password \
+  -- --vault Systemorph --prefix acme- --namespace acme "${KVE_DB[@]}"
+[ "$_kve_rc" -eq 0 ] && ok "an EXISTING db-connection object is kept (a re-provision is idempotent)" || bad "existing db-connection is kept" "exited ${_kve_rc}: ${_kve_out}"
+case "$_kve_log" in *"secret set"*"acme-db-connection"*) bad "a kept object is never rewritten" "az saw: ${_kve_log}" ;; *) ok "a kept object is never rewritten" ;; esac
+case "$_kve_log" in *"memex-postgres-password"*) bad "…and the password is not even read" "az saw: ${_kve_log}" ;; *) ok "…and the password is not even read" ;; esac
+case "$_kve_out" in *"::hosting:: kv_db_connection=kept"*) ok "the run reports kv_db_connection=kept" ;; *) bad "reports kept" "said: ${_kve_out}" ;; esac
+case "$_kve_out" in *"::hosting:: kv_kept=3"*) ok "…and the three present objects are counted" ;; *) bad "kept count" "said: ${_kve_out}" ;; esac
+rm -rf "$_kve_state"
+
+# A record that names no db-connection plans none: today's command line, unchanged.
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" -- --vault Systemorph --prefix acme- --namespace acme
+[ "$_kve_rc" -eq 0 ] && ok "without --db-connection nothing about the database is touched" || bad "without --db-connection" "exited ${_kve_rc}: ${_kve_out}"
+case "$_kve_out" in *kv_db_connection*) bad "…and no kv_db_connection fact is reported" "said: ${_kve_out}" ;; *) ok "…and no kv_db_connection fact is reported" ;; esac
+rm -rf "$_kve_state"
+
+# The refusals, each naming the hand command that still works.
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" HOSTING_KVE_PASSWORD_OBJECT=other \
+  -- --vault Systemorph --prefix acme- --namespace acme "${KVE_DB[@]}"
+[ "$_kve_rc" -ne 0 ] && ok "an unreadable password object refuses" || bad "unreadable password refuses" "exited 0: ${_kve_out}"
+case "$_kve_out" in *"could not read memex-postgres-password"*"az keyvault secret set --vault-name Systemorph --name acme-db-connection --file"*) ok "…naming the object and the exact hand command" ;; *) bad "names the hand command" "said: ${_kve_out}" ;; esac
+case "$_kve_log" in *"secret set"*"acme-db-connection"*) bad "…and writes nothing" "az saw: ${_kve_log}" ;; *) ok "…and writes nothing" ;; esac
+rm -rf "$_kve_state"
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" HOSTING_KVE_PASSWORD_OBJECT=memex-postgres-password \
+  -- --vault Systemorph --prefix acme- --namespace acme --db-connection acme-db-connection --db-host pg.postgres.database.azure.com --db-port 5432 --db-user memexadmin --db-name acmedb --db-password-secret ""
+[ "$_kve_rc" -ne 0 ] && ok "an absent object with no password secret named refuses" || bad "no password secret refuses" "exited 0: ${_kve_out}"
+case "$_kve_out" in *"missing --db-password-secret"*"AZ_POSTGRES_PASSWORD_SECRET"*) ok "…naming the flag and the operator.environment key that supplies it" ;; *) bad "names AZ_POSTGRES_PASSWORD_SECRET" "said: ${_kve_out}" ;; esac
+rm -rf "$_kve_state"
+kve HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" HOSTING_KVE_PASSWORD_OBJECT=memex-postgres-password HOSTING_KVE_SET_FAIL=1 \
+  -- --vault Systemorph --prefix acme- --namespace acme "${KVE_DB[@]}"
+[ "$_kve_rc" -ne 0 ] && ok "a vault that refuses the write fails the step" || bad "refused write fails" "exited 0: ${_kve_out}"
+case "$_kve_out" in *NEVER-PRINTED*) bad "…without printing the password on the failure path" "it did: ${_kve_out}" ;; *) ok "…without printing the password on the failure path" ;; esac
+rm -rf "$_kve_state"
+refuses_hard "kv-ensure refuses a db-host that is not a hostname" "is not a hostname" \
+  hosting-kv-ensure --vault V --namespace n --db-connection c --db-host 'pg;id' --db-port 5432 --db-user u --db-name d --db-password-secret p
+refuses_hard "kv-ensure refuses a db-port that is not a number" "is not a port number" \
+  hosting-kv-ensure --vault V --namespace n --db-connection c --db-host pg.test --db-port '5432;id' --db-user u --db-name d --db-password-secret p
+refuses_hard "kv-ensure refuses a db-connection object with a metacharacter" "is not a plain name" \
+  hosting-kv-ensure --vault V --namespace n --db-connection 'c`id`' --db-host pg.test --db-port 5432 --db-user u --db-name d --db-password-secret p
+
+# A dry run reads no password, writes nothing, and says what it would create.
+kve HOSTING_DRY_RUN=true HOSTING_KVE_EXISTING="acme-Ai-KeyProtection-MasterKey acme-PluginCatalog-RegistryToken" HOSTING_KVE_PASSWORD_OBJECT=memex-postgres-password \
+  -- --vault Systemorph --prefix acme- --namespace acme "${KVE_DB[@]}"
+[ "$_kve_rc" -eq 0 ] && ok "a dry-run kv-ensure with --db-connection succeeds" || bad "dry-run kv-ensure" "exited ${_kve_rc}: ${_kve_out}"
+case "$_kve_log" in *"memex-postgres-password"*|*"secret set"*) bad "a dry run neither reads the password nor writes" "az saw: ${_kve_log}" ;; *) ok "a dry run neither reads the password nor writes" ;; esac
+case "$_kve_out" in *"::hosting:: kv_db_connection=would-create"*) ok "…and reports would-create, never created" ;; *) bad "dry run reports would-create" "said: ${_kve_out}" ;; esac
+rm -rf "$_kve_state"
+unset _kve_out _kve_rc _kve_log _kve_state _kve_written
+
+echo
 echo "── the ::hosting:: contract the mesh parses ──────────────────────"
 emits "dry-run backup announces the object" "::hosting:: object=arch-1" \
   env HOSTING_DRY_RUN=true hosting-backup --database d --server s --store-uri https://x/y/z --object arch-1

--- a/deploy/aks/operator/test/stubs/kv-ensure/az
+++ b/deploy/aks/operator/test/stubs/kv-ensure/az
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# A stand-in `az` for hosting-kv-ensure's behaviour tests (MeshWeaver.Plugins#1721). It records
+# every invocation VERBATIM — argv is how the test proves the server password and the composed
+# connection string never travel on a command line — and answers the vault from a small state:
+#
+#   HOSTING_KVE_STATE            directory: az.log (every argv), set.<name> (what a `set --file` wrote)
+#   HOSTING_KVE_EXISTING         space-separated object names `keyvault secret show` answers with an id
+#   HOSTING_KVE_PASSWORD_OBJECT  the one object whose `show --query value` answers HOSTING_KVE_PASSWORD
+#   HOSTING_KVE_PASSWORD         a sentinel the test greps for (default: an obviously fake one)
+#   HOSTING_KVE_SET_FAIL=1       every `keyvault secret set` refuses
+#
+# Not a mock of az: nothing here asserts az's own behaviour. What is under test is which objects
+# the script reads, which it writes, with what content, and what it never prints.
+set -uo pipefail
+state="${HOSTING_KVE_STATE:?the az stub needs HOSTING_KVE_STATE}"
+printf 'az %s\n' "$*" >> "$state/az.log"
+case "${1:-} ${2:-} ${3:-}" in
+  "keyvault secret show")
+    name="" query=""
+    while [ $# -gt 0 ]; do case "$1" in --name) name="${2:-}"; shift 2 ;; --query) query="${2:-}"; shift 2 ;; *) shift ;; esac; done
+    if [ "$query" = "value" ]; then
+      if [ "$name" = "${HOSTING_KVE_PASSWORD_OBJECT:-}" ]; then printf '%s\n' "${HOSTING_KVE_PASSWORD-fake-server-password-NEVER-PRINTED}"; exit 0; fi
+      echo "ERROR: (SecretNotFound) A secret with (name/id) ${name} was not found in this key vault." >&2; exit 3
+    fi
+    for existing in ${HOSTING_KVE_EXISTING:-}; do
+      if [ "$existing" = "$name" ]; then printf 'https://vault.test/secrets/%s/0\n' "$name"; exit 0; fi
+    done
+    # an object this run created is readable afterwards (the read-back the script does)
+    if [ -f "$state/set.$name" ]; then printf 'https://vault.test/secrets/%s/1\n' "$name"; exit 0; fi
+    echo "ERROR: (SecretNotFound) A secret with (name/id) ${name} was not found in this key vault." >&2; exit 3 ;;
+  "keyvault secret set")
+    [ "${HOSTING_KVE_SET_FAIL:-0}" = "1" ] && { echo "ERROR: (Forbidden) The user, group or application does not have secrets set permission" >&2; exit 1; }
+    name="" file="" value=""
+    while [ $# -gt 0 ]; do case "$1" in --name) name="${2:-}"; shift 2 ;; --file) file="${2:-}"; shift 2 ;; --value) value="${2:-}"; shift 2 ;; *) shift ;; esac; done
+    if [ -n "$file" ]; then [ -f "$file" ] || { echo "az stub: --file ${file} does not exist" >&2; exit 1; }; cp "$file" "$state/set.$name"
+    else printf '%s' "$value" > "$state/set.$name"; fi
+    exit 0 ;;
+esac
+echo "az stub: unexpected invocation: $*" >&2
+exit 1


### PR DESCRIPTION
Operator half of MeshWeaver.Plugins#1721 (the plan half is the paired Plugins PR; `Pairs-with: none — this PR removes no public surface`).

## The hand step it replaces

Memex `docs/new-deployment.md` step 3, *"The database connection string → `<prefix>db-connection`"*:

> The Provision creates the database (`az postgres flexible-server db create`), but the connection string the portal reads is a vault secret **you** write.

## What changes

`hosting-kv-ensure` takes `--db-connection <object> --db-host <fqdn> --db-port <n> --db-user <user> --db-name <db> --db-password-secret <object>`:

- **absent** → composes `Host=…;Port=…;Username=…;Password=…;Database=…;SslMode=Require;Trust Server Certificate=true` (the runbook's exact shape) from the flags and the server password it reads from the vault, writes it through `--file` (never argv), reads it back by id, reports `::hosting:: kv_db_connection=created`;
- **present** → **KEPT**, no password read, no write — the same rule as `<prefix>Ai-KeyProtection-MasterKey`; reports `kv_db_connection=kept`;
- every input is gated (`safe_name`/`safe_host`/port) before the vault is touched; every refusal names the exact hand command;
- dry run reads no password, writes nothing, reports `kv_db_connection=would-create`.

Without `--db-connection` the command line is unchanged (today's plans keep working).

## Rights the operator identity needs

Key Vault **secret get** on the server password object (`memex-postgres-password`) and **set** on `<prefix>db-connection` — both covered by the *Key Vault Secrets Officer* grant on `Systemorph` (OperatorEnablement step 2). Nothing new. The password object's NAME reaches the plan from `AZ_POSTGRES_PASSWORD_SECRET` on the control record's `operator.environment` (Memex record change in the follow-up Memex PR).

## Gates run

```
$ bash deploy/aks/operator/test/run-tests.sh
318 passed, 0 failed          (291 on main; +27 new hosting-kv-ensure cases)
$ shellcheck -S warning deploy/aks/operator/bin/_common.sh deploy/aks/operator/bin/run.sh deploy/aks/operator/bin/hosting-* deploy/aks/operator/test/stubs/kv-ensure/az
(clean)
```

## Ships how

Hop (C): `hosting-operator.yml` publishes `hosting-operator:<sha>` on the merge to `main`; the step reaches a Provision when `operator.image` on `Deployments/memex` moves to that sha. Merging is not shipping.

Closes: nothing here — MeshWeaver.Plugins#1721 is closed by the plan PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
