### PR TITLE
fix(#4097): a module refused by plan tier says so on the instance — /health, the package card and the self-updater name the tier, not the consequence

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -153,30 +153,61 @@ public static class PluginRegistryEndpoints
     // hold a whole source (Plugins/*) or a single plugin out of one (Reinsurance/UWDeepfield) — so
     // the filter runs BEFORE the merge, while each package still knows which source it came from.
     // A caller therefore cannot even learn that an ungranted package exists.
-    private static IObservable<IReadOnlyList<PackageManifest>> ListAll(
+    //
+    // 🚨 #4097 — with ONE exception that is not enumeration: a package this registry itself
+    // declares in the caller's DEFAULT SET (preInstalled) from a source the caller's grant
+    // REACHES, refused only by the caller's PLAN. That verdict used to be logged here and omitted
+    // from the wire, so the instance showed every consequence (canPatch=False, "required module
+    // not installed — install it from the registry", which it cannot) and never the cause. It now
+    // rides beside the listing as a typed refusal — package, required tier, instance plan. A
+    // package from an UNGRANTED source stays absent, tier or no tier: TierRefusal answers only
+    // when some entry reaches the package.
+    private static IObservable<RegistryListing> ListAll(
         IReadOnlyList<ConfiguredPackageSource> sources, AuthenticatedInstance? caller,
         IObservable<IReadOnlyList<PublicationArtifact>> artifacts, ILogger? logger)
         => Observable.CombineLatest(sources.Select(s =>
                 ListFrom(s, sources.Count == 1, logger).Select(list => (Source: s, Packages: list))))
-            .SelectMany(perSource => artifacts.Select(pushed => (IReadOnlyList<PackageManifest>)perSource
+            .SelectMany(perSource => artifacts.Select(pushed => new RegistryListing
+            {
                 // Stamp the source each package came from BEFORE the merge — afterwards the
                 // provenance is gone. Consumers scope source-specific actions on it (notably
                 // PluginCatalog:InstallByDefault, which must distinguish the platform repo from
                 // paid content the same instance may also be granted).
+                Packages = perSource
+                    .SelectMany(x => x.Packages
+                        .Where(p => IsGranted(caller, x.Source, p))
+                        .Select(p => p with
+                        {
+                            Source = x.Source.Name,
+                            // The bundle as an OCI artifact in the fleet's registry
+                            // (Doc/Architecture/PluginBundlesInTheRegistry), when this registry has
+                            // pushed it — matched on the content version manifest.lock gives the
+                            // bundle, then the catalog's own version. Null otherwise; additive.
+                            Artifact = pushed.ReferenceFor(
+                                x.Source.Name, p.Id, p.ReleasedVersion, p.ModuleVersion, p.Version),
+                        }))
+                    .DistinctBy(p => p.Id, StringComparer.Ordinal)
+                    .ToList(),
+                Refused = TierRefusals(caller, perSource),
+            }));
+
+    /// <summary>The default-set packages the caller's plan refuses (#4097): pre-installed, from a
+    /// source the grant reaches, not covered by the plan. Empty for the legacy anonymous caller
+    /// (nothing is refused to it) and for every package the enumeration defence must hide.</summary>
+    internal static IReadOnlyList<PlanTierRefusal> TierRefusals(
+        AuthenticatedInstance? caller,
+        IEnumerable<(ConfiguredPackageSource Source, IReadOnlyList<PackageManifest> Packages)> perSource)
+        => caller is null
+            ? []
+            : perSource
                 .SelectMany(x => x.Packages
-                    .Where(p => IsGranted(caller, x.Source, p))
-                    .Select(p => p with
-                    {
-                        Source = x.Source.Name,
-                        // The bundle as an OCI artifact in the fleet's registry
-                        // (Doc/Architecture/PluginBundlesInTheRegistry), when this registry has
-                        // pushed it — matched on the content version manifest.lock gives the
-                        // bundle, then the catalog's own version. Null otherwise; additive.
-                        Artifact = pushed.ReferenceFor(
-                            x.Source.Name, p.Id, p.ReleasedVersion, p.ModuleVersion, p.Version),
-                    }))
-                .DistinctBy(p => p.Id, StringComparer.Ordinal)
-                .ToList()));
+                    .Where(p => p.PreInstalled && !IsGranted(caller, x.Source, p))
+                    .Select(p => caller.TierRefusal(x.Source.Name, p.Id, p.Tier, p.Module))
+                    .Where(r => r is not null)
+                    .Select(r => r!))
+                .DistinctBy(r => r.PackageId, StringComparer.Ordinal)
+                .OrderBy(r => r.PackageId, StringComparer.Ordinal)
+                .ToList();
 
     /// <summary>The registry's record of pushed publications, read once per listing; the platform
     /// default records nothing.</summary>
@@ -200,7 +231,18 @@ public static class PluginRegistryEndpoints
         if (sources.Count == 0)
             return Task.FromResult(Results.Content(PluginRegistryPayloads.List([]), "application/json"));
         return ListAll(sources, caller, Artifacts(hub), logger)
-            .Select(list => (IResult)Results.Content(PluginRegistryPayloads.List(list), "application/json"))
+            .Do(listing =>
+            {
+                // Named on the registry too, as before #4097 — now beside the wire answer rather
+                // than instead of it.
+                if (listing.Refused.Count > 0)
+                    logger?.LogInformation(
+                        "Plugin registry: {Count} default-set package(s) refused to {Instance} by plan tier: {Refused}",
+                        listing.Refused.Count, caller?.Instance.InstanceId ?? "(anonymous)",
+                        string.Join("; ", listing.Refused.Select(r => r.Describe())));
+            })
+            .Select(listing => (IResult)Results.Content(
+                PluginRegistryPayloads.List(listing.Packages, listing.Refused), "application/json"))
             .Catch((Exception ex) =>
             {
                 // Surface the failure (502) rather than hide it as an empty catalog — the consumer's

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -45,6 +45,7 @@ public class SelfUpdateHostedService : IHostedService
     private readonly SelfUpdateOptions _options;
     private readonly ILogger<SelfUpdateHostedService>? _logger;
     private readonly IIoPool _http;
+    private readonly IIoPool _fileSystem;
     private IDisposable? _subscription;
 
     /// <summary>
@@ -88,26 +89,35 @@ public class SelfUpdateHostedService : IHostedService
         // The ACR list + the k8s PATCH are outbound HTTP → the Http resource class. Falls back to the
         // stateless unbounded pool when no registry is wired (tests).
         _http = registry?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        // The one file read this poller makes — the activation record's plan-tier marker for the
+        // patcher's module (#4097) — goes through the FileSystem resource class, never inline on
+        // the hosted-service startup thread: the module root can be a slow shared volume.
+        _fileSystem = registry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
     }
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
-        // 🚨 #4097 — canPatch=False used to be the whole story, and it pointed at
-        // Modules:Assemblies. When the patcher's package was refused by the instance's PLAN, the
-        // line now says so: the tier it needs and the plan the instance is on.
-        var cannotPatch = _updater.CanPatch
-            ? string.Empty
-            : UnavailableUpdateMechanics.DescribeCannotPatch(
-                UnavailableUpdateMechanics.PatcherTierRefusal(_hub.ServiceProvider.GetService<IConfiguration>()));
         _logger?.LogInformation(
             "[SelfUpdate] starting (event-driven, with a {SafetyNet} safety net); version={Version}, "
-            + "registry={Registry}/{Repo} listed as {RegistryKind}, canPatch={CanPatch}{CannotPatch}, retryInterval={Interval}.",
+            + "registry={Registry}/{Repo} listed as {RegistryKind}, canPatch={CanPatch}, retryInterval={Interval}.",
             _options.SafetyNetCheckInterval > TimeSpan.Zero
                 ? _options.SafetyNetCheckInterval.ToString()
                 : "disabled",
             ShippedReleaseSeed.InstalledPlatformVersion, _options.Registry, _options.PortalRepository,
             UsesOciListing ? "an OCI Distribution registry (the mirror, instance-key auth)" : "an Azure Container Registry",
-            _updater.CanPatch, cannotPatch, _options.RetryInterval);
+            _updater.CanPatch, _options.RetryInterval);
+
+        // 🚨 #4097 — canPatch=False used to be the whole story, and it pointed at
+        // Modules:Assemblies. When the patcher's package was refused by the instance's PLAN, the
+        // startup log now says so — the tier it needs and the plan the instance is on — as the
+        // next [SelfUpdate] line, read off the activation record on the FileSystem pool so the
+        // hosted-service startup thread never waits on the module volume.
+        if (!_updater.CanPatch)
+            CannotPatchReason()
+                .Subscribe(
+                    reason => _logger?.LogInformation("[SelfUpdate] canPatch=False{Reason}", reason),
+                    ex => _logger?.LogWarning(ex,
+                        "[SelfUpdate] could not read why this install cannot patch — the activation record was unreadable"));
 
         // 🚨 EVENT-DRIVEN WITH A SAFETY NET, and the event source is deliberately OUTSIDE the
         // policy stream.
@@ -347,17 +357,25 @@ public class SelfUpdateHostedService : IHostedService
                 });
         });
 
+    /// <summary>Why this install cannot patch, as the qualifier after <c>canPatch=False</c> (#4097):
+    /// the plan-tier sentence when the patcher's package was refused by the instance's plan, else
+    /// the standing hint. One file read on the FileSystem pool; emits once.</summary>
+    private IObservable<string> CannotPatchReason()
+    {
+        var configuration = _hub.ServiceProvider.GetService<IConfiguration>();
+        return _fileSystem
+            .InvokeBlocking(_ => UnavailableUpdateMechanics.PatcherTierRefusal(configuration))
+            .Select(UnavailableUpdateMechanics.DescribeCannotPatch);
+    }
+
     /// <summary>The restart itself: detect-only says so; the floor defers; otherwise the updater rolls
     /// the running image, or reports that it cannot.</summary>
     private IObservable<SelfUpdateVerdict> Restart(SelfUpdateVerdict platform)
     {
         var installed = ShippedReleaseSeed.InstalledPlatformVersion;
         if (!_updater.CanPatch)
-            return Observable.Return(SelfUpdateVerdict.RestartUnavailable(
-                platform, installed,
-                "this install does not self-patch"
-                + UnavailableUpdateMechanics.DescribeCannotPatch(
-                    UnavailableUpdateMechanics.PatcherTierRefusal(_hub.ServiceProvider.GetService<IConfiguration>()))));
+            return CannotPatchReason().Select(reason => SelfUpdateVerdict.RestartUnavailable(
+                platform, installed, "this install does not self-patch" + reason));
 
         // The same floor read Apply makes, and skipped for the same reason when the floor is off:
         // LastRolledAtAsync is a Kubernetes GET whose answer cannot change a decision the floor

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -92,15 +92,22 @@ public class SelfUpdateHostedService : IHostedService
 
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // 🚨 #4097 — canPatch=False used to be the whole story, and it pointed at
+        // Modules:Assemblies. When the patcher's package was refused by the instance's PLAN, the
+        // line now says so: the tier it needs and the plan the instance is on.
+        var cannotPatch = _updater.CanPatch
+            ? string.Empty
+            : UnavailableUpdateMechanics.DescribeCannotPatch(
+                UnavailableUpdateMechanics.PatcherTierRefusal(_hub.ServiceProvider.GetService<IConfiguration>()));
         _logger?.LogInformation(
             "[SelfUpdate] starting (event-driven, with a {SafetyNet} safety net); version={Version}, "
-            + "registry={Registry}/{Repo} listed as {RegistryKind}, canPatch={CanPatch}, retryInterval={Interval}.",
+            + "registry={Registry}/{Repo} listed as {RegistryKind}, canPatch={CanPatch}{CannotPatch}, retryInterval={Interval}.",
             _options.SafetyNetCheckInterval > TimeSpan.Zero
                 ? _options.SafetyNetCheckInterval.ToString()
                 : "disabled",
             ShippedReleaseSeed.InstalledPlatformVersion, _options.Registry, _options.PortalRepository,
             UsesOciListing ? "an OCI Distribution registry (the mirror, instance-key auth)" : "an Azure Container Registry",
-            _updater.CanPatch, _options.RetryInterval);
+            _updater.CanPatch, cannotPatch, _options.RetryInterval);
 
         // 🚨 EVENT-DRIVEN WITH A SAFETY NET, and the event source is deliberately OUTSIDE the
         // policy stream.
@@ -347,7 +354,10 @@ public class SelfUpdateHostedService : IHostedService
         var installed = ShippedReleaseSeed.InstalledPlatformVersion;
         if (!_updater.CanPatch)
             return Observable.Return(SelfUpdateVerdict.RestartUnavailable(
-                platform, installed, "this install does not self-patch (detect-and-notify)"));
+                platform, installed,
+                "this install does not self-patch"
+                + UnavailableUpdateMechanics.DescribeCannotPatch(
+                    UnavailableUpdateMechanics.PatcherTierRefusal(_hub.ServiceProvider.GetService<IConfiguration>()))));
 
         // The same floor read Apply makes, and skipped for the same reason when the floor is off:
         // LastRolledAtAsync is a Kubernetes GET whose answer cannot change a decision the floor

--- a/memex/Memex.Portal.Shared/SelfUpdate/UnavailableUpdateMechanics.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UnavailableUpdateMechanics.cs
@@ -1,5 +1,9 @@
-using Microsoft.Extensions.Logging;
+using System.IO;
 using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.SelfUpdate;
 
@@ -20,6 +24,42 @@ namespace Memex.Portal.Shared.SelfUpdate;
 /// </summary>
 internal static class UnavailableUpdateMechanics
 {
+    /// <summary>The module that supplies the ACR reader and the Kubernetes patcher — what
+    /// <see cref="IDeploymentUpdater.CanPatch"/> is false without. Ships in the registry's
+    /// <c>Hosting</c> package (<c>tier: enterprise</c>), which is why a lower-plan instance runs
+    /// detect-only (#4097).</summary>
+    internal const string PatcherModule = "MeshWeaver.SelfUpdate.Aks";
+
+    /// <summary>
+    /// 🚨 WHY this install cannot patch, when the reason is the instance's PLAN (#4097): the
+    /// registry declared the patcher's package in the default set and refused it by tier, and the
+    /// default install recorded that on the activation record. Read at startup so the
+    /// <c>canPatch=False</c> line names the tier instead of pointing at <c>Modules:Assemblies</c>,
+    /// which is not where the module was going to come from. Null when no such refusal is
+    /// recorded — a non-Kubernetes install, or a plan that covers the package.
+    /// </summary>
+    internal static PlanTierRefusal? PatcherTierRefusal(IConfiguration? configuration)
+    {
+        try
+        {
+            return ModuleActivationSidecar.ReadTierRefusals(ModuleRoot.Resolve(configuration))
+                .Values.FirstOrDefault(r => r.IsForModule(PatcherModule));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>The startup line's qualifier after <c>canPatch=False</c>: the plan-tier sentence
+    /// when the patcher's package was refused by plan, otherwise the standing hint.</summary>
+    internal static string DescribeCannotPatch(PlanTierRefusal? patcherRefusal) =>
+        patcherRefusal is { } refused
+            ? $" ({refused.Describe()} The Kubernetes patcher ships in that package, so this install "
+              + "runs detect-and-notify until the instance's plan covers it.)"
+            : $" (detect-and-notify: list {PatcherModule} under Modules:Assemblies for a Kubernetes install, "
+              + "or install the Hosting package from the registry)";
+
     /// <summary>
     /// Reports no tags, so the poller finds no candidate version. Correct for an install with no
     /// container registry to read: the alternative — leaving <see cref="IAcrTagLister"/>

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -245,6 +245,48 @@ free. A cap can only lower, never raise — which is precisely what the previous
 *"a plan-less entry covers every tier"* let every instance registered before plans existed pull
 `pro` and `enterprise` bundles, and a `@pro` suffix licensed pro on any instance that carried it.
 
+#### A refusal by plan is said on the instance (2026-09-12, #4097)
+
+Every registry decision above refuses a package the plan does not cover **silently on the wire** —
+the same answer as "no such package" — and logs which it was on the registry. That is the
+enumeration defence, and it stays: a registered instance must not learn what a registry carries
+from the shape of its refusals. But it made one case invisible where it mattered. A fresh instance
+on the free plan (`build.meshweaver.cloud`, 2026-09-12) never saw the enterprise `Hosting` package
+the registry itself declares `preInstalled`; the instance showed `canPatch=False` (pointing at
+`Modules:Assemblies`), `/health` said "install the package from the registry" — which the instance
+cannot do — and the Plugin Catalog had no card for it. One cause, three consequences, nothing on
+the instance naming the cause.
+
+Since #4097 the listing carries the verdict for exactly that case: a package the registry declares
+in the instance's **default set** (`preInstalled: true`), from a source the instance's grant
+**reaches** (some entry matches it, within term), that the **plan** refuses. It rides beside the
+granted packages as `refused: [{ packageId, module, requiredTier, instancePlan }]`
+(`PluginGrant.TierRefusal` → `AuthenticatedInstance.TierRefusal` → `PluginRegistryEndpoints.ListAll`),
+additive in both directions: an old consumer ignores the member, an old registry never writes it.
+The `instancePlan` is the plan the decision was taken at — the record's plan narrowed by the
+reaching entry's cap — so the sentence names the plan that actually refused. A package from an
+**ungranted** source is still absent, tier or no tier: `TierRefusal` answers only when an entry
+reaches the package, so the default set is what the registry chose to tell the instance about and
+nothing else becomes enumerable.
+
+On the consumer the unattended default install (`InstanceAutoRegistrationService`) records each
+refusal typed on the `_DefaultInstallLedger` and keeps one marker per refused module in step with
+the registry's answer of that boot — `modules/activation.d/<Module>.tier-refused`
+(`ModuleActivationSidecar.SyncTierRefusals`), cleared by the next pass in which the registry no
+longer refuses it (a plan upgrade). `ModuleActivationSidecar.Read` folds the markers onto
+`ModuleActivationList.TierRefusals`, which is how the verdict reaches every surface that used to
+name the consequence without a new parameter on a host compiled against the previous platform:
+
+| surface | before | since #4097 |
+|---|---|---|
+| `/health` `required_modules` (`RequiredModuleStatus.Classify`) | "store-delivered and NOT installed on this instance — install the package from the registry" | "⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. Installing it from the registry is not possible on this plan — raise the instance's plan on the registry, or delist it from Modules:Required" (still `ExpectedLater`: no rollout changes a plan) |
+| the package card (`CatalogLayoutAreas.BuildCard`) | no card | the card, with the same sentence localized (`ui.packageRefusedByPlanTier`) and no Install button |
+| the activation report (`ModuleActivationReport.TierRefused`, `/health`'s activation line) | nothing | the refused modules, named |
+| the self-updater's startup line (`SelfUpdateHostedService.StartAsync`) | `canPatch=False` and "list MeshWeaver.SelfUpdate.Aks under Modules:Assemblies" | `canPatch=False (⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. The Kubernetes patcher ships in that package …)` |
+
+The vocabulary is #4091's binding-conflict sentence ("⛔ Not installed on this platform: it needs
+YamlDotNet 18.1.0.0, this platform provides 16.3.0.0") with the nouns of a plan.
+
 **The ladder is the Store's data, not a table in the platform.** The registry reads its own
 `Admin/Tiers/{id}` nodes (`content.rank`, `content.allAccess`) once a minute (`PlanTierLadder`) and
 hands the snapshot to the authenticated caller, so every surface decides the same way and there is

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md
@@ -273,14 +273,16 @@ On the consumer the unattended default install (`InstanceAutoRegistrationService
 refusal typed on the `_DefaultInstallLedger` and keeps one marker per refused module in step with
 the registry's answer of that boot — `modules/activation.d/<Module>.tier-refused`
 (`ModuleActivationSidecar.SyncTierRefusals`), cleared by the next pass in which the registry no
-longer refuses it (a plan upgrade). `ModuleActivationSidecar.Read` folds the markers onto
+longer refuses it (a plan upgrade). A pass in which some source's listing FAILED moves nothing —
+neither the ledger's refusals nor the markers — because a registry that was down at boot has not
+lifted anybody's plan. `ModuleActivationSidecar.Read` folds the markers onto
 `ModuleActivationList.TierRefusals`, which is how the verdict reaches every surface that used to
 name the consequence without a new parameter on a host compiled against the previous platform:
 
 | surface | before | since #4097 |
 |---|---|---|
 | `/health` `required_modules` (`RequiredModuleStatus.Classify`) | "store-delivered and NOT installed on this instance — install the package from the registry" | "⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. Installing it from the registry is not possible on this plan — raise the instance's plan on the registry, or delist it from Modules:Required" (still `ExpectedLater`: no rollout changes a plan) |
-| the package card (`CatalogLayoutAreas.BuildCard`) | no card | the card, with the same sentence localized (`ui.packageRefusedByPlanTier`) and no Install button |
+| the package card (`CatalogLayoutAreas.BuildCard`) | no card | the card, with the same sentence localized (`ui.packageRefusedByPlanTier`) and no Install button; after a plan DOWNGRADE an already-installed package says installed-but-no-longer-covered (`ui.packageInstalledAboveThisPlan`) and loses its Update button |
 | the activation report (`ModuleActivationReport.TierRefused`, `/health`'s activation line) | nothing | the refused modules, named |
 | the self-updater's startup line (`SelfUpdateHostedService.StartAsync`) | `canPatch=False` and "list MeshWeaver.SelfUpdate.Aks under Modules:Assemblies" | `canPatch=False (⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. The Kubernetes patcher ships in that package …)` |
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-plan-tier-refusal-says-so-on-the-instance.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-a-plan-tier-refusal-says-so-on-the-instance.md
@@ -1,0 +1,26 @@
+---
+Name: A module refused by plan tier says so on the instance
+Category: Fix
+Description: A pre-installed package the registry refuses to an instance's plan is now named on the instance — on /health, on the package card and on the self-updater's startup line — instead of showing only the consequence.
+Icon: Sparkle
+Order: -20260912
+---
+
+# A module refused by plan tier says so on the instance
+
+An instance on a plan that does not cover a package the registry declares in its default set —
+a free instance and the enterprise `Hosting` package, say — used to see only the consequences:
+`canPatch=False` pointing at `Modules:Assemblies`, `/health` saying "install the package from the
+registry" (which the instance cannot do), and no package card at all. The refusal was logged on the
+registry, where the instance cannot read it.
+
+The registry now returns that verdict to the instance as a typed refusal — package, required tier,
+instance plan — and the instance says it in one sentence wherever it used to name the consequence:
+
+> ⛔ Not installed on this instance: **Hosting** needs plan tier **enterprise**, this instance is on **free**.
+
+The sentence appears on `/health`'s `required_modules` line, on the package's card in the Plugin
+Catalog (with no Install button, since the instance cannot install it), on the activation report,
+and on the self-updater's `[SelfUpdate] starting` line when the Kubernetes patcher's package is what
+was refused. The enumeration defence is unchanged: a package from a source the instance is not
+granted stays indistinguishable from one that does not exist.

--- a/src/MeshWeaver.Mesh.Contract/Security/PlanTierRefusal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PlanTierRefusal.cs
@@ -1,0 +1,51 @@
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// 🚨 A package the registry itself declares in an instance's DEFAULT SET (<c>preInstalled</c>)
+/// that the instance's plan does not cover — returned to the consumer as a typed verdict rather
+/// than as an omission (#4097).
+///
+/// <para><b>Why this exists.</b> Until #4097 a plan-tier refusal was indistinguishable from "no
+/// such package" on the wire — the enumeration defence — and was logged on the REGISTRY, where
+/// the consumer cannot read it. A free instance therefore booted fine, quietly lacked the
+/// enterprise <c>Hosting</c> package, and every surface on the instance named a consequence
+/// (<c>canPatch=False</c>, "required module not installed — install the package from the
+/// registry") and never the cause. An hour was spent on RBAC, module delivery and a design change
+/// before the plan was suspected (measured 2026-09-12 on <c>build.meshweaver.cloud</c>).</para>
+///
+/// <para><b>What it is not.</b> The enumeration defence is about UNGRANTED SOURCES: a refusal for
+/// a package outside the instance's granted sources stays byte-identical to absence, so a
+/// registered instance can never learn what else a registry carries. A pre-installed package the
+/// registry declares in the instance's own default set is not enumeration — the registry chose to
+/// tell every instance about it — and <see cref="PluginGrant.TierRefusal"/> answers ONLY when
+/// some grant entry reaches the package and the plan is what refuses it.</para>
+/// </summary>
+/// <param name="PackageId">The package the plan does not cover (e.g. <c>Hosting</c>).</param>
+/// <param name="Module">The compiled module the package delivers, when it declares one
+/// (<c>MeshWeaver.SelfUpdate.Aks</c>) — what <c>Modules:Required</c> and the activation record are
+/// keyed by; null for a content-only package.</param>
+/// <param name="RequiredTier">The tier the package declares (<c>enterprise</c>).</param>
+/// <param name="InstancePlan">The plan the decision was taken at: the instance's own plan
+/// (<c>free</c> when the record carries none), narrowed by the reaching entry's cap when it
+/// names one — so the sentence names the plan that actually refused, never a plan the instance
+/// holds but the entry does not license.</param>
+public sealed record PlanTierRefusal(
+    string PackageId, string? Module, string RequiredTier, string InstancePlan)
+{
+    /// <summary>
+    /// The one sentence every consumer surface says, in the vocabulary #4091 introduced for a
+    /// binding conflict ("⛔ Not installed on this platform: it needs X, this platform provides
+    /// Y") with the nouns of a plan: <c>⛔ Not installed on this instance: Hosting needs plan tier
+    /// enterprise, this instance is on free.</c> Operator-facing (logs, <c>/health</c>); the
+    /// package card renders the same data through a localized key.
+    /// </summary>
+    public string Describe() =>
+        $"⛔ Not installed on this instance: {PackageId} needs plan tier {RequiredTier}, "
+        + $"this instance is on {InstancePlan}.";
+
+    /// <summary>Whether this refusal is about the module <paramref name="moduleName"/> (simple
+    /// assembly name, compared case-insensitively).</summary>
+    public bool IsForModule(string? moduleName) =>
+        !string.IsNullOrWhiteSpace(Module)
+        && string.Equals(Module, moduleName, StringComparison.OrdinalIgnoreCase);
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
@@ -129,9 +129,13 @@ public record PluginGrant
         {
             if (!entry.Matches(sourceName, packageId) || !entry.IsValidAt(now))
                 continue;
-            var effective = ranks.Narrower(instancePlan, entry.Tier);
-            var plan = PlanTierRanks.Canonical(effective) is { Length: > 0 } named
-                ? named
+            // The plan the entry DECIDED with, in the ladder's own words: Narrower reads an
+            // unknown plan or cap as the baseline, and so must the sentence — "this instance is
+            // on gold" for a cap the ladder does not know would name a plan that is neither the
+            // instance's nor an upgrade target.
+            var canonical = PlanTierRanks.Canonical(ranks.Narrower(instancePlan, entry.Tier));
+            var plan = canonical.Length > 0 && (ranks.RankOf(canonical) is not null || ranks.IsAllAccess(canonical))
+                ? canonical
                 : PlanTierRanks.BaselinePlan;
             if (widest is null || (ranks.RankOf(plan) ?? PlanTierRanks.BaselineRank) > (ranks.RankOf(widest) ?? PlanTierRanks.BaselineRank))
                 widest = plan;

--- a/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs
@@ -104,6 +104,42 @@ public record PluginGrant
             && ranks.CoversInstance(ranks.Narrower(instancePlan, e.Tier), packageTier));
 
     /// <summary>
+    /// 🚨 The typed PLAN-TIER refusal (#4097): the plan the decision was taken at when this grant
+    /// REACHES <paramref name="packageId"/> from <paramref name="sourceName"/> — some entry matches
+    /// the pair and is within its term at <paramref name="now"/> — and yet no entry covers the
+    /// package's <paramref name="packageTier"/> under the instance's plan. Null when the package is
+    /// allowed, and null just the same when NO entry reaches it: a package outside the instance's
+    /// granted sources must stay indistinguishable from absence (the enumeration defence), and only
+    /// a package the grant already reaches may be named as "refused by plan".
+    ///
+    /// <para>The plan returned is the one <see cref="Allows(string,string,string?,PlanTierRanks,string?,DateTimeOffset)"/>
+    /// decided with — the instance's plan narrowed by the reaching entry's cap
+    /// (<see cref="PlanTierRanks.Narrower"/>), the baseline when the record carries none — so the
+    /// sentence built from it names the plan that actually refused. With several reaching entries
+    /// the WIDEST effective plan is reported: that is the closest the instance came.</para>
+    /// </summary>
+    public string? TierRefusal(
+        string sourceName, string packageId, string? packageTier, PlanTierRanks ranks,
+        string? instancePlan, DateTimeOffset now)
+    {
+        if (IsRevoked || Allows(sourceName, packageId, packageTier, ranks, instancePlan, now))
+            return null;
+        string? widest = null;
+        foreach (var entry in Entries)
+        {
+            if (!entry.Matches(sourceName, packageId) || !entry.IsValidAt(now))
+                continue;
+            var effective = ranks.Narrower(instancePlan, entry.Tier);
+            var plan = PlanTierRanks.Canonical(effective) is { Length: > 0 } named
+                ? named
+                : PlanTierRanks.BaselinePlan;
+            if (widest is null || (ranks.RankOf(plan) ?? PlanTierRanks.BaselineRank) > (ranks.RankOf(widest) ?? PlanTierRanks.BaselineRank))
+                widest = plan;
+        }
+        return widest;
+    }
+
+    /// <summary>
     /// <see cref="Allows(string,string,string?,PlanTierRanks,string?,DateTimeOffset)"/> for a
     /// caller that knows no instance plan — decided at the BASELINE, so a plan-less entry covers
     /// free and untiered packages and nothing above. Kept for the surfaces that carry no instance

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -626,6 +626,7 @@
   "ui.moduleHeldAtLanding": "Auf dieser Plattform nicht installiert: es benötigt {0}, diese Plattform stellt {1} bereit. Es wird installiert, sobald diese Installation auf eine Plattform aktualisiert, die es bereitstellt.",
   "ui.moduleHeldAtLandingTypes": "Auf dieser Plattform nicht installiert: es verweist auf {0}, was diese Plattform nicht hat. Es wird installiert, sobald diese Installation aktualisiert wird.",
   "ui.packageRefusedByPlanTier": "Auf dieser Instanz nicht installiert: {0} benötigt die Tarifstufe {1}, diese Instanz ist auf {2}. Es wird installiert, sobald der Tarif der Instanz auf der Registry es abdeckt.",
+  "ui.packageInstalledAboveThisPlan": "Installiert ({0}), aber der Tarif dieser Instanz deckt es nicht mehr ab: {1} benötigt die Tarifstufe {2}, diese Instanz ist auf {3}. Es funktioniert weiterhin; Aktualisierungen bleiben aus, bis der Tarif der Instanz auf der Registry es abdeckt.",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",
   "ui.resetToDefault": "Auf Standard zurücksetzen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -625,6 +625,7 @@
   "ui.moduleDeclaresNewerPlatform": "Deklariert Plattform ≥ {0}; diese Installation läuft mit {1}. Nur ein Hinweis — ob es lädt, wird gemessen, nicht deklariert.",
   "ui.moduleHeldAtLanding": "Auf dieser Plattform nicht installiert: es benötigt {0}, diese Plattform stellt {1} bereit. Es wird installiert, sobald diese Installation auf eine Plattform aktualisiert, die es bereitstellt.",
   "ui.moduleHeldAtLandingTypes": "Auf dieser Plattform nicht installiert: es verweist auf {0}, was diese Plattform nicht hat. Es wird installiert, sobald diese Installation aktualisiert wird.",
+  "ui.packageRefusedByPlanTier": "Auf dieser Instanz nicht installiert: {0} benötigt die Tarifstufe {1}, diese Instanz ist auf {2}. Es wird installiert, sobald der Tarif der Instanz auf der Registry es abdeckt.",
   "ui.orphanedInstallRecords": "Verwaiste Installationseinträge",
   "ui.requestAccess": "Zugriff anfragen",
   "ui.resetToDefault": "Auf Standard zurücksetzen",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -625,6 +625,7 @@
   "ui.moduleRunsPreviousVersion": "Running the previous version {0}: version {1} is installed but does not load on this platform. It activates once a build that loads here ships.",
   "ui.moduleHeldAtLanding": "Not installed on this platform: it needs {0}, this platform provides {1}. It installs when this installation updates to a platform that provides it.",
   "ui.moduleHeldAtLandingTypes": "Not installed on this platform: it references {0}, which this platform does not have. It installs when this installation updates.",
+  "ui.packageRefusedByPlanTier": "Not installed on this instance: {0} needs plan tier {1}, this instance is on {2}. It installs when the instance's plan on the registry covers it.",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -626,6 +626,7 @@
   "ui.moduleHeldAtLanding": "Not installed on this platform: it needs {0}, this platform provides {1}. It installs when this installation updates to a platform that provides it.",
   "ui.moduleHeldAtLandingTypes": "Not installed on this platform: it references {0}, which this platform does not have. It installs when this installation updates.",
   "ui.packageRefusedByPlanTier": "Not installed on this instance: {0} needs plan tier {1}, this instance is on {2}. It installs when the instance's plan on the registry covers it.",
+  "ui.packageInstalledAboveThisPlan": "Installed ({0}), but this instance's plan no longer covers it: {1} needs plan tier {2}, this instance is on {3}. It keeps working; updates stop until the instance's plan on the registry covers it.",
   "ui.orphanedInstallRecords": "Orphaned install records",
   "ui.requestAccess": "Request Access",
   "ui.resetToDefault": "Reset to default",

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -743,15 +743,25 @@ public static class CatalogLayoutAreas
         if (pkg.Refusal is { } tier)
         {
             // 🚨 #4097 — the registry declares this package in the instance's default set and
-            // REFUSES it by plan tier. No button: the instance cannot install it on this plan,
-            // and a button whose click is refused is the "consequence without cause" this line
-            // replaces. Same vocabulary as the #4083 landing refusal below, with the nouns of a
-            // plan, as DATA inside a localized sentence — platform-owned chrome follows the VIEWER.
-            card = card.WithView(Controls.Body(
-                    "⛔ " + host.Localize("ui.packageRefusedByPlanTier",
-                        pkg.Name ?? pkg.Id, tier.RequiredTier, tier.InstancePlan))
-                .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
-                           + "display: block; margin-top: 6px;"));
+            // REFUSES it by plan tier. No button either way: the instance cannot install or
+            // update it on this plan, and a button whose click is refused is the "consequence
+            // without cause" this line replaces. Same vocabulary as the #4083 landing refusal
+            // below, with the nouns of a plan, as DATA inside a localized sentence —
+            // platform-owned chrome follows the VIEWER.
+            //
+            // Two truths, two sentences. With NO install record the package is not here. With
+            // one — a plan DOWNGRADE after an install — the package IS here and keeps working;
+            // saying "not installed" would be the catalog lying about a package that is present.
+            // That card says installed, and that the plan no longer covers it, so updates stop.
+            card = card.WithView(Controls.Body(installed is null
+                    ? "⛔ " + host.Localize("ui.packageRefusedByPlanTier",
+                        pkg.Name ?? pkg.Id, tier.RequiredTier, tier.InstancePlan)
+                    : "⚠️ " + host.Localize("ui.packageInstalledAboveThisPlan",
+                        installed.Version ?? "?", pkg.Name ?? pkg.Id, tier.RequiredTier, tier.InstancePlan))
+                .WithStyle((installed is null
+                                ? "color: var(--error-foreground, #a4262c); "
+                                : "color: var(--warning-foreground, #9d5d00); ")
+                           + "font-size: 12px; display: block; margin-top: 6px;"));
             return card;
         }
 

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -396,7 +396,18 @@ public static class CatalogLayoutAreas
     {
         if (source is null)
             return Observable.Return((Packages: (IReadOnlyList<PackageManifest>)[], Answered: true));
-        return source.ListPackages(sourceRef)
+        // 🚨 #4097 — the registry's plan-tier refusals ride the listing as refused rows: a
+        // pre-installed package the registry declares in this instance's default set but its plan
+        // does not cover gets a CARD saying so, not an absent entry. Only a registry source can
+        // answer with refusals; every other source is its plain listing.
+        var listing = source is RegistryPackageSource registry
+            ? registry.ListCatalog(sourceRef).Select(l => (IReadOnlyList<PackageManifest>)l.Packages
+                .Concat(l.Refused
+                    .Where(r => !l.Packages.Any(p => string.Equals(p.Id, r.PackageId, StringComparison.Ordinal)))
+                    .Select(r => PackageManifest.FromRefusal(r, null)))
+                .ToList())
+            : source.ListPackages(sourceRef);
+        return listing
             .Select(packages => (Packages: packages, Answered: true))
             .Catch<(IReadOnlyList<PackageManifest> Packages, bool Answered), Exception>(ex =>
             {
@@ -729,6 +740,21 @@ public static class CatalogLayoutAreas
                 ? string.Equals(installed.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal)
                 : string.Equals(installed.Version, pkg.Version, StringComparison.Ordinal));
 
+        if (pkg.Refusal is { } tier)
+        {
+            // 🚨 #4097 — the registry declares this package in the instance's default set and
+            // REFUSES it by plan tier. No button: the instance cannot install it on this plan,
+            // and a button whose click is refused is the "consequence without cause" this line
+            // replaces. Same vocabulary as the #4083 landing refusal below, with the nouns of a
+            // plan, as DATA inside a localized sentence — platform-owned chrome follows the VIEWER.
+            card = card.WithView(Controls.Body(
+                    "⛔ " + host.Localize("ui.packageRefusedByPlanTier",
+                        pkg.Name ?? pkg.Id, tier.RequiredTier, tier.InstancePlan))
+                .WithStyle("color: var(--error-foreground, #a4262c); font-size: 12px; "
+                           + "display: block; margin-top: 6px;"));
+            return card;
+        }
+
         if (upToDate)
         {
             card = card.WithView(Controls.Body(host.Localize("ui.catalogInstalledVersion", installed!.Version))
@@ -879,8 +905,11 @@ public static class CatalogLayoutAreas
         IReadOnlyList<PackageManifest> closure;
         try
         {
+            // #4097 — a plan-tier refusal is a card, never a dependency universe member: a
+            // closure that pulled one in would fail at /files with the 404 the refusal replaces.
             closure = PackageDependencyGraph.InstallClosure(
-                pkg, catalog ?? [pkg], installedIds ?? ImmutableHashSet<string>.Empty, logger);
+                pkg, catalog?.Where(p => !p.IsRefused).ToList() ?? [pkg],
+                installedIds ?? ImmutableHashSet<string>.Empty, logger);
         }
         catch (InvalidOperationException ex)
         {

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -854,10 +854,10 @@ public sealed class InstanceAutoRegistrationService(
                     // package this environment's flags declare must re-assert on every boot — that
                     // is the difference between the two lanes — so it is never dropped here, the
                     // same exemption the platform's own preInstalled baseline already has.
-                    .Select(candidates => (IReadOnlyList<InstallCandidate>)candidates
-                        .Where(c => c.Reconciled || !seeded.Contains(c.Package.Id))
-                        .ToList())
-                    .SelectMany(InstallAll)
+                    .SelectMany(selection => InstallAll(selection.Candidates
+                            .Where(c => c.Reconciled || !seeded.Contains(c.Package.Id))
+                            .ToList())
+                        .Select(summary => summary with { ListingIncomplete = selection.ListingIncomplete }))
                     .SelectMany(summary => RecordSeeded(ledger, summary).Select(_ => summary));
             }));
     }
@@ -950,28 +950,41 @@ public sealed class InstanceAutoRegistrationService(
             .OrderBy(s => s.Package, StringComparer.Ordinal)
             .ToImmutableList();
 
-        var tierRefused = summary.TierRefused
-            .DistinctBy(r => r.PackageId, StringComparer.Ordinal)
-            .OrderBy(r => r.PackageId, StringComparer.Ordinal)
-            .ToImmutableList();
+        // 🚨 #4097 — a pass in which SOME source did not answer knows only what it saw. The
+        // per-source catch in Candidates substitutes an empty list for a failed listing, so
+        // another source can still populate this summary while the failed source's refusals are
+        // simply missing from it — not lifted. Treating that as authoritative would clear the
+        // markers and send /health and the self-updater back to the generic "not installed"
+        // sentence for the length of a registry outage. So an incomplete pass keeps the ledger's
+        // previous refusals and leaves the markers standing; only a pass every source answered
+        // may move them — in either direction.
+        var tierRefused = summary.ListingIncomplete
+            ? ledger.TierRefused
+            : summary.TierRefused
+                .DistinctBy(r => r.PackageId, StringComparer.Ordinal)
+                .OrderBy(r => r.PackageId, StringComparer.Ordinal)
+                .ToImmutableList();
 
-        // 🚨 #4097 — the activation record's plan-tier markers are made to MATCH this pass's
-        // answer, before the ledger and regardless of whether the ledger changes: /health's
-        // required_modules line, the activation report and the self-updater read the markers,
-        // and a marker left standing after a plan upgrade would name a refusal that no longer
-        // exists. Guarded above by the same "a pass that read no listing knows nothing" rule —
-        // a failed listing must not clear a standing refusal. A volume that cannot be written
-        // is reported, never fatal: the ledger below still records the verdict.
-        try
+        // The activation record's plan-tier markers are made to MATCH this pass's answer, before
+        // the ledger and regardless of whether the ledger changes: /health's required_modules
+        // line, the activation report and the self-updater read the markers, and a marker left
+        // standing after a plan upgrade would name a refusal that no longer exists. Guarded by
+        // the "knows nothing" rule above and the completeness rule here — a failed listing must
+        // not clear a standing refusal. A volume that cannot be written is reported, never
+        // fatal: the ledger below still records the verdict.
+        if (!summary.ListingIncomplete)
         {
-            ModuleActivationSidecar.SyncTierRefusals(
-                ModuleRoot.Resolve(hub.ServiceProvider.GetService<IConfiguration>()), tierRefused);
-        }
-        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
-        {
-            logger.LogWarning(ex,
-                "[DefaultInstall] could not write the plan-tier refusal markers under the module root; "
-                + "/health and the self-updater will not name the plan until a pass can.");
+            try
+            {
+                ModuleActivationSidecar.SyncTierRefusals(
+                    ModuleRoot.Resolve(hub.ServiceProvider.GetService<IConfiguration>()), tierRefused);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                logger.LogWarning(ex,
+                    "[DefaultInstall] could not write the plan-tier refusal markers under the module root; "
+                    + "/health and the self-updater will not name the plan until a pass can.");
+            }
         }
 
         if (delivered.Count == 0
@@ -1178,7 +1191,12 @@ public sealed class InstanceAutoRegistrationService(
             ? hit.Flag
             : null;
 
-    private IObservable<IReadOnlyList<InstallCandidate>> Candidates(
+    /// <summary>One pass's selection, and whether every source ANSWERED (#4097): a source whose
+    /// listing failed contributes nothing, and a pass with such a source must not read its own
+    /// silence as "that source refuses nothing".</summary>
+    private sealed record CandidateSelection(IReadOnlyList<InstallCandidate> Candidates, bool ListingIncomplete);
+
+    private IObservable<CandidateSelection> Candidates(
         IReadOnlyList<ConfiguredPackageSource> sources,
         bool baseline,
         IReadOnlyList<PluginGrantEntry> wanted,
@@ -1227,22 +1245,24 @@ public sealed class InstanceAutoRegistrationService(
                 // The WHOLE listing is carried forward, not just the selected packages: a selected
                 // package's requirements are resolved against the full catalog below, and a
                 // dependency that is neither pre-installed nor pattern-matched exists only here.
-                .Select(packages => packages
+                .Select(packages => (Candidates: packages
                     .Select(p => string.IsNullOrEmpty(p.Source) ? p with { Source = source.Name } : p)
                     .Select(p => new InstallCandidate(source, p))
-                    .ToList())
+                    .ToList(), Failed: false))
                 .Catch((Exception exception) =>
                 {
                     logger.LogWarning(exception,
                         "[DefaultInstall] listing {Name} @ {Ref} failed — its packages are skipped "
                         + "this boot", source.Name, source.GitRef);
-                    return Observable.Return(new List<InstallCandidate>());
+                    return Observable.Return((Candidates: new List<InstallCandidate>(), Failed: true));
                 }))
             .ToObservable()
             .Concat()
             .ToList()
-            .Select(perSource =>
+            .Select(answers =>
             {
+                var listingIncomplete = answers.Any(a => a.Failed);
+                var perSource = answers.Select(a => a.Candidates).ToList();
                 var catalog = perSource
                     .SelectMany(list => list)
                     .GroupBy(c => c.Package.Id, StringComparer.Ordinal)
@@ -1300,7 +1320,7 @@ public sealed class InstanceAutoRegistrationService(
                 // policy (PackageDependencyGraph.InstallClosure).
                 var ordered = PackageDependencyGraph.InDependencyOrder(withDependencies, logger);
                 var bySource = catalog.ToDictionary(c => c.Package.Id, StringComparer.Ordinal);
-                return (IReadOnlyList<InstallCandidate>)ordered
+                return new CandidateSelection(ordered
                     .Select(p => bySource[p.Id])
                     // 🚨 The EXCLUSION is applied LAST — after the dependency closure, so it also
                     // removes a package the closure pulled back in as somebody's requirement. That
@@ -1336,7 +1356,7 @@ public sealed class InstanceAutoRegistrationService(
                                      || IsIncluded(c)
                                      || (c.Source.LocalCheckout && IsWanted(c)),
                     })
-                    .ToList();
+                    .ToList(), listingIncomplete);
             }));
 
     /// <summary>
@@ -1708,7 +1728,8 @@ public sealed class InstanceAutoRegistrationService(
                 sources, baseline, wanted,
                 Parse((composition ?? FeatureComposition.Empty).Included),
                 Parse((composition ?? FeatureComposition.Empty).Excluded))
-            .SelectMany(InstallAll);
+            .SelectMany(selection => InstallAll(selection.Candidates)
+                .Select(summary => summary with { ListingIncomplete = selection.ListingIncomplete }));
 
     /// <summary>
     /// Runs the PRODUCTION default-install pass on demand — the identical selection, ordering and
@@ -1826,6 +1847,14 @@ public readonly record struct DefaultInstallSummary(
     public ImmutableList<PlanTierRefusal> TierRefused { get; init; } = ImmutableList<PlanTierRefusal>.Empty;
 
     /// <summary>
+    /// 🚨 True when at least one source's listing FAILED this pass (#4097), so what the pass did
+    /// not see is unknown rather than absent. <see cref="TierRefused"/> is then a partial answer:
+    /// the ledger keeps its previous refusals and the activation markers are left standing,
+    /// because a registry that was down at boot has not lifted anybody's plan.
+    /// </summary>
+    public bool ListingIncomplete { get; init; }
+
+    /// <summary>
     /// The ids this pass actually DELIVERED — installed or already current. The ledger's input:
     /// what the seed may stop re-asserting.
     /// </summary>
@@ -1849,6 +1878,7 @@ public readonly record struct DefaultInstallSummary(
             .AddRange(other.Skipped ?? ImmutableList<DefaultInstallSkip>.Empty),
         TierRefused = (TierRefused ?? ImmutableList<PlanTierRefusal>.Empty)
             .AddRange(other.TierRefused ?? ImmutableList<PlanTierRefusal>.Empty),
+        ListingIncomplete = ListingIncomplete || other.ListingIncomplete,
     };
 
     /// <inheritdoc />

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -950,9 +950,34 @@ public sealed class InstanceAutoRegistrationService(
             .OrderBy(s => s.Package, StringComparer.Ordinal)
             .ToImmutableList();
 
+        var tierRefused = summary.TierRefused
+            .DistinctBy(r => r.PackageId, StringComparer.Ordinal)
+            .OrderBy(r => r.PackageId, StringComparer.Ordinal)
+            .ToImmutableList();
+
+        // 🚨 #4097 — the activation record's plan-tier markers are made to MATCH this pass's
+        // answer, before the ledger and regardless of whether the ledger changes: /health's
+        // required_modules line, the activation report and the self-updater read the markers,
+        // and a marker left standing after a plan upgrade would name a refusal that no longer
+        // exists. Guarded above by the same "a pass that read no listing knows nothing" rule —
+        // a failed listing must not clear a standing refusal. A volume that cannot be written
+        // is reported, never fatal: the ledger below still records the verdict.
+        try
+        {
+            ModuleActivationSidecar.SyncTierRefusals(
+                ModuleRoot.Resolve(hub.ServiceProvider.GetService<IConfiguration>()), tierRefused);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            logger.LogWarning(ex,
+                "[DefaultInstall] could not write the plan-tier refusal markers under the module root; "
+                + "/health and the self-updater will not name the plan until a pass can.");
+        }
+
         if (delivered.Count == 0
             && failures.SequenceEqual(ledger.Failed, StringComparer.Ordinal)
-            && skipped.SequenceEqual(ledger.Skipped))
+            && skipped.SequenceEqual(ledger.Skipped)
+            && tierRefused.SequenceEqual(ledger.TierRefused))
             return Observable.Return(Unit.Default);
 
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
@@ -978,6 +1003,7 @@ public sealed class InstanceAutoRegistrationService(
                 Seeded = already.Union(delivered).OrderBy(x => x, StringComparer.Ordinal).ToImmutableList(),
                 Failed = failures,
                 Skipped = skipped,
+                TierRefused = tierRefused,
                 UpdatedAt = DateTimeOffset.UtcNow,
             },
         };
@@ -1188,7 +1214,7 @@ public sealed class InstanceAutoRegistrationService(
                         string.Join(", ", sourceNames));
             return Observable.Return(Unit.Default);
         }).SelectMany(_ => sources
-            .Select(source => source.Source.ListPackages(source.GitRef)
+            .Select(source => ListWithRefusals(source)
                 .Take(1)
                 // 🚨 Stamp the source name HERE, not only in the registry's HTTP merge. Source-
                 // scoped matching reads PackageManifest.Source, and until now only
@@ -1314,6 +1340,23 @@ public sealed class InstanceAutoRegistrationService(
             }));
 
     /// <summary>
+    /// One source's listing WITH the registry's plan-tier refusals folded in as refused rows
+    /// (#4097). Only a <see cref="RegistryPackageSource"/> can answer with refusals — a git source
+    /// read directly (a registry installing its own defaults) has no plan to refuse against — so
+    /// every other source is its plain listing. A refused row carries <see cref="PackageManifest.Refusal"/>
+    /// and is selected like the pre-installed package it is, so that the pass SKIPS it with the
+    /// typed reason and records it, instead of never learning the package exists.
+    /// </summary>
+    private static IObservable<IReadOnlyList<PackageManifest>> ListWithRefusals(ConfiguredPackageSource source) =>
+        source.Source is RegistryPackageSource registry
+            ? registry.ListCatalog(source.GitRef).Select(listing => (IReadOnlyList<PackageManifest>)listing.Packages
+                .Concat(listing.Refused
+                    .Where(r => !listing.Packages.Any(p => string.Equals(p.Id, r.PackageId, StringComparison.Ordinal)))
+                    .Select(r => PackageManifest.FromRefusal(r, source.Name)))
+                .ToList())
+            : source.Source.ListPackages(source.GitRef);
+
+    /// <summary>
     /// <paramref name="selected"/> plus everything it transitively REQUIRES that the catalog can
     /// supply — the unattended twin of <see cref="PackageDependencyGraph.InstallClosure"/>, kept
     /// TOLERANT for the same reason the boot sort is: nobody is present to fix a malformed manifest,
@@ -1431,7 +1474,12 @@ public sealed class InstanceAutoRegistrationService(
     /// <param name="package">The selected candidate's manifest, as the catalog lists it now.</param>
     /// <returns>The speaking skip reason, or null when the pass may install it.</returns>
     internal static string? TerminalSkipReason(PackageManifest package) =>
-        package.IsCommercial() ? PackageEntitlement.Reason(package, null) : null;
+        package.Refusal is { } refused
+            // #4097 — the registry refuses it to this instance's PLAN. Not an authorization this
+            // lane lacks; a licence the instance does not hold. Re-derived from the listing each
+            // pass, so a plan upgrade lifts it on the next boot.
+            ? refused.Describe()
+            : package.IsCommercial() ? PackageEntitlement.Reason(package, null) : null;
 
     /// <summary>Installs the selected packages sequentially and folds their outcomes into one summary.</summary>
     private IObservable<DefaultInstallSummary> InstallAll(IReadOnlyList<InstallCandidate> candidates)
@@ -1451,16 +1499,37 @@ public sealed class InstanceAutoRegistrationService(
         var installable = skipped.Count == 0
             ? candidates
             : candidates.Where(c => TerminalSkipReason(c.Package) is null).ToList();
-        if (skipped.Count > 0)
+        if (skipped.Count(x => candidates.Any(c => c.Package.Id == x.Package && !c.Package.IsRefused)) > 0)
             logger.LogWarning(
                 "[DefaultInstall] {Count} declared package(s) require an authorization this "
                 + "unattended install can never obtain and are SKIPPED, not failed: [{Skipped}]. "
                 + "They are recorded with their reasons on {Ledger} and no boot re-attempts them — "
                 + "a Global Admin installing them from the catalog, or the package ceasing to be "
                 + "commercial, is what changes this.",
-                skipped.Count, string.Join(", ", skipped.Select(s => s.Package)), SeedLedgerPath);
+                skipped.Count(x => candidates.Any(c => c.Package.Id == x.Package && !c.Package.IsRefused)),
+                string.Join(", ", skipped
+                    .Where(x => candidates.Any(c => c.Package.Id == x.Package && !c.Package.IsRefused))
+                    .Select(s => s.Package)),
+                SeedLedgerPath);
 
-        var seed = DefaultInstallSummary.Empty with { Skipped = skipped };
+        // 🚨 #4097 — the plan-tier refusals, TYPED, beside the string-reasoned skips above: the
+        // ledger and the activation record carry them as data (package, module, tier, plan), and
+        // the log line names the cause the instance never used to see. Warning, once per pass,
+        // like the other skips — this is a standing fact about the plan, not a per-boot error.
+        var tierRefused = candidates
+            .Select(c => c.Package.Refusal)
+            .Where(r => r is not null)
+            .Select(r => r!)
+            .DistinctBy(r => r.PackageId, StringComparer.Ordinal)
+            .ToImmutableList();
+        if (tierRefused.Count > 0)
+            logger.LogWarning(
+                "[DefaultInstall] {Count} package(s) the registry declares in this instance's default "
+                + "set are REFUSED by its plan tier and are not installed: {Refused}. Raise the "
+                + "instance's plan on the registry to receive them; nothing on this instance can.",
+                tierRefused.Count, string.Join("; ", tierRefused.Select(r => r.Describe())));
+
+        var seed = DefaultInstallSummary.Empty with { Skipped = skipped, TierRefused = tierRefused };
         if (installable.Count == 0)
             return Observable.Return(seed);
         logger.LogInformation(
@@ -1698,6 +1767,14 @@ public record DefaultInstallLedger
     public ImmutableList<DefaultInstallSkip> Skipped { get; init; } =
         ImmutableList<DefaultInstallSkip>.Empty;
 
+    /// <summary>
+    /// The default-set packages the registry refused to this instance's PLAN on the last pass
+    /// (#4097), typed. A snapshot with <see cref="Skipped"/>'s semantics: an entry drops off the
+    /// moment the registry stops refusing the package (a plan upgrade) or stops declaring it in
+    /// the default set. Every entry is also in <see cref="Skipped"/> with the same sentence.
+    /// </summary>
+    public ImmutableList<PlanTierRefusal> TierRefused { get; init; } = ImmutableList<PlanTierRefusal>.Empty;
+
     /// <summary>When the ledger last changed.</summary>
     public DateTimeOffset UpdatedAt { get; init; }
 }
@@ -1740,6 +1817,15 @@ public readonly record struct DefaultInstallSummary(
         ImmutableList<DefaultInstallSkip>.Empty;
 
     /// <summary>
+    /// The default-set packages the registry REFUSED to this instance's plan tier this pass
+    /// (#4097), typed — package, module, required tier, instance plan. Every one is also in
+    /// <see cref="Skipped"/> with the same sentence as its reason; this is the data the ledger
+    /// and the activation record keep, so <c>/health</c>, the package card and the self-updater
+    /// can name the plan instead of the consequence.
+    /// </summary>
+    public ImmutableList<PlanTierRefusal> TierRefused { get; init; } = ImmutableList<PlanTierRefusal>.Empty;
+
+    /// <summary>
     /// The ids this pass actually DELIVERED — installed or already current. The ledger's input:
     /// what the seed may stop re-asserting.
     /// </summary>
@@ -1761,6 +1847,8 @@ public readonly record struct DefaultInstallSummary(
             .AddRange(other.Failures ?? ImmutableList<string>.Empty),
         Skipped = (Skipped ?? ImmutableList<DefaultInstallSkip>.Empty)
             .AddRange(other.Skipped ?? ImmutableList<DefaultInstallSkip>.Empty),
+        TierRefused = (TierRefused ?? ImmutableList<PlanTierRefusal>.Empty)
+            .AddRange(other.TierRefused ?? ImmutableList<PlanTierRefusal>.Empty),
     };
 
     /// <inheritdoc />

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -727,4 +727,28 @@ public sealed record AuthenticatedInstance(MeshWeaverInstance Instance, PluginGr
     /// <summary><see cref="Allows(string,string,string?,DateTimeOffset)"/> right now.</summary>
     public bool Allows(string sourceName, string packageId, string? packageTier) =>
         Allows(sourceName, packageId, packageTier, DateTimeOffset.UtcNow);
+
+    /// <summary>
+    /// 🚨 The typed refusal for a package this caller's grant REACHES but its plan does not cover
+    /// (#4097) — <see cref="PluginGrant.TierRefusal"/> decided with the caller's ladder and the
+    /// record's plan, as a <see cref="PlanTierRefusal"/> the listing can return. Null when the
+    /// package is allowed, when no grant entry reaches it (absence — the enumeration defence), or
+    /// when the presented token's scope excludes it (a token can only narrow; a package outside its
+    /// scope is absent to this token, whatever the grant says).
+    /// </summary>
+    /// <param name="module">The compiled module the package delivers, carried onto the refusal so
+    /// the consumer can key it by module name (<c>Modules:Required</c>, the activation record).</param>
+    public PlanTierRefusal? TierRefusal(
+        string sourceName, string packageId, string? packageTier, string? module, DateTimeOffset now)
+    {
+        if (TokenScope is not null && !TokenScope.Covers(sourceName, packageId))
+            return null;
+        return Grant.TierRefusal(sourceName, packageId, packageTier, Ranks, Instance.Plan, now) is { } plan
+            ? new PlanTierRefusal(packageId, module, PlanTierRanks.Canonical(packageTier), plan)
+            : null;
+    }
+
+    /// <summary><see cref="TierRefusal(string,string,string?,string?,DateTimeOffset)"/> right now.</summary>
+    public PlanTierRefusal? TierRefusal(string sourceName, string packageId, string? packageTier, string? module) =>
+        TierRefusal(sourceName, packageId, packageTier, module, DateTimeOffset.UtcNow);
 }

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -146,6 +146,25 @@ public sealed record ModuleActivationList
     /// restart — the minimal #1664 step-10 "restart required" signal. Boot consumes it: applying
     /// the list IS the restart, so <c>ConfigureMemexMesh</c> resets it to false.</summary>
     public bool PendingRestart { get; init; }
+
+    /// <summary>
+    /// 🚨 The modules this instance's PLAN keeps it from installing (#4097) — one per
+    /// <c>activation.d/&lt;Module&gt;.tier-refused</c> marker, written by the unattended default
+    /// install from the registry's typed answer (<see cref="Mesh.Security.PlanTierRefusal"/>).
+    /// Read from the markers, never from the aggregate file (<see cref="JsonIgnoreAttribute"/>),
+    /// so a bulk <see cref="ModuleActivationSidecar.Write"/> neither persists nor resurrects one.
+    ///
+    /// <para>Carried on the activation list because the list is what every surface that says
+    /// "not installed" already reads — <c>RequiredModuleStatus.Classify</c> on <c>/health</c>,
+    /// the activation report on the package card — so the refusal reaches them with no new
+    /// parameter on a host that was compiled against the previous platform.</para>
+    /// </summary>
+    [JsonIgnore]
+    public ImmutableList<Mesh.Security.PlanTierRefusal> TierRefusals { get; init; } = [];
+
+    /// <summary>The plan-tier refusal recorded for <paramref name="moduleName"/>, or null.</summary>
+    public Mesh.Security.PlanTierRefusal? TierRefusalFor(string? moduleName) =>
+        TierRefusals.FirstOrDefault(r => r.IsForModule(moduleName));
 }
 
 /// <summary>
@@ -279,7 +298,105 @@ public static class ModuleActivationSidecar
             // The marker is authoritative; the legacy flag is honoured once, for a deployment
             // upgrading with the flag still set. Boot clears both.
             PendingRestart = File.Exists(PendingRestartMarkerPath(baseDirectory)) || legacy.PendingRestart,
+            // #4097 — what the registry said this instance's plan refuses, from the markers the
+            // default install keeps in step with the registry's answer.
+            TierRefusals = [.. ReadTierRefusals(baseDirectory).Values],
         };
+    }
+
+    // ── the plan-tier refusal marker (#4097) ──────────────────────────────────
+
+    /// <summary>The per-module plan-tier refusal marker's file suffix inside
+    /// <see cref="EntriesDirectoryName"/> — like <see cref="RefusedMarkerSuffix"/>, deliberately
+    /// not <c>.json</c>, so entry enumeration never parses it and the bulk write never sweeps it.</summary>
+    public const string TierRefusedMarkerSuffix = ".tier-refused";
+
+    /// <summary>The marker recording that the registry refuses a module's package to this
+    /// instance's PLAN: <c>modules/activation.d/&lt;Module&gt;.tier-refused</c>.</summary>
+    public static string TierRefusedMarkerPath(string baseDirectory, string moduleName) =>
+        Path.Combine(EntriesDirectory(baseDirectory), moduleName + TierRefusedMarkerSuffix);
+
+    /// <summary>
+    /// 🚨 Makes the marker set MATCH <paramref name="refusals"/> — one marker per refusal that
+    /// names a module, every other <c>.tier-refused</c> marker removed. The default-install pass
+    /// calls it with the registry's answer of THIS boot, so a plan upgrade (the registry stops
+    /// refusing) clears the markers on the next pass and a downgrade writes them; a stale marker
+    /// would otherwise say "refused by plan" on a plan that covers the package. A marker whose
+    /// content is unchanged is not rewritten (the directory's write time is the report's cache
+    /// fingerprint). Refusals for content-only packages carry no module and leave no marker — the
+    /// package card renders them from the listing.
+    /// </summary>
+    /// <returns>The module names that carry a marker after the sync, sorted.</returns>
+    public static ImmutableList<string> SyncTierRefusals(
+        string baseDirectory, IEnumerable<Mesh.Security.PlanTierRefusal> refusals)
+    {
+        ArgumentNullException.ThrowIfNull(refusals);
+        var wanted = new Dictionary<string, Mesh.Security.PlanTierRefusal>(StringComparer.OrdinalIgnoreCase);
+        foreach (var refusal in refusals)
+            if (!string.IsNullOrWhiteSpace(refusal.Module))
+                wanted[refusal.Module] = refusal;
+
+        var current = ReadTierRefusals(baseDirectory);
+        foreach (var stale in current.Keys.Where(name => !wanted.ContainsKey(name)))
+            ClearTierRefused(baseDirectory, stale);
+        foreach (var (module, refusal) in wanted)
+        {
+            if (current.TryGetValue(module, out var existing) && existing == refusal)
+                continue;
+            ValidateModuleName(module);
+            WriteAtomic(TierRefusedMarkerPath(baseDirectory, module), JsonSerializer.Serialize(refusal, Json));
+        }
+        return [.. wanted.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)];
+    }
+
+    /// <summary>Removes one module's plan-tier marker. Tolerant of an absent file and a read-only
+    /// volume, like <see cref="ClearRefused"/>.</summary>
+    public static void ClearTierRefused(string baseDirectory, string moduleName)
+    {
+        ValidateModuleName(moduleName);
+        try
+        {
+            File.Delete(TierRefusedMarkerPath(baseDirectory, moduleName));
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            // Another replica clearing the same marker, or a read-only volume.
+        }
+    }
+
+    /// <summary>Every plan-tier refusal marker under the deployment, module name → refusal, sorted
+    /// by name. An unreadable or malformed marker contributes nothing.</summary>
+    public static ImmutableSortedDictionary<string, Mesh.Security.PlanTierRefusal> ReadTierRefusals(string baseDirectory)
+    {
+        var builder = ImmutableSortedDictionary.CreateBuilder<string, Mesh.Security.PlanTierRefusal>(StringComparer.OrdinalIgnoreCase);
+        var directory = EntriesDirectory(baseDirectory);
+        if (!Directory.Exists(directory))
+            return builder.ToImmutable();
+        string[] files;
+        try
+        {
+            files = Directory.EnumerateFiles(directory, "*" + TierRefusedMarkerSuffix).ToArray();
+        }
+        catch (Exception e) when (e is IOException or UnauthorizedAccessException)
+        {
+            return builder.ToImmutable();
+        }
+        foreach (var file in files)
+        {
+            var name = Path.GetFileName(file)[..^TierRefusedMarkerSuffix.Length];
+            try
+            {
+                var text = TryReadAllText(file);
+                if (text is not null
+                    && JsonSerializer.Deserialize<Mesh.Security.PlanTierRefusal>(text, Json) is { } refusal)
+                    builder[name] = refusal;
+            }
+            catch (Exception e) when (e is IOException or UnauthorizedAccessException or JsonException)
+            {
+                // Unreadable or malformed: no verdict, never a wrong one.
+            }
+        }
+        return builder.ToImmutable();
     }
 
     // ── the unloadable-head marker (#3650) ──────────────────────────────────

--- a/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleActivation.cs
@@ -333,8 +333,12 @@ public static class ModuleActivationSidecar
         ArgumentNullException.ThrowIfNull(refusals);
         var wanted = new Dictionary<string, Mesh.Security.PlanTierRefusal>(StringComparer.OrdinalIgnoreCase);
         foreach (var refusal in refusals)
-            if (!string.IsNullOrWhiteSpace(refusal.Module))
-                wanted[refusal.Module] = refusal;
+            // 🚨 The module name arrives from the REGISTRY and becomes a file name. One that is not
+            // a valid module name (which no assembly simple name is) gets no marker rather than an
+            // exception: the refusal is still on the ledger and the card, and one malformed entry
+            // must not abort the pass that records every other one.
+            if (IsValidModuleName(refusal.Module))
+                wanted[refusal.Module!] = refusal;
 
         var current = ReadTierRefusals(baseDirectory);
         foreach (var stale in current.Keys.Where(name => !wanted.ContainsKey(name)))
@@ -343,7 +347,6 @@ public static class ModuleActivationSidecar
         {
             if (current.TryGetValue(module, out var existing) && existing == refusal)
                 continue;
-            ValidateModuleName(module);
             WriteAtomic(TierRefusedMarkerPath(baseDirectory, module), JsonSerializer.Serialize(refusal, Json));
         }
         return [.. wanted.Keys.OrderBy(name => name, StringComparer.OrdinalIgnoreCase)];
@@ -594,13 +597,18 @@ public static class ModuleActivationSidecar
         return entry with { UnloadableFrameworkMvid = marker.FrameworkMvid };
     }
 
+    /// <summary>Whether <paramref name="moduleName"/> may become a file name under the entries
+    /// directory — the predicate behind <see cref="ValidateModuleName"/>.</summary>
+    private static bool IsValidModuleName(string? moduleName) =>
+        !string.IsNullOrWhiteSpace(moduleName)
+        && moduleName is not ("." or "..")
+        && moduleName.IndexOfAny(Path.GetInvalidFileNameChars()) < 0
+        && !moduleName.Contains('/') && !moduleName.Contains('\\');
+
     /// <summary>The same rule <see cref="WriteEntry"/> applies: the name BECOMES a path.</summary>
     private static void ValidateModuleName(string? moduleName)
     {
-        if (string.IsNullOrWhiteSpace(moduleName)
-            || moduleName is "." or ".."
-            || moduleName.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0
-            || moduleName.Contains('/') || moduleName.Contains('\\'))
+        if (!IsValidModuleName(moduleName))
             throw new ArgumentException(
                 $"'{moduleName}' is not a valid module name — a marker is a file named after its module.",
                 nameof(moduleName));

--- a/src/MeshWeaver.PluginCatalog/Package.cs
+++ b/src/MeshWeaver.PluginCatalog/Package.cs
@@ -221,6 +221,35 @@ public record PackageManifest
     /// </summary>
     public bool PreInstalled { get; init; }
 
+    /// <summary>
+    /// 🚨 Set on a catalog entry the registry declares in this instance's default set but REFUSES
+    /// by plan tier (#4097) — the typed verdict the listing carries beside the granted packages
+    /// (<see cref="RegistryListing.Refused"/>), folded into a manifest so the package card and the
+    /// unattended default install can say it in the package's own row. Never on an installable
+    /// entry, never on an install record (<see cref="JsonIgnoreAttribute"/>): a refused package is
+    /// not installed, and <see cref="RegistryPackageSource.ListPackages"/> — what every other
+    /// consumer reads — never carries one.
+    /// </summary>
+    [JsonIgnore]
+    public Mesh.Security.PlanTierRefusal? Refusal { get; init; }
+
+    /// <summary>Whether this entry is a plan-tier refusal rather than an installable package.</summary>
+    [JsonIgnore]
+    public bool IsRefused => Refusal is not null;
+
+    /// <summary>The manifest-shaped row for a plan-tier refusal (#4097): the package's identity,
+    /// its module and tier, pre-installed by definition, with <see cref="Refusal"/> set.</summary>
+    public static PackageManifest FromRefusal(Mesh.Security.PlanTierRefusal refusal, string? source) => new()
+    {
+        Id = refusal.PackageId,
+        Name = refusal.PackageId,
+        Module = refusal.Module,
+        Tier = refusal.RequiredTier,
+        PreInstalled = true,
+        Source = source,
+        Refusal = refusal,
+    };
+
     // ── storefront metadata (read off the root node when listing; all optional) ──
 
     /// <summary>The store's browse-by-category key (the root node's <c>category</c>).</summary>

--- a/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
+++ b/src/MeshWeaver.PluginCatalog/PendingModuleActivations.cs
@@ -113,6 +113,18 @@ public sealed record ModuleActivationReport(
     /// <summary>Whether anything was refused at landing.</summary>
     public bool HasRefused => !IsUndetermined && !Refused.IsEmpty;
 
+    /// <summary>
+    /// 🚨 The modules this instance's PLAN keeps it from installing (#4097): the registry
+    /// declared their packages in the default set and refused them by tier, and the default
+    /// install recorded the typed verdict on the activation record. Not pending (nothing landed),
+    /// not refused-at-landing (nothing was fetched) — a state whose remedy is the instance's plan,
+    /// which no restart, landing or platform update changes. Init-only, for binary compatibility.
+    /// </summary>
+    public ImmutableList<Mesh.Security.PlanTierRefusal> TierRefused { get; init; } = [];
+
+    /// <summary>Whether any module's package is refused by the instance's plan.</summary>
+    public bool HasTierRefused => !IsUndetermined && !TierRefused.IsEmpty;
+
     /// <summary>The refusal row for the module the install record at <paramref name="packagePath"/>
     /// asked to land, or null.</summary>
     public ModuleRefusal? RefusalForPackage(string? packagePath) =>
@@ -208,7 +220,8 @@ public sealed record ModuleActivationReport(
               + (HasQuarantined ? "; " + DescribeQuarantined(Quarantined) : string.Empty)
               + (HasFallbacks ? "; " + DescribeFallbacks(Fallbacks) : string.Empty)
               + (HasFloorAdvisories ? "; " + DescribeFloorAdvisories(FloorAdvisories) : string.Empty)
-              + (HasRefused ? "; " + DescribeRefused(Refused) : string.Empty);
+              + (HasRefused ? "; " + DescribeRefused(Refused) : string.Empty)
+              + (HasTierRefused ? "; " + DescribeTierRefused(TierRefused) : string.Empty);
 
     /// <summary>
     /// One human-readable line naming the modules that run their PREVIOUS generation (#3649) or
@@ -236,6 +249,20 @@ public sealed record ModuleActivationReport(
             + "and working, behind the set; no restart changes that, a build that loads here does: "
             + string.Join("; ", rows.Take(Math.Max(1, maxNamed)))
             + (rows.Length > maxNamed ? $"; …(+{rows.Length - maxNamed})" : string.Empty);
+    }
+
+    /// <summary>The plan-tier sentence for operators (#4097): each refused package with the tier it
+    /// needs and the plan the instance is on — <c>⛔ Not installed on this instance: Hosting needs
+    /// plan tier enterprise, this instance is on free.</c></summary>
+    public static string DescribeTierRefused(IReadOnlyCollection<Mesh.Security.PlanTierRefusal> refused, int maxNamed = 10)
+    {
+        var named = refused.Take(maxNamed)
+            .Select(r => $"{r.Module ?? r.PackageId}: {r.Describe()}");
+        return $"{refused.Count} module(s) are refused by this instance's PLAN — the registry "
+               + "declares their packages in the default set and does not serve them at this plan; "
+               + "no restart, landing or platform update changes that: "
+               + string.Join("; ", named)
+               + (refused.Count > maxNamed ? $" … +{refused.Count - maxNamed}" : string.Empty);
     }
 
     /// <summary>The refusal sentence for operators (#4083): each module by name with its status
@@ -653,6 +680,9 @@ public sealed class PendingModuleActivations(string moduleRoot)
                 .Select(pair => new ModuleRefusal(
                     pair.Key, pair.Value.PackagePath, pair.Value.Version, pair.Value.Reason,
                     pair.Value.RefusedAt, pair.Value.Needs, pair.Value.Provides))],
+            // #4097 — what the registry refuses this instance's PLAN, from the markers the default
+            // install keeps in step with the registry's answer (the same list boot and /health read).
+            TierRefused = activation.TierRefusals,
             MeshModuleSet = ModuleSetStore.Describe(sets)
                 + (setNotes.Count > 0 ? " — " + string.Join("; ", setNotes) : string.Empty),
         };

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http;
 using System.Reactive.Linq;
 using System.Text.Json;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -63,7 +64,6 @@ public sealed class RegistryPackageSource : IPackageSource
     /// </summary>
     public PluginBundleClient? Bundles { get; init; }
 
-    private sealed record ListResponse(IReadOnlyList<PackageManifest>? Packages);
     private sealed record FilesResponse(IReadOnlyList<PackageFile>? Files);
 
     // Per-REQUEST auth header — never on the client: _http can be the process-wide SharedHttp, and
@@ -81,6 +81,18 @@ public sealed class RegistryPackageSource : IPackageSource
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+        ListCatalog(gitRef).Select(listing => listing.Packages);
+
+    /// <summary>
+    /// The registry's whole answer for this instance (#4097): the packages it is granted AND the
+    /// pre-installed packages the registry declares in its default set that its PLAN refuses, as
+    /// typed <see cref="PlanTierRefusal"/>s. <see cref="ListPackages"/> is the first half and is
+    /// what every existing consumer keeps reading — a refused package is never mistaken for an
+    /// installable one by the reconciler, the update watcher or the Store's count. The two surfaces
+    /// that must SAY the refusal (the unattended default install, which records it, and the package
+    /// card, which renders it) read this form.
+    /// </summary>
+    public IObservable<RegistryListing> ListCatalog(string gitRef) =>
         _httpPool.Invoke(async ct =>
         {
             var url = $"{_registryUrl}{RoutePrefix}?ref={Uri.EscapeDataString(gitRef ?? "")}";
@@ -90,8 +102,7 @@ public sealed class RegistryPackageSource : IPackageSource
             if (!resp.IsSuccessStatusCode)
                 throw new RegistryResponseException(resp.StatusCode,
                     $"Registry catalog list failed ({(int)resp.StatusCode}): {json}");
-            var parsed = JsonSerializer.Deserialize<ListResponse>(json, Json);
-            return (IReadOnlyList<PackageManifest>)(parsed?.Packages ?? []);
+            return PluginRegistryPayloads.ParseList(json);
         })
         // 🚨 A successful read is the EVENT a deferred boot reconcile waits for (#2888). Every
         // registry contact this installation makes — a catalog open, an install, the Store's
@@ -103,12 +114,12 @@ public sealed class RegistryPackageSource : IPackageSource
         // service scope is being torn down and a resolve would throw ObjectDisposedException INTO the
         // caller's successful read. A read during teardown has no boot reconcile left to drain, so it
         // simply does not report.
-        .Do(packages =>
+        .Do(listing =>
         {
             if (_hub.RunLevel > MessageHubRunLevel.Started)
                 return;
             _hub.ServiceProvider.GetService<RegistryUpdateReconciler>()
-                ?.OnFeedRead(_registryUrl, gitRef, packages);
+                ?.OnFeedRead(_registryUrl, gitRef, listing.Packages);
         });
 
     /// <inheritdoc />
@@ -153,13 +164,48 @@ public static class PluginRegistryPayloads
     /// <summary>Serializer options both sides use (Web camelCase).</summary>
     public static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web);
 
-    /// <summary>Serializes the list-catalog response: <c>{ packages: [PackageManifest…] }</c>.</summary>
-    public static string List(IReadOnlyList<PackageManifest> packages) =>
-        JsonSerializer.Serialize(new { packages }, Json);
+    /// <summary>Serializes the list-catalog response: <c>{ packages: [PackageManifest…] }</c>, plus
+    /// <c>refused: [PlanTierRefusal…]</c> when the registry has plan-tier refusals to report
+    /// (#4097). An old consumer deserializes only <c>packages</c> and ignores the sibling; an old
+    /// registry never writes it and the consumer reads an empty list — additive both ways.</summary>
+    public static string List(IReadOnlyList<PackageManifest> packages, IReadOnlyList<PlanTierRefusal>? refused = null) =>
+        refused is { Count: > 0 }
+            ? JsonSerializer.Serialize(new { packages, refused }, Json)
+            // Nothing refused ⇒ the member is not written at all — the pre-#4097 bytes exactly.
+            : JsonSerializer.Serialize(new { packages }, Json);
+
+    /// <summary>Parses the list-catalog response <see cref="List"/> wrote.</summary>
+    public static RegistryListing ParseList(string json)
+    {
+        var parsed = JsonSerializer.Deserialize<ListResponse>(json, Json);
+        return new RegistryListing
+        {
+            Packages = parsed?.Packages ?? [],
+            Refused = parsed?.Refused ?? [],
+        };
+    }
+
+    private sealed record ListResponse(
+        IReadOnlyList<PackageManifest>? Packages, IReadOnlyList<PlanTierRefusal>? Refused);
 
     /// <summary>Serializes the fetch-files response: <c>{ files: [PackageFile…] }</c>.</summary>
     public static string Files(IReadOnlyList<PackageFile> files) =>
         JsonSerializer.Serialize(new { files }, Json);
+}
+
+/// <summary>
+/// One registry listing as the consumer sees it (#4097): what it may pull, and what the registry
+/// declares in its default set but its plan refuses. Init properties rather than positional
+/// parameters so a later field is not a binary break for a host compiled against this shape.
+/// </summary>
+public sealed record RegistryListing
+{
+    /// <summary>The packages this instance is granted and its plan covers — the catalog.</summary>
+    public IReadOnlyList<PackageManifest> Packages { get; init; } = [];
+
+    /// <summary>The pre-installed packages the registry declares in this instance's default set
+    /// whose tier the instance's plan does not cover. Empty from a registry that predates #4097.</summary>
+    public IReadOnlyList<PlanTierRefusal> Refused { get; init; } = [];
 }
 
 /// <summary>

--- a/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
+++ b/src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs
@@ -55,6 +55,14 @@ public sealed record RequiredModuleVerdict(
 /// standing revert-debt — a "gate" whose one escape hatch is deleting the declaration is the
 /// skip-trapdoor with its polarity flipped: it fails on no evidence instead of passing on it.</para>
 ///
+/// <para>🚨 <b>A module the instance's PLAN refuses says so (#4097).</b> The registry declares
+/// the package in the instance's default set and refuses it by tier; that verdict reaches this
+/// classification through the activation record (<see cref="ModuleActivationList.TierRefusals"/>,
+/// kept in step by the default install) and the reason names the package, the tier it needs and
+/// the plan the instance is on — instead of "install the package from the registry", which the
+/// instance cannot do. Still <see cref="RequiredModuleState.ExpectedLater"/>: no rollout can
+/// change a plan.</para>
+///
 /// <para><b>The missing evidence was already on disk: <c>Modules:Assemblies</c>.</b> That list is
 /// the IMAGE's own claim about what it carries. A module named under BOTH keys is the image's
 /// responsibility — absent means the build lost it, and that stays <see cref="RequiredModuleState.Absent"/>
@@ -235,6 +243,17 @@ public static class RequiredModuleStatus
 
         string StoreReason(string name)
         {
+            // 🚨 #4097 — BEFORE "install the package from the registry", because on this plan the
+            // instance cannot. The registry declared the package in this instance's default set
+            // and refused it by PLAN TIER; the default install recorded that verdict on the
+            // activation record (ModuleActivationSidecar.SyncTierRefusals), and this is the one
+            // line on /health that used to name only the consequence. Same vocabulary as #4091's
+            // binding conflict, with the nouns of a plan.
+            if (activation?.TierRefusalFor(name) is { } refused)
+                return $"store-delivered and NOT installed on this instance: {refused.Describe()} "
+                    + "Installing it from the registry is not possible on this plan — raise the "
+                    + "instance's plan on the registry, or delist it from Modules:Required if this "
+                    + "deployment does not want the feature.";
             if (!landed.TryGetValue(name, out var record) || !record.Enabled)
                 return "store-delivered and NOT installed on this instance — install the package "
                     + "from the registry, or delist it from Modules:Required if this deployment "

--- a/test/Memex.Portal.Shared.Test/PlanTierRefusalTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlanTierRefusalTest.cs
@@ -174,6 +174,19 @@ public class PlanTierRefusalTest : IDisposable
         Assert.Equal("free", refusal!.InstancePlan);
     }
 
+    /// <summary>
+    /// 🚨 The sentence speaks the LADDER's language. A cap the ladder does not know reads as the
+    /// baseline in the decision (<c>Narrower</c>), so the sentence says <c>free</c> too — never
+    /// "this instance is on gold", a plan that is neither the instance's nor an upgrade target.
+    /// </summary>
+    [Fact]
+    public void AnUnknownCap_ReportsTheBaseline_NotTheUnknownWord()
+    {
+        var refusal = Instance("pro", Entry(Platform, cap: "gold"))
+            .TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now);
+        Assert.Equal("free", refusal!.InstancePlan);
+    }
+
     /// <summary>A token can only NARROW: a package outside the presented token's scope is absent
     /// to that token, whatever the durable grant says.</summary>
     [Fact]
@@ -328,6 +341,23 @@ public class PlanTierRefusalTest : IDisposable
         Assert.Empty(ModuleActivationSidecar.SyncTierRefusals(root, []));
         Assert.False(File.Exists(ModuleActivationSidecar.TierRefusedMarkerPath(root, Patcher)));
         Assert.Empty(ModuleActivationSidecar.Read(root).TierRefusals);
+    }
+
+    /// <summary>
+    /// A module name arrives from the REGISTRY and becomes a file name. One that cannot be a file
+    /// name gets no marker and no exception — the pass that records every other refusal must not
+    /// abort on it (the refusal is still on the ledger and the card).
+    /// </summary>
+    [Fact]
+    public void AMalformedModuleName_LeavesNoMarker_AndDoesNotThrow()
+    {
+        var written = ModuleActivationSidecar.SyncTierRefusals(root,
+        [
+            new PlanTierRefusal("Evil", "../escape", "enterprise", "free"),
+            new PlanTierRefusal("Hosting", Patcher, "enterprise", "free"),
+        ]);
+        Assert.Equal([Patcher], written);
+        Assert.Single(ModuleActivationSidecar.Read(root).TierRefusals);
     }
 
     /// <summary>The marker is a sibling of the #4083 refusal marker and must not be mistaken for

--- a/test/Memex.Portal.Shared.Test/PlanTierRefusalTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlanTierRefusalTest.cs
@@ -1,0 +1,397 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A module refused by plan tier says so on the instance (#4097).</b>
+///
+/// <para><b>The hour these pin — 2026-09-12, <c>build.meshweaver.cloud</c>.</b> A fresh instance
+/// on the free plan showed <c>canPatch=False</c> ("list MeshWeaver.SelfUpdate.Aks under
+/// Modules:Assemblies"), <c>required_modules: Degraded — install the package from the registry</c>,
+/// and a package card that simply did not exist. The cause was one line on the REGISTRY: the
+/// <c>Hosting</c> package (<c>preInstalled: true</c>, <c>tier: enterprise</c>) was refused by
+/// <c>PluginGrant.Allows → PlanTierRanks.CoversInstance</c>, and by design that refusal was
+/// indistinguishable from "no such bundle" on the wire. One cause, three consequences, nothing on
+/// the instance naming it.</para>
+///
+/// <para><b>The two halves.</b> The REGISTRY side returns a TYPED refusal for a package it itself
+/// declares in the instance's default set from a source the grant reaches — and stays silent,
+/// exactly as before, for a package outside the granted sources (the enumeration defence). The
+/// CONSUMER side records the verdict on the activation record and says the one sentence in the
+/// #4091 vocabulary on every surface that used to name the consequence.</para>
+/// </summary>
+public class PlanTierRefusalTest : IDisposable
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 12, 12, 0, 0, TimeSpan.Zero);
+
+    /// <summary>The Store's ladder as the registry reads it: free 0 · personal 10 · pro 20 ·
+    /// dedicated 25 (all-access) · enterprise 30.</summary>
+    private static readonly PlanTierRanks Ladder = new(
+        ImmutableDictionary<string, int>.Empty
+            .Add("free", 0).Add("personal", 10).Add("pro", 20).Add("dedicated", 25).Add("enterprise", 30),
+        ImmutableHashSet.Create("dedicated"));
+
+    private const string Platform = "Plugins";
+    private const string Paid = "Reinsurance";
+    private const string Patcher = "MeshWeaver.SelfUpdate.Aks";
+
+    private static PluginGrantEntry Entry(string source, string package = PluginGrantEntry.AllPackages, string? cap = null) =>
+        new() { Source = source, PackageId = package, Tier = cap };
+
+    private static AuthenticatedInstance Instance(string? plan, params PluginGrantEntry[] entries) =>
+        new(new MeshWeaverInstance { InstanceId = "build", KeyHash = "hash", Plan = plan },
+            new PluginGrant { InstanceId = "build", Entries = entries })
+        { Ranks = Ladder };
+
+    /// <summary>The Hosting package as MeshWeaver.Plugins' <c>Hosting/index.json</c> declares it.</summary>
+    private static readonly PackageManifest Hosting = new()
+    {
+        Id = "Hosting", Name = "Hosting", Module = Patcher, PreInstalled = true, Tier = "enterprise",
+    };
+
+    private static readonly PackageManifest Store = new() { Id = "Store", Name = "Store", PreInstalled = true };
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-tierrefusal-" + Guid.NewGuid().ToString("N"));
+
+    public PlanTierRefusalTest() => Directory.CreateDirectory(root);
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    // ───────────────────────────────────────────── the registry side: the grant's verdict
+
+    /// <summary>
+    /// The incident's exact shape: a free instance holding <c>Plugins/*</c>, and the enterprise
+    /// <c>Hosting</c> package the registry declares in its default set. Allowed? No. Refused BY
+    /// PLAN, and said so — with the plan the decision was taken at.
+    /// </summary>
+    [Fact]
+    public void AFreeInstance_IsRefusedTheEnterprisePreInstall_ByPlan_AndToldSo()
+    {
+        var caller = Instance("free", Entry(Platform));
+
+        Assert.False(caller.Allows(Platform, Hosting.Id, Hosting.Tier, Now));
+
+        var refusal = caller.TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now);
+        Assert.NotNull(refusal);
+        Assert.Equal("Hosting", refusal!.PackageId);
+        Assert.Equal(Patcher, refusal.Module);
+        Assert.Equal("enterprise", refusal.RequiredTier);
+        Assert.Equal("free", refusal.InstancePlan);
+        Assert.Equal(
+            "⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free.",
+            refusal.Describe());
+    }
+
+    /// <summary>A record that predates the plan field is a FREE instance, and the sentence says
+    /// <c>free</c>, never "(none)".</summary>
+    [Fact]
+    public void ABlankPlan_IsRefusedAtTheBaseline_AndTheSentenceNamesFree()
+    {
+        var refusal = Instance(null, Entry(Platform)).TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now);
+        Assert.Equal("free", refusal!.InstancePlan);
+    }
+
+    /// <summary>
+    /// 🚨 THE ENUMERATION DEFENCE, unchanged. The same enterprise package from a source the
+    /// instance holds NO entry for is absence — null, exactly like a package that does not exist.
+    /// A registered instance must not learn what a registry carries by reading its refusals.
+    /// </summary>
+    [Fact]
+    public void AnUngrantedSource_YieldsAbsence_NotARefusal()
+    {
+        var caller = Instance("free", Entry(Platform));
+
+        Assert.Null(caller.TierRefusal(Paid, "UWDeepfield", "enterprise", null, Now));
+        // And the grant itself agrees, before the token scope even enters.
+        Assert.Null(caller.Grant.TierRefusal(Paid, "UWDeepfield", "enterprise", Ladder, "free", Now));
+    }
+
+    /// <summary>An expired entry reaches nothing: absence, not a refusal it could not decide.</summary>
+    [Fact]
+    public void AnExpiredEntry_YieldsAbsence()
+    {
+        var expired = new PluginGrantEntry { Source = Platform, PackageId = PluginGrantEntry.AllPackages, ExpiresAt = Now.AddDays(-1) };
+        Assert.Null(Instance("free", expired).TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now));
+    }
+
+    /// <summary>A revoked grant licenses nothing and explains nothing — the kill switch is silence.</summary>
+    [Fact]
+    public void ARevokedGrant_YieldsAbsence()
+    {
+        var caller = new AuthenticatedInstance(
+            new MeshWeaverInstance { InstanceId = "build", KeyHash = "hash", Plan = "free" },
+            new PluginGrant { InstanceId = "build", Entries = [Entry(Platform)], IsRevoked = true })
+        { Ranks = Ladder };
+        Assert.Null(caller.TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now));
+    }
+
+    /// <summary>A plan that covers the package is ALLOWED — no refusal to report.</summary>
+    [Theory]
+    [InlineData("enterprise")]
+    [InlineData("dedicated")]
+    public void ACoveringPlan_IsAllowed_AndNothingIsRefused(string plan)
+    {
+        var caller = Instance(plan, Entry(Platform));
+        Assert.True(caller.Allows(Platform, Hosting.Id, Hosting.Tier, Now));
+        Assert.Null(caller.TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now));
+    }
+
+    /// <summary>A baseline package (no tier) is covered by every plan, so a free instance is never
+    /// told it is refused the Store.</summary>
+    [Fact]
+    public void ABaselinePackage_IsNeverRefused()
+    {
+        Assert.Null(Instance("free", Entry(Platform)).TierRefusal(Platform, Store.Id, Store.Tier, null, Now));
+    }
+
+    /// <summary>
+    /// 🚨 The sentence names the plan that ACTUALLY refused. A pro instance whose only entry for
+    /// the source is capped at free (<c>Plugins/*@free</c>) is decided at free — saying "this
+    /// instance is on pro" would send the operator to a plan that is not the problem.
+    /// </summary>
+    [Fact]
+    public void ACappedEntry_ReportsTheNarrowedPlan()
+    {
+        var refusal = Instance("pro", Entry(Platform, cap: "free"))
+            .TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now);
+        Assert.Equal("free", refusal!.InstancePlan);
+    }
+
+    /// <summary>A token can only NARROW: a package outside the presented token's scope is absent
+    /// to that token, whatever the durable grant says.</summary>
+    [Fact]
+    public void ATokenScopeExcludingThePackage_YieldsAbsence()
+    {
+        var caller = Instance("free", Entry(Platform)) with
+        {
+            TokenScope = new SyncAccessTokenClaims("build", "hash", ["Plugins/Store"], Now.AddHours(1)),
+        };
+        Assert.Null(caller.TierRefusal(Platform, Hosting.Id, Hosting.Tier, Hosting.Module, Now));
+    }
+
+    // ───────────────────────────────────────────── the registry side: the listing
+
+    /// <summary>
+    /// The listing's refusal set, computed exactly as <c>/api/plugins</c> computes it: the
+    /// pre-installed package the plan refuses from the GRANTED source is named; the same package
+    /// from an UNGRANTED source is not; a granted package is not; a refused package that is NOT
+    /// pre-installed is not either — the default set is what the registry chose to tell the
+    /// instance about, and nothing else is.
+    /// </summary>
+    [Fact]
+    public void TheListing_NamesOnlyTheDefaultSetRefusals_FromGrantedSources()
+    {
+        var caller = Instance("free", Entry(Platform));
+        var platform = new ConfiguredPackageSource(new NullSource(), "HEAD", Platform);
+        var paid = new ConfiguredPackageSource(new NullSource(), "HEAD", Paid);
+        var optionalEnterprise = Hosting with { Id = "Optional", Module = null, PreInstalled = false };
+
+        var refused = PluginRegistryEndpoints.TierRefusals(caller,
+        [
+            (platform, (IReadOnlyList<PackageManifest>)[Store, Hosting, optionalEnterprise]),
+            (paid, (IReadOnlyList<PackageManifest>)[Hosting with { Id = "PaidHosting" }]),
+        ]);
+
+        var only = Assert.Single(refused);
+        Assert.Equal("Hosting", only.PackageId);
+        Assert.Equal(Patcher, only.Module);
+    }
+
+    /// <summary>The legacy anonymous caller sees everything and is refused nothing.</summary>
+    [Fact]
+    public void TheAnonymousCaller_HasNoRefusals()
+    {
+        var platform = new ConfiguredPackageSource(new NullSource(), "HEAD", Platform);
+        Assert.Empty(PluginRegistryEndpoints.TierRefusals(null, [(platform, (IReadOnlyList<PackageManifest>)[Hosting])]));
+    }
+
+    /// <summary>
+    /// The wire is ADDITIVE both ways: the refusal travels beside <c>packages</c> and round-trips
+    /// typed; a listing from a registry that predates #4097 (no <c>refused</c> member) parses to
+    /// an empty refusal set, never to an error.
+    /// </summary>
+    [Fact]
+    public void ThePayload_CarriesTheRefusalBesideThePackages_AndAnOldRegistryParsesToNone()
+    {
+        var refusal = new PlanTierRefusal("Hosting", Patcher, "enterprise", "free");
+        var json = PluginRegistryPayloads.List([Store], [refusal]);
+        Assert.Contains("\"refused\"", json);
+
+        var listing = PluginRegistryPayloads.ParseList(json);
+        Assert.Equal("Store", Assert.Single(listing.Packages).Id);
+        Assert.Equal(refusal, Assert.Single(listing.Refused));
+
+        var legacy = PluginRegistryPayloads.ParseList("{\"packages\":[{\"id\":\"Store\"}]}");
+        Assert.Single(legacy.Packages);
+        Assert.Empty(legacy.Refused);
+
+        // No refusals ⇒ the member is not written at all — byte-identical to before #4097.
+        Assert.DoesNotContain("refused", PluginRegistryPayloads.List([Store]));
+    }
+
+    // ───────────────────────────────────────────── the consumer side
+
+    /// <summary>
+    /// Surface 1 — <c>/health</c> <c>required_modules</c>. With the refusal on the activation
+    /// record (which is what the host's health check reads), the required patcher module is still
+    /// ExpectedLater — no rollout can change a plan — but the reason names the package, the tier
+    /// and the plan instead of "install the package from the registry".
+    /// </summary>
+    [Fact]
+    public void TheRequiredModuleProbe_NamesTheTier_InsteadOfTellingTheInstanceToInstall()
+    {
+        var activation = new ModuleActivationList
+        {
+            TierRefusals = [new PlanTierRefusal("Hosting", Patcher, "enterprise", "free")],
+        };
+
+        var verdicts = RequiredModuleStatus.Classify(
+            requiredEntries: [Patcher + ".dll"],
+            baselineEntries: [],
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: activation,
+            landedDllExists: _ => false,
+            platformGate: _ => null,
+            incompatibleModules: []);
+
+        var expected = Assert.Single(RequiredModuleStatus.ExpectedLater(verdicts));
+        Assert.Equal(Patcher, expected.Name);
+        Assert.Contains(
+            "⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free.",
+            expected.Reason);
+        Assert.DoesNotContain("install the package from the registry", expected.Reason);
+        Assert.Empty(RequiredModuleStatus.Absent(verdicts));
+    }
+
+    /// <summary>The control arm: without a recorded refusal the sentence is the one it always was.</summary>
+    [Fact]
+    public void TheRequiredModuleProbe_WithoutARefusal_StillSaysInstallFromTheRegistry()
+    {
+        var verdicts = RequiredModuleStatus.Classify(
+            requiredEntries: [Patcher + ".dll"],
+            baselineEntries: [],
+            loadedAssemblyNames: new HashSet<string>(StringComparer.OrdinalIgnoreCase),
+            resolvesFromDeployment: _ => false,
+            activation: new ModuleActivationList(),
+            landedDllExists: _ => false,
+            platformGate: _ => null,
+            incompatibleModules: []);
+
+        Assert.Contains("install the package from the registry", Assert.Single(verdicts).Reason);
+    }
+
+    /// <summary>
+    /// The record between the default install and the probes: the markers are made to MATCH the
+    /// registry's answer of the pass — written, read back onto the activation list (the SAME read
+    /// the host's health check performs), and cleared by a later pass in which the registry no
+    /// longer refuses (a plan upgrade). A content-only refusal leaves no marker.
+    /// </summary>
+    [Fact]
+    public void TheMarkers_FollowTheRegistrysAnswer_AndReadBackOntoTheActivationList()
+    {
+        var hosting = new PlanTierRefusal("Hosting", Patcher, "enterprise", "free");
+        var contentOnly = new PlanTierRefusal("Course", null, "pro", "free");
+
+        Assert.Equal([Patcher], ModuleActivationSidecar.SyncTierRefusals(root, [hosting, contentOnly]));
+        Assert.True(File.Exists(ModuleActivationSidecar.TierRefusedMarkerPath(root, Patcher)));
+
+        var read = ModuleActivationSidecar.Read(root);
+        Assert.Equal(hosting, Assert.Single(read.TierRefusals));
+        Assert.Equal(hosting, read.TierRefusalFor(Patcher));
+        Assert.Equal(hosting, read.TierRefusalFor(Patcher.ToUpperInvariant()));
+        Assert.Null(read.TierRefusalFor("MeshWeaver.AI"));
+
+        // The activation report — what the package card and the activation health line read.
+        var report = new PendingModuleActivations(root).Read(new HashSet<string>(StringComparer.OrdinalIgnoreCase));
+        Assert.True(report.HasTierRefused);
+        Assert.Contains("Hosting needs plan tier enterprise, this instance is on free", report.Describe());
+
+        // The plan was raised: the next pass answers no refusals, and the marker goes.
+        Assert.Empty(ModuleActivationSidecar.SyncTierRefusals(root, []));
+        Assert.False(File.Exists(ModuleActivationSidecar.TierRefusedMarkerPath(root, Patcher)));
+        Assert.Empty(ModuleActivationSidecar.Read(root).TierRefusals);
+    }
+
+    /// <summary>The marker is a sibling of the #4083 refusal marker and must not be mistaken for
+    /// an activation ENTRY by the bulk write or the entry enumeration.</summary>
+    [Fact]
+    public void TheMarker_IsNotAnEntry_AndSurvivesABulkWrite()
+    {
+        ModuleActivationSidecar.SyncTierRefusals(root, [new PlanTierRefusal("Hosting", Patcher, "enterprise", "free")]);
+        ModuleActivationSidecar.Write(root, new ModuleActivationList
+        {
+            Entries = [new ModuleActivationEntry { Name = "MeshWeaver.AI", Directory = "MeshWeaver.AI/1" }],
+        });
+
+        var read = ModuleActivationSidecar.Read(root);
+        Assert.Equal("MeshWeaver.AI", Assert.Single(read.Entries).Name);
+        Assert.Single(read.TierRefusals);
+    }
+
+    /// <summary>
+    /// Surface 3 — the self-updater's startup line. With the patcher's package refused by plan
+    /// the qualifier after <c>canPatch=False</c> names the tier; without one it keeps pointing at
+    /// the two ways a Kubernetes install gets its patcher.
+    /// </summary>
+    [Fact]
+    public void TheSelfUpdaterStartupLine_NamesTheTier_WhenThePatchersPackageWasRefused()
+    {
+        ModuleActivationSidecar.SyncTierRefusals(root, [new PlanTierRefusal("Hosting", Patcher, "enterprise", "free")]);
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { [ModuleRoot.ConfigKey] = root })
+            .Build();
+
+        var refusal = UnavailableUpdateMechanics.PatcherTierRefusal(configuration);
+        Assert.NotNull(refusal);
+        var line = UnavailableUpdateMechanics.DescribeCannotPatch(refusal);
+        Assert.Contains("Hosting needs plan tier enterprise, this instance is on free", line);
+        Assert.DoesNotContain("Modules:Assemblies", line);
+
+        ModuleActivationSidecar.SyncTierRefusals(root, []);
+        Assert.Null(UnavailableUpdateMechanics.PatcherTierRefusal(configuration));
+        Assert.Contains("Modules:Assemblies", UnavailableUpdateMechanics.DescribeCannotPatch(null));
+    }
+
+    /// <summary>Surface 2 — the card's row: the refusal folds into a manifest that is pre-installed,
+    /// carries the module and the tier, and is never mistaken for an installable entry.</summary>
+    [Fact]
+    public void ARefusalFoldsIntoAManifestRow_ThatIsRefused_NotInstallable()
+    {
+        var row = PackageManifest.FromRefusal(new PlanTierRefusal("Hosting", Patcher, "enterprise", "free"), Platform);
+        Assert.True(row.IsRefused);
+        Assert.True(row.PreInstalled);
+        Assert.Equal("Hosting", row.Id);
+        Assert.Equal(Patcher, row.Module);
+        Assert.Equal("enterprise", row.Tier);
+        Assert.Equal(Platform, row.Source);
+        Assert.False(Hosting.IsRefused);
+    }
+
+    /// <summary>A source that lists nothing — the endpoints' refusal computation never lists.</summary>
+    private sealed class NullSource : IPackageSource
+    {
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            System.Reactive.Linq.Observable.Return((IReadOnlyList<PackageManifest>)[]);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>
+            System.Reactive.Linq.Observable.Return((IReadOnlyList<PackageFile>)[]);
+    }
+}


### PR DESCRIPTION
Closes #4097.

## The hour (verbatim, 2026-09-12, `build.meshweaver.cloud`, fresh instance on the free plan)

What the instance showed, through the plugin's Logs/Sample actions and its public `/health`:

- `[SelfUpdate] starting … canPatch=False` (DetectOnly updater: "list MeshWeaver.SelfUpdate.Aks under Modules:Assemblies for a Kubernetes install");
- `required_modules: Degraded — 3 required module(s) are store-delivered and not here yet … install the package from the registry, or delist it`;
- `pending_module_activation` clearing after a Restart, but the patcher still absent.

What was actually true: the AKS patcher ships in the **Hosting** package (MeshWeaver.Plugins `Hosting/index.json`: `module: MeshWeaver.SelfUpdate.Aks`, `preInstalled: true`, `tier: enterprise`). The instance's plan was `free`, so `PluginGrant.Allows` → `PlanTierRanks.CoversInstance` refused the pre-install, and by design the refusal was indistinguishable from "no such bundle" on the wire (the enumeration defence) and logged **on the registry**, where the consumer cannot read it. One cause, three symptoms, nothing on the instance naming the cause.

## The mechanism

**Registry side — a typed refusal for the default set, absence for everything else.**

- `src/MeshWeaver.Mesh.Contract/Security/PlanTierRefusal.cs` (new) — `PlanTierRefusal(PackageId, Module, RequiredTier, InstancePlan)` and its one sentence, `Describe()`: `⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free.` — #4091's BindingConflict vocabulary with the nouns of a plan.
- `src/MeshWeaver.Mesh.Contract/Security/PluginGrant.cs:121` `TierRefusal(...)` — answers the plan the decision was taken at ONLY when some entry **reaches** the package (matches, within term) and no entry covers its tier; null when allowed and null when no entry reaches it. The plan reported is the instance's plan narrowed by the reaching entry's cap (`Narrower`), so a `Plugins/*@free` entry on a pro instance says `free` — the plan that actually refused — and an unknown cap or plan says the baseline, as `Narrower` decides it.
- `src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs:741` `AuthenticatedInstance.TierRefusal(...)` — the same, with the caller's ladder and record, and a token scope that excludes the package answering absence (a token only narrows).
- `memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs:191,197` — `ListAll` now returns a `RegistryListing`; `TierRefusals` names a package iff it is `preInstalled` **and** not granted **and** `TierRefusal` answers. A package from an ungranted source stays absent, tier or no tier; a refused package that is not pre-installed stays absent too. Logged on the registry as before, now beside the wire answer instead of instead of it.
- `src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs:171,178` — the payload is `{ packages, refused }` when there is something to refuse and byte-identical to before when there is not; `ParseList` reads a pre-#4097 registry's answer to an empty refusal set. `ListCatalog` (`:95`) is the typed form; `ListPackages` stays the granted half, so the reconciler, the update watcher, the Store's count and the entitlement anchor never see a refused row.

**Consumer side — the verdict is recorded once and read by every surface that used to name the consequence.**

- `src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs` — `ListWithRefusals` folds the refusals into the default-install candidates as refused rows (`PackageManifest.FromRefusal`); `TerminalSkipReason` skips each with the typed sentence; `InstallAll` carries them typed on the summary and logs the cause once at Warning; `RecordSeeded` keeps the activation record's markers in step with this pass's answer (`ModuleActivationSidecar.SyncTierRefusals`: `modules/activation.d/<Module>.tier-refused`, written on refusal, cleared the pass the registry stops refusing — a plan upgrade) and writes them on the `_DefaultInstallLedger.TierRefused`. A pass in which some source's listing failed (`DefaultInstallSummary.ListingIncomplete`, carried from the per-source catch in `Candidates`) moves neither the markers nor the ledger's refusals: a registry that was down at boot has not lifted anybody's plan. A module name that cannot be a file name gets no marker and no exception.
- `src/MeshWeaver.PluginCatalog/ModuleActivation.cs:163,303` — `ModuleActivationSidecar.Read` folds the markers onto `ModuleActivationList.TierRefusals` (`[JsonIgnore]`, so a bulk write neither persists nor resurrects one). This is what lets the verdict reach `/health` **with no change to the host**: `RequiredModulesHealthCheck` in MeshWeaver.Plugins already reads the list with `ModuleActivationSidecar.Read` and passes it to `Classify`.

## The three surfaces

1. **`/health` `required_modules`** — `src/MeshWeaver.PluginCatalog/RequiredModuleStatus.cs:252`: before "install the package from the registry", a module whose package the registry refused by plan says `store-delivered and NOT installed on this instance: ⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. Installing it from the registry is not possible on this plan — raise the instance's plan on the registry, or delist it from Modules:Required …`. Still `ExpectedLater`: no rollout changes a plan. The activation report gains the same rows (`PendingModuleActivations.cs:123,257,685`) for `/health`'s activation line.
2. **The package card** — `src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs:404` folds the refusals into the catalog page's listing so the refused pre-install gets a card; `:743` renders `⛔` + `ui.packageRefusedByPlanTier` (en/de) with **no Install button** when there is no install record, and — after a plan downgrade, when the package IS installed — `⚠️` + `ui.packageInstalledAboveThisPlan` (installed, keeps working, updates stop) with no Update button; the click's dependency closure never contains a refused row.
3. **The self-updater's startup line** — `memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs` `StartAsync`: right after `canPatch=False`, a second `[SelfUpdate] canPatch=False (⛔ Not installed on this instance: Hosting needs plan tier enterprise, this instance is on free. The Kubernetes patcher ships in that package, so this install runs detect-and-notify until the instance's plan covers it.)` line replaces the pointer at `Modules:Assemblies` (`UnavailableUpdateMechanics.PatcherTierRefusal` / `DescribeCannotPatch`, `UnavailableUpdateMechanics.cs:41,56`). The marker read runs on the FileSystem `IIoPool` (`CannotPatchReason`), never inline on the hosted-service startup thread; the `Restart` verdict's reason says the same.

Doc: a dated section in `src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md` ("A refusal by plan is said on the instance"); What's New entry `2026-09-12-a-plan-tier-refusal-says-so-on-the-instance.md` (Category: Fix).

## Tests

`test/Memex.Portal.Shared.Test/PlanTierRefusalTest.cs` (new, 21 tests):

- registry: `AFreeInstance_IsRefusedTheEnterprisePreInstall_ByPlan_AndToldSo`, `ABlankPlan_IsRefusedAtTheBaseline_AndTheSentenceNamesFree`, `AnUngrantedSource_YieldsAbsence_NotARefusal` (the enumeration defence), `AnExpiredEntry_YieldsAbsence`, `ARevokedGrant_YieldsAbsence`, `ACoveringPlan_IsAllowed_AndNothingIsRefused` (enterprise, dedicated), `ABaselinePackage_IsNeverRefused`, `ACappedEntry_ReportsTheNarrowedPlan`, `AnUnknownCap_ReportsTheBaseline_NotTheUnknownWord`, `ATokenScopeExcludingThePackage_YieldsAbsence`, `TheListing_NamesOnlyTheDefaultSetRefusals_FromGrantedSources`, `TheAnonymousCaller_HasNoRefusals`, `ThePayload_CarriesTheRefusalBesideThePackages_AndAnOldRegistryParsesToNone`;
- consumer: `TheRequiredModuleProbe_NamesTheTier_InsteadOfTellingTheInstanceToInstall`, `TheRequiredModuleProbe_WithoutARefusal_StillSaysInstallFromTheRegistry` (control), `TheMarkers_FollowTheRegistrysAnswer_AndReadBackOntoTheActivationList`, `TheMarker_IsNotAnEntry_AndSurvivesABulkWrite`, `AMalformedModuleName_LeavesNoMarker_AndDoesNotThrow`, `TheSelfUpdaterStartupLine_NamesTheTier_WhenThePatchersPackageWasRefused`, `ARefusalFoldsIntoAManifestRow_ThatIsRefused_NotInstallable`.

```
$ dotnet build memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj -c Release -warnaserror      → 0 Warning(s) 0 Error(s)
$ dotnet build test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj -c Release -warnaserror → 0 Warning(s) 0 Error(s)
$ dotnet test test/Memex.Portal.Shared.Test -c Release --no-build --filter "PlanTierRefusalTest|ModuleFloorAdvisoryTest|ModulePlatformLinkTest|ModuleGenerationDivergenceTest|SyncTokenScopeTest"
Passed!  - Failed: 0, Passed: 77, Skipped: 0, Total: 77
$ dotnet test test/MeshWeaver.Messaging.Hub.Test -c Release --no-build --filter LocalizationTest
Passed!  - Failed: 0, Passed: 58, Skipped: 0, Total: 58
```

Copilot's five review findings on the first push are all addressed in the second commit: the unknown-cap sentence (`PluginGrant.TierRefusal` normalizes to the ladder), the malformed module name (no marker, no throw), the installed-but-downgraded card, the partial-listing marker clear (`ListingIncomplete`), and the inline sidecar read at startup (FileSystem pool).

Guards run locally against the merge base: `check-record-signatures.py` (no public record's primary constructor changed — every addition is an init property or a new type), `check-type-forwards.py`, `check-i18n-mirror-sync.py`.

Not touched: workflows, `AGENTS.md`, skills, `.github/scripts/*`, MeshWeaver.Plugins (the host's `RequiredModulesHealthCheck` needs no change — it already reads the activation list this PR extends).

## i18n mirror handover

Two new keys, `ui.packageRefusedByPlanTier` and `ui.packageInstalledAboveThisPlan` (en/de). As with #4091 (handed to MeshWeaver.Plugins#1716), the React/RN mirror is synced from the plugins repo after this merges.

Mirror-sync: MeshWeaver.Plugins will run `npm run sync:i18n -- --ref <the merged core sha of this PR>` — tracked on #4097 until the plugins PR carrying it is opened

🤖 Generated with [Claude Code](https://claude.com/claude-code)
