### PR TITLE
fix(hosting): invalidate every replica from storage changes

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -251,7 +251,7 @@ public static class JsonSynchronizationStream
     }
 
     /// <summary>
-    /// Subscribes to the mesh change feed (resolved via reflection to avoid a
+    /// Subscribes to the mesh invalidation feed (resolved via reflection to avoid a
     /// Data → Mesh.Contract → Layout → Data project cycle) and invokes
     /// <paramref name="onOwnerChanged"/> with the announced node version when an event's Path
     /// equals the owner's bare path. Returns null if no change-feed service is registered.
@@ -262,11 +262,18 @@ public static class JsonSynchronizationStream
         try
         {
             var feedType = Type.GetType(
-                "MeshWeaver.Mesh.Services.IMeshChangeFeed, MeshWeaver.Mesh.Contract",
+                "MeshWeaver.Mesh.Services.IMeshInvalidationFeed, MeshWeaver.Mesh.Contract",
                 throwOnError: false);
-            if (feedType is null) return null;
-            var feed = serviceProvider.GetService(feedType);
-            if (feed is null) return null;
+            var feed = feedType is null ? null : serviceProvider.GetService(feedType);
+            if (feed is null)
+            {
+                // Compatibility for minimal hosts that supply their own pre-split logical feed.
+                feedType = Type.GetType(
+                    "MeshWeaver.Mesh.Services.IMeshChangeFeed, MeshWeaver.Mesh.Contract",
+                    throwOnError: false);
+                feed = feedType is null ? null : serviceProvider.GetService(feedType);
+            }
+            if (feedType is null || feed is null) return null;
 
             var eventType = Type.GetType(
                 "MeshWeaver.Mesh.Services.MeshChangeEvent, MeshWeaver.Mesh.Contract",
@@ -280,19 +287,20 @@ public static class JsonSynchronizationStream
                 nameof(SubscribeOwnerPathChangeFeedHelper),
                 System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!
                 .MakeGenericMethod(eventType);
-            return (IDisposable?)helper.Invoke(null, [feed, pathProp, versionProp, ownerPath, onOwnerChanged]);
+            return (IDisposable?)helper.Invoke(
+                null, [feed, feedType, pathProp, versionProp, ownerPath, onOwnerChanged]);
         }
         catch (Exception ex)
         {
             logger.LogDebug(ex,
-                "Stream subscriber could not attach MeshChangeFeed listener for {Owner} — falling back to heartbeat-only resubscribe.",
+                "Stream subscriber could not attach MeshInvalidationFeed listener for {Owner} — falling back to heartbeat-only resubscribe.",
                 ownerPath);
             return null;
         }
     }
 
     private static IDisposable? SubscribeOwnerPathChangeFeedHelper<TEvent>(
-        object feed, System.Reflection.PropertyInfo pathProperty,
+        object feed, Type feedType, System.Reflection.PropertyInfo pathProperty,
         System.Reflection.PropertyInfo? versionProperty, string ownerPath, Action<long> onOwnerChanged)
         where TEvent : class
     {
@@ -310,7 +318,7 @@ public static class JsonSynchronizationStream
             }
             catch { /* keep change-feed alive on handler faults */ }
         };
-        var subscribe = feed.GetType().GetMethod("Subscribe");
+        var subscribe = feedType?.GetMethod("Subscribe");
         return (IDisposable?)subscribe!.Invoke(feed, [handler, null]);
     }
 

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -76,7 +76,7 @@ public class Workspace : IWorkspace
         // GetRemoteStream after eviction creates a fresh subscription against the
         // (re-)activated owner and pulls the current persistence state.
         //
-        // IMeshChangeFeed lives in MeshWeaver.Mesh.Contract which would create a
+        // IMeshInvalidationFeed lives in MeshWeaver.Mesh.Contract which would create a
         // Data → Mesh.Contract → Layout → Data project cycle. Resolve via reflection
         // and adapt the Subscribe(Action<MeshChangeEvent>, MeshChangeKind?) signature.
         _changeFeedSubscription = TrySubscribeToChangeFeed(hub.ServiceProvider, _logger,
@@ -238,10 +238,21 @@ public class Workspace : IWorkspace
     {
         try
         {
-            var feedType = Type.GetType("MeshWeaver.Mesh.Services.IMeshChangeFeed, MeshWeaver.Mesh.Contract", throwOnError: false);
-            if (feedType is null) return null;
-            var feed = serviceProvider.GetService(feedType);
-            if (feed is null) return null;
+            var feedType = Type.GetType(
+                "MeshWeaver.Mesh.Services.IMeshInvalidationFeed, MeshWeaver.Mesh.Contract",
+                throwOnError: false);
+            var feed = feedType is null ? null : serviceProvider.GetService(feedType);
+            if (feed is null)
+            {
+                // Compatibility for minimal hosts that supply their own pre-split logical feed.
+                feedType = Type.GetType(
+                    "MeshWeaver.Mesh.Services.IMeshChangeFeed, MeshWeaver.Mesh.Contract",
+                    throwOnError: false);
+                feed = feedType is null ? null : serviceProvider.GetService(feedType);
+            }
+            if (feedType is null || feed is null) return null;
+            var subscribe = feedType.GetMethod("Subscribe");
+            if (subscribe is null) return null;
 
             var eventType = Type.GetType("MeshWeaver.Mesh.Services.MeshChangeEvent, MeshWeaver.Mesh.Contract", throwOnError: false);
             if (eventType is null) return null;
@@ -252,18 +263,18 @@ public class Workspace : IWorkspace
             // runtime sees the exact delegate signature Subscribe expects.
             var helper = typeof(Workspace).GetMethod(nameof(SubscribeChangeFeedHelper),
                 BindingFlags.NonPublic | BindingFlags.Static)!.MakeGenericMethod(eventType);
-            return (IDisposable?)helper.Invoke(null, [feed, pathProp, onPathChanged]);
+            return (IDisposable?)helper.Invoke(null, [feed, subscribe, pathProp, onPathChanged]);
         }
         catch (Exception ex)
         {
             logger.LogWarning(ex,
-                "Workspace failed to subscribe to IMeshChangeFeed — remote stream cache will only invalidate via heartbeat resubscribe.");
+                "Workspace failed to subscribe to IMeshInvalidationFeed — remote stream cache will only invalidate via heartbeat resubscribe.");
             return null;
         }
     }
 
     private static IDisposable? SubscribeChangeFeedHelper<TEvent>(
-        object feed, PropertyInfo pathProperty, Action<string> onPathChanged)
+        object feed, MethodInfo subscribe, PropertyInfo pathProperty, Action<string> onPathChanged)
         where TEvent : class
     {
         Action<TEvent> handler = evt =>
@@ -275,7 +286,6 @@ public class Workspace : IWorkspace
             }
             catch { /* keep change-feed alive on handler faults */ }
         };
-        var subscribe = feed.GetType().GetMethod("Subscribe");
         return (IDisposable?)subscribe!.Invoke(feed, [handler, null]);
     }
 
@@ -287,7 +297,7 @@ public class Workspace : IWorkspace
     ///
     /// <para>🚨🚨 <b>DO NOT make this conditional on the stream still being LIVE.</b> It is the
     /// obvious change to make — the mirror looks healthy, the owner's own fan-out delivers routine
-    /// updates, and the two other consumers of this same <c>IMeshChangeFeed</c> broadcast already
+    /// updates, and the two other consumers of this same <c>IMeshInvalidationFeed</c> broadcast already
     /// say so in as many words (<c>MeshNodeStreamCache.ResetFailureState</c>: <i>"A healthy live
     /// entry is left untouched"</i>; <c>JsonSynchronizationStream</c>'s version-gated
     /// <c>Resubscribe</c>: <i>"a HEALTHY subscriber receives that same write through its own

--- a/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
@@ -44,7 +44,7 @@ Registered once, `silo.AddMemoryStreams(StreamProviders.Memory)` in
 |---|---|---|---|
 | `RoutingGrain.BuildPodHubRoute` → `FallBackToStream` | a delivery to a stream-routed address (`portal`, `client`, `cache`, `mesh`, `import`) **only after** the directed `IPodHubGrain.Deliver` threw `PodHubNotHereException` | the owner's `SubscribeWhenStreamingReadyAsync` subscription | the requester waits out its budget (#2320, #2322, #2406) |
 | `RoutingGrain.PostFailure` → `PublishFailureOverStream` | a `DeliveryFailure` to a stream-routed sender, when the directed NACK failed for any reason | same | the sender waits out its budget |
-| `OrleansMeshChangeFeed.BroadcastAsync` | every `MeshChangeEvent` (Created / Updated / Deleted), one stream per kind | `PathCacheInvalidatorGrain` on every other silo → `InProcessMeshChangeFeed.PublishLocal` | **permanent, silent, per-node staleness** on every other silo — the path-resolution cache, the remote-stream cache, `NodeTypeRebindWatcher`, `EventSubscriptionRunner`, `AccessGrantNotifier`, `SyncedQueryMeshNodes` all miss it for the life of the process |
+| `OrleansMeshChangeFeed.BroadcastAsync` | every `MeshChangeEvent` (Created / Updated / Deleted), one stream per kind | intended: `PathCacheInvalidatorGrain` → `InProcessMeshChangeFeed.PublishLocal`; actual default composition selects the local feed before the wrapper, and the grain key would activate once per cluster rather than once per silo | **permanent, silent, per-node staleness** on replicas that never receive it — the path-resolution cache, the remote-stream cache, `NodeTypeRebindWatcher`, `EventSubscriptionRunner`, `AccessGrantNotifier`, `SyncedQueryMeshNodes` all miss it for the life of the process |
 | `RootMeshHubReplyStreamService` | the `mesh/{id}` root hub's *subscription* (not a publisher) | the root hub | cross-silo replies to the root hub — served by the directed call since the swap; the stream is its fallback |
 
 Two facts that change the shape of the design, both verified from source:
@@ -58,8 +58,8 @@ Two facts that change the shape of the design, both verified from source:
    registers `PostgreSqlChangeListener` *and* the `IHostedService` that opens its `LISTEN mesh_node_changes`
    session (`PostgreSqlExtensions.cs`, pinned by `ChangeListenerWiringTests` since #1814/#1816).
    Every commit on any `mesh_nodes` table fires `notify_mesh_node_changes()`, which already
-   de-duplicates no-op updates. The feed carries `{path, op}` and surfaces as
-   `IStorageAdapter.Changes` (`DataChangeNotification`, `Entity = null`). Several code comments still
+   de-duplicates no-op updates. The feed carries `{path, op, node_type}` and surfaces as
+   `IStorageAdapter.Changes` (`DataChangeNotification`, with an identifier-only descriptor). Several code comments still
    say this session "is not started in the partitioned wiring"; they date from before #1816 and
    are wrong — see *Stale claims* below.
 
@@ -178,29 +178,34 @@ be loud (a windowed `Warning` naming the address) rather than silent.
 This is the only memory-stream user whose loss is **permanent**, and it is also the one with a
 ready-made durable substitute that the platform already operates, monitors and backs up.
 
-Today there are two parallel cross-process channels for the same commit:
+Before the storage relay there were two parallel cross-process channels for the same commit:
 
 ```
-write ──commit──► pg_notify('mesh_node_changes', {path, op})  ──LISTEN──► IStorageAdapter.Changes  ─► synced queries re-run,
+write ──commit──► pg_notify('mesh_node_changes', {path, op, node_type}) ──LISTEN──► IStorageAdapter.Changes ─► synced queries re-run,
                                                                                                     MeshDataSource reconcile re-reads
       └─post-commit─► IMeshChangeFeed.Publish(MeshChangeEvent)  ─local Subject─► consumers
                                 └─► Orleans memory stream "mesh-{kind}" ─► PathCacheInvalidatorGrain (other silos) ─► PublishLocal
 ```
 
-The design collapses the second cross-process leg onto the first:
+The first core slice collapses the cache-invalidation leg onto the storage feed while retaining the
+Orleans broadcast during the additive rollout:
 
-1. **The NOTIFY payload carries `nodeType` and `version`** beside `path` and `op` — the trigger
-   already has `NEW.node_type` / `NEW.version` in hand. `DataChangeNotification` gains
+1. **The notification contract carries `NodeType` and `Version`.** The PostgreSQL trigger already
+   sends `node_type` beside `path` and `op`, and has `NEW.version` in hand. `DataChangeNotification` gains
    `NodeType` and `Version` as **optional** members (additive; every existing producer passes
    `null`). Core lands first, the trigger change in the PostgreSql adapter second; the relay below
    tolerates a payload without them by re-reading the node before any consumer that filters on
    type sees the event.
-2. **A relay, not a grain.** A mesh-scoped singleton `StorageChangeFeedRelay` subscribes
+2. **A relay, not a grain.** The mesh-scoped `InProcessMeshChangeFeed` owns one
+   `StorageChangeFeedRelay`, which subscribes
    `IStorageAdapter.Changes` and relays each notification into
-   `InProcessMeshChangeFeed.PublishLocal(MeshChangeEvent)`. It replaces `OrleansMeshChangeFeed`'s
-   broadcast queue and `PathCacheInvalidatorGrain` entirely; `IMeshChangeFeed` is
-   `InProcessMeshChangeFeed` on every host, and a monolith or `LocalMesh` process that shares a
-   database with another process gains cross-process invalidation it never had.
+   `InProcessMeshChangeFeed.PublishLocal(MeshChangeEvent)`. Each process therefore receives its
+   own database listener's copy directly. A monolith or `LocalMesh` process that shares a database
+   with another process gains cross-process invalidation too. The old Orleans broadcast classes
+   remain binary-compatible during the additive rollout; the default Orleans composition already
+   resolves the process-local feed because `AddPartitionedInMemoryPersistence` registers it before
+   the wrapper's `TryAdd`. After the PostgreSQL payload upgrade ships, the dead wrapper registration
+   and `PathCacheInvalidatorGrain` can be deleted without a mixed-version gap.
 3. **Own-write echoes are already tolerated.** Every consumer of `IMeshChangeFeed` is an
    invalidation or a `Pending → Fired`-gated continuation, and on the publishing silo they *already*
    receive each own write twice — once from `Publish`, once relayed back by that silo's own
@@ -215,6 +220,25 @@ The design collapses the second cross-process leg onto the first:
 5. **Backend-agnostic by construction.** Cosmos and Snowflake already feed `Changes` with
    `Entity = null`; the in-memory and file-system adapters feed it in-process. The relay does not
    know which one it is on.
+
+### The production proof that selected the relay
+
+On 2026-09-12 the public two-replica portal held two incompatible answers for the same path after a
+successful plugin publication. An exact read of `Hosting/PlatformBuilds/plugins` on one request
+returned the old v7 row and source SHA, while the children query returned a newly-created v1 row
+with a different storage identity and the current SHA. The new row had committed and its Created
+notification had been emitted; one process's exact-path cache had simply never seen it.
+
+The reason is structural twice over. The default Orleans composition calls
+`AddPartitionedInMemoryPersistence` first; that reaches `AddMeshCatalog` and registers
+`IMeshChangeFeed` as the process-local feed, so the later Orleans wrapper's `TryAdd` is ignored.
+Even if that order were reversed, `OrleansMeshChangeFeed` publishes every kind at stream id
+`Guid.Empty`, and `PathCacheInvalidatorGrain` is an ordinary grain at that same key. Orleans grain
+identity is a cluster singleton, although the class comment claimed one activation per silo. Its
+handler calls a process-local `InProcessMeshChangeFeed`, so only the process hosting that one
+activation is invalidated. No retry, registration reorder or second publish can guarantee delivery
+to every process. Subscribing each process to the storage notification stream removes both
+impossible fan-out assumptions.
 
 ## 4 · At-least-once work items — the `_Inbox` node is the durable stream
 
@@ -259,7 +283,7 @@ checked against it:
 | pod-hub claim: indefinite, derived lifetime, `Warning` where grains can be hosted | **landed** — #2745 | closed the #1742 residual *"a claim that fails to land degrades silently"*; core only |
 | routing: transient NACK on `PodHubNotHere`; fallback gated on declared client-hosted types | **landed** — #2745 | closed #2320, #2322, #2406 as *made unreachable*. Shipped with slice 1 rather than after a clean roll — see *The N+2 gate* above for why the two together satisfy it by construction |
 | owner-side eviction re-gated on the `TargetUnserved` STAMP alone | **landed with the slice above** | required by it: gating on `NotFound` would have made the new verdict inert and re-opened #2426/#2546 |
-| `DataChangeNotification.NodeType/Version` + `StorageChangeFeedRelay` | next | **core first**; the relay must tolerate a payload without the new fields |
+| `DataChangeNotification.NodeType/Version` + `StorageChangeFeedRelay` | **implemented in the first core slice** | relay owns the mixed-version reread; tests pin one shared local feed, old-payload recovery, per-event failure isolation and two independent replica feeds |
 | `notify_mesh_node_changes()` emits `nodeType`, `version` | after the core slice | PostgreSql adapter (MeshWeaver.Plugins); a schema-initializer revision, re-applied by the existing DROP-then-CREATE |
 | delete `OrleansMeshChangeFeed` broadcast + `PathCacheInvalidatorGrain` | after both | the memory stream then carries routing fallback only |
 | `StreamMessageSizeGuard` retarget onto `MaxMessageBodySize` | optional, not blocking | the directed call already THROWS at that wall, which is the outcome the guard produces — see the bullet above |

--- a/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
@@ -191,11 +191,14 @@ The first core slice collapses the cache-invalidation leg onto the storage feed 
 Orleans broadcast during the additive rollout:
 
 1. **The notification contract carries `NodeType` and `Version`.** The PostgreSQL trigger already
-   sends `node_type` beside `path` and `op`, and has `NEW.version` in hand. `DataChangeNotification` gains
-   `NodeType` and `Version` as **optional** members (additive; every existing producer passes
-   `null`). Core lands first, the trigger change in the PostgreSql adapter second; the relay below
-   tolerates a payload without them by re-reading the node before any consumer that filters on
-   type sees the event.
+   sends `node_type` beside `path` and `op`, and has `NEW.version` in hand. `DataChangeNotification`
+   gains `NodeType` and `Version` as **optional** members. Typed in-process producers derive the
+   hints from their entity immediately; older and path-only backend payloads leave them null. Core
+   lands first, the trigger change in the PostgreSql adapter second; the relay below tolerates a
+   payload without them by re-reading the node before any consumer that filters on type sees the
+   event. That compatibility read has a five-second bound. An error, silence or missing row still
+   emits a path-only version-zero invalidation, so one backend fault cannot wedge the serial relay
+   or leave the replica's exact-path cache untouched.
 2. **A relay, not a grain.** The mesh-scoped `InProcessMeshChangeFeed` owns one
    `StorageChangeFeedRelay`, which subscribes
    `IStorageAdapter.Changes` and relays each notification into
@@ -212,7 +215,9 @@ Orleans broadcast during the additive rollout:
    `InstanceSyncCoordinator` (which can write to another instance). Sending a database echo through
    the logical feed would run those effects once per replica, while PostgreSQL can additionally
    echo the writer's own commit. Cache invalidators are idempotent and deliberately run in every
-   process; logical effects retain the publisher's single delivery.
+   process; logical effects retain the publisher's single delivery. Both channels serialize
+   concurrent publishers. Invalidation subscribers are isolated per callback, so a broken cache
+   misses its own event and cannot prevent later caches from receiving the same commit.
 4. **Loss semantics are strictly better.** A NOTIFY is missed only inside the listener's own
    reconnect window (a 5 s retry loop, logged at `Error`), which is the window the synced queries
    already accept and the reconcile-on-start pattern in

--- a/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DurableStreamsViaMeshNodes.md
@@ -44,7 +44,7 @@ Registered once, `silo.AddMemoryStreams(StreamProviders.Memory)` in
 |---|---|---|---|
 | `RoutingGrain.BuildPodHubRoute` → `FallBackToStream` | a delivery to a stream-routed address (`portal`, `client`, `cache`, `mesh`, `import`) **only after** the directed `IPodHubGrain.Deliver` threw `PodHubNotHereException` | the owner's `SubscribeWhenStreamingReadyAsync` subscription | the requester waits out its budget (#2320, #2322, #2406) |
 | `RoutingGrain.PostFailure` → `PublishFailureOverStream` | a `DeliveryFailure` to a stream-routed sender, when the directed NACK failed for any reason | same | the sender waits out its budget |
-| `OrleansMeshChangeFeed.BroadcastAsync` | every `MeshChangeEvent` (Created / Updated / Deleted), one stream per kind | intended: `PathCacheInvalidatorGrain` → `InProcessMeshChangeFeed.PublishLocal`; actual default composition selects the local feed before the wrapper, and the grain key would activate once per cluster rather than once per silo | **permanent, silent, per-node staleness** on replicas that never receive it — the path-resolution cache, the remote-stream cache, `NodeTypeRebindWatcher`, `EventSubscriptionRunner`, `AccessGrantNotifier`, `SyncedQueryMeshNodes` all miss it for the life of the process |
+| `OrleansMeshChangeFeed.BroadcastAsync` | every `MeshChangeEvent` (Created / Updated / Deleted), one stream per kind | intended: `PathCacheInvalidatorGrain` → process-local cache invalidation; actual default composition selects the local feed before the wrapper, and the grain key would activate once per cluster rather than once per silo | **permanent, silent, per-node staleness** on replicas that never receive it — the path-resolution cache, the remote-stream cache, `NodeTypeRebindWatcher`, activation-failure registry and `SyncedQueryMeshNodes` all miss it for the life of the process |
 | `RootMeshHubReplyStreamService` | the `mesh/{id}` root hub's *subscription* (not a publisher) | the root hub | cross-silo replies to the root hub — served by the directed call since the swap; the stream is its fallback |
 
 Two facts that change the shape of the design, both verified from source:
@@ -199,18 +199,20 @@ Orleans broadcast during the additive rollout:
 2. **A relay, not a grain.** The mesh-scoped `InProcessMeshChangeFeed` owns one
    `StorageChangeFeedRelay`, which subscribes
    `IStorageAdapter.Changes` and relays each notification into
-   `InProcessMeshChangeFeed.PublishLocal(MeshChangeEvent)`. Each process therefore receives its
-   own database listener's copy directly. A monolith or `LocalMesh` process that shares a database
-   with another process gains cross-process invalidation too. The old Orleans broadcast classes
-   remain binary-compatible during the additive rollout; the default Orleans composition already
-   resolves the process-local feed because `AddPartitionedInMemoryPersistence` registers it before
-   the wrapper's `TryAdd`. After the PostgreSQL payload upgrade ships, the dead wrapper registration
-   and `PathCacheInvalidatorGrain` can be deleted without a mixed-version gap.
-3. **Own-write echoes are already tolerated.** Every consumer of `IMeshChangeFeed` is an
-   invalidation or a `Pending → Fired`-gated continuation, and on the publishing silo they *already*
-   receive each own write twice — once from `Publish`, once relayed back by that silo's own
-   `PathCacheInvalidatorGrain`. The relay changes the second delivery's transport, not its
-   existence.
+   the process-local `IMeshInvalidationFeed`. Each process therefore receives its own database
+   listener's copy directly. A monolith or `LocalMesh` process that shares a database with another
+   process gains cross-process invalidation too. The old Orleans broadcast classes remain
+   binary-compatible during the additive rollout; their `PublishLocal` entry point now feeds only
+   invalidators. After the PostgreSQL payload upgrade ships, the dead wrapper registration and
+   `PathCacheInvalidatorGrain` can be deleted without a mixed-version gap.
+3. **Cache invalidation and logical delivery are separate.** A direct
+   `IMeshChangeFeed.Publish` reaches both logical subscribers and the writer's local invalidators.
+   A storage or Orleans echo reaches only `IMeshInvalidationFeed`. This boundary is load-bearing:
+   logical subscribers include `AccessGrantNotifier` (which can send mail) and
+   `InstanceSyncCoordinator` (which can write to another instance). Sending a database echo through
+   the logical feed would run those effects once per replica, while PostgreSQL can additionally
+   echo the writer's own commit. Cache invalidators are idempotent and deliberately run in every
+   process; logical effects retain the publisher's single delivery.
 4. **Loss semantics are strictly better.** A NOTIFY is missed only inside the listener's own
    reconnect window (a 5 s retry loop, logged at `Error`), which is the window the synced queries
    already accept and the reconcile-on-start pattern in
@@ -283,7 +285,7 @@ checked against it:
 | pod-hub claim: indefinite, derived lifetime, `Warning` where grains can be hosted | **landed** — #2745 | closed the #1742 residual *"a claim that fails to land degrades silently"*; core only |
 | routing: transient NACK on `PodHubNotHere`; fallback gated on declared client-hosted types | **landed** — #2745 | closed #2320, #2322, #2406 as *made unreachable*. Shipped with slice 1 rather than after a clean roll — see *The N+2 gate* above for why the two together satisfy it by construction |
 | owner-side eviction re-gated on the `TargetUnserved` STAMP alone | **landed with the slice above** | required by it: gating on `NotFound` would have made the new verdict inert and re-opened #2426/#2546 |
-| `DataChangeNotification.NodeType/Version` + `StorageChangeFeedRelay` | **implemented in the first core slice** | relay owns the mixed-version reread; tests pin one shared local feed, old-payload recovery, per-event failure isolation and two independent replica feeds |
+| `DataChangeNotification.NodeType/Version` + `StorageChangeFeedRelay` | **implemented in the first core slice** | relay owns the mixed-version reread; tests pin the logical/invalidation boundary, old-payload recovery, per-event failure isolation and two independent replica feeds |
 | `notify_mesh_node_changes()` emits `nodeType`, `version` | after the core slice | PostgreSql adapter (MeshWeaver.Plugins); a schema-initializer revision, re-applied by the existing DROP-then-CREATE |
 | delete `OrleansMeshChangeFeed` broadcast + `PathCacheInvalidatorGrain` | after both | the memory stream then carries routing fallback only |
 | `StreamMessageSizeGuard` retarget onto `MaxMessageBodySize` | optional, not blocking | the directed call already THROWS at that wall, which is the outcome the guard produces — see the bullet above |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
@@ -1,0 +1,19 @@
+---
+Name: Every portal replica sees a committed change
+Category: Fix
+Description: A database change now invalidates the matching caches in every running portal replica, so one request cannot keep seeing an old node after another replica has already loaded the new one.
+Icon: ArrowSync
+Order: -20260912
+---
+
+# Every portal replica sees a committed change
+
+A multi-replica portal could hold two answers for the same node after a successful update. One
+replica loaded the new database row while another kept serving its old exact-path cache, sometimes
+until that process restarted. This surfaced during plugin publication: the plugin list showed the
+current build while an exact lookup still returned the previous one.
+
+Every process now connects its database change listener directly to its local cache invalidation
+feed. Older notification payloads remain supported during rollout by reading the committed row once
+for its node type and version. A notification handled by one replica no longer has to reach another
+replica's process memory through a single cluster grain.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
@@ -18,4 +18,6 @@ feed. Older notification payloads remain supported during rollout by reading the
 for its node type and version. A notification handled by one replica no longer has to reach another
 replica's process memory through a single cluster grain. Database echoes stay on the cache-only
 feed, so actions such as access-grant email and instance synchronization still run once from the
-writer's logical event.
+writer's logical event. Concurrent notifications are serialized, one broken cache cannot starve
+the others, and an older notification whose metadata read fails or stays silent still clears the
+path before the relay continues.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-12-every-portal-replica-sees-a-committed-change.md
@@ -16,4 +16,6 @@ current build while an exact lookup still returned the previous one.
 Every process now connects its database change listener directly to its local cache invalidation
 feed. Older notification payloads remain supported during rollout by reading the committed row once
 for its node type and version. A notification handled by one replica no longer has to reach another
-replica's process memory through a single cluster grain.
+replica's process memory through a single cluster grain. Database echoes stay on the cache-only
+feed, so actions such as access-grant email and instance synchronization still run once from the
+writer's logical event.

--- a/src/MeshWeaver.Graph.Contract/SyncedQueryMeshNodes.cs
+++ b/src/MeshWeaver.Graph.Contract/SyncedQueryMeshNodes.cs
@@ -193,7 +193,7 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
     ///         per-query stream plus the
     ///         <see cref="_externalChanges"/> side-channel (synthetic
     ///         <see cref="NotifyDeleted"/> events) and
-    ///         <see cref="IMeshChangeFeed"/> deletion fast-path into a
+    ///         <see cref="IMeshInvalidationFeed"/> deletion fast-path into a
     ///         single tagged stream of
     ///         <see cref="QueryResultChange{MeshNode}"/>.</item>
     ///   <item>A single <c>Scan</c> folds the deltas into
@@ -205,7 +205,7 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
     ///         ALL downstream emissions until the upstream query has produced
     ///         its first provider <c>Initial</c>/<c>Reset</c>. The
     ///         <see cref="_externalChanges"/> side-channel and the
-    ///         <see cref="IMeshChangeFeed"/> deletion fast-path are NOT
+    ///         <see cref="IMeshInvalidationFeed"/> deletion fast-path are NOT
     ///         filtered by the query — if either fires in the
     ///         subscribe→Initial window, an un-gated Scan emits an EMPTY
     ///         dictionary as its FIRST emission, which <c>Replay(1)</c>
@@ -314,24 +314,30 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
         }
 
         // Hub-level change-feed deletion fast-path: when ANY hub publishes a
-        // delete via IMeshChangeFeed (the canonical post-delete dispatch in
+        // delete via IMeshInvalidationFeed (the canonical post-delete dispatch in
         // <c>HandleDeleteNodeRequest</c>), translate it into a synthetic
         // Removed event for the path-set Scan. Synchronous reliability path
         // on top of the upstream IMeshQueryProvider.Query's Removed
         // event, which can be debounced/stalled by the persistence layer's
         // change-notifier and security-filter chain.
-        var changeFeed = workspace.Hub.ServiceProvider.GetService<IMeshChangeFeed>();
-        var feedRemovals = changeFeed is null
+        var invalidationFeed = workspace.Hub.ServiceProvider.GetService<IMeshInvalidationFeed>();
+        var legacyFeed = invalidationFeed is null
+            ? workspace.Hub.ServiceProvider.GetService<IMeshChangeFeed>()
+            : null;
+        var feedRemovals = invalidationFeed is null && legacyFeed is null
             ? Observable.Empty<QueryResultChange<MeshNode>>()
             : Observable.Create<QueryResultChange<MeshNode>>(observer =>
-                changeFeed.Subscribe(
-                    e => observer.OnNext(new QueryResultChange<MeshNode>
-                    {
-                        ChangeType = QueryChangeType.Removed,
-                        Items = new[] { new MeshNode(e.Path) },
-                        Timestamp = e.Timestamp,
-                    }),
-                    MeshChangeKind.Deleted));
+            {
+                void Removed(MeshChangeEvent e) => observer.OnNext(new QueryResultChange<MeshNode>
+                {
+                    ChangeType = QueryChangeType.Removed,
+                    Items = new[] { new MeshNode(e.Path) },
+                    Timestamp = e.Timestamp,
+                });
+                return invalidationFeed is not null
+                    ? invalidationFeed.Subscribe(Removed, MeshChangeKind.Deleted)
+                    : legacyFeed!.Subscribe(Removed, MeshChangeKind.Deleted);
+            });
 
         var allChanges = upstream.Merge(externalChanges).Merge(feedRemovals);
 
@@ -346,7 +352,7 @@ public sealed record SyncedQueryMeshNodes : VirtualTypeSource<MeshNode>
         // promises NO downstream emission until the upstream query has
         // produced its first Initial/Reset. `externalChanges` (the
         // NotifyDeleted side-channel) and `feedRemovals` (the process-wide
-        // IMeshChangeFeed deletions, UNFILTERED by this query) can fire in
+        // IMeshInvalidationFeed deletions, UNFILTERED by this query) can fire in
         // the subscribe→Initial window; without the gate the Scan's FIRST
         // emission is an EMPTY dictionary, which Replay(1) consumers
         // (MeshNodeStreamCache.GetQueryRaw) cache and replay — downstream

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeRebindWatcher.cs
@@ -38,7 +38,7 @@ namespace MeshWeaver.Graph.Configuration;
 /// <para><b>The mechanism.</b> Every activation arms a watcher on the instance hub (the same
 /// <c>WithInitialization</c> + self-<see cref="DisposeRequest"/> idiom as
 /// <c>NodeTypeEnrichmentHelpers.ArmOverlaySelfHeal</c> and <c>RecycleLayoutArea</c>). It observes
-/// <see cref="IMeshChangeFeed"/> for THIS node's path and recycles the hub the first time an event
+/// <see cref="IMeshInvalidationFeed"/> for THIS node's path and recycles the hub the first time an event
 /// reports a NodeType different from the one the configuration was bound from. The hub tears down,
 /// the next access re-activates it, and enrichment binds the node's real type.</para>
 ///
@@ -71,6 +71,14 @@ namespace MeshWeaver.Graph.Configuration;
 /// </summary>
 internal static class NodeTypeRebindWatcher
 {
+    private sealed class LegacyInvalidationFeed(IMeshChangeFeed feed) : IMeshInvalidationFeed
+    {
+        public IDisposable Subscribe(
+            Action<MeshChangeEvent> handler,
+            MeshChangeKind? filter = null)
+            => feed.Subscribe(handler, filter);
+    }
+
     /// <summary>
     /// Wraps <paramref name="enriched"/>'s HubConfiguration so the hub it activates arms the
     /// rebind watcher. The baseline is <paramref name="enriched"/>'s own NodeType — the type the
@@ -104,7 +112,10 @@ internal static class NodeTypeRebindWatcher
                         // on its activation-time type until someone recycles it), never a dead hub.
                         try
                         {
-                            var feed = meshHub.ServiceProvider.GetService<IMeshChangeFeed>();
+                            var feed = meshHub.ServiceProvider.GetService<IMeshInvalidationFeed>();
+                            if (feed is null
+                                && meshHub.ServiceProvider.GetService<IMeshChangeFeed>() is { } logicalFeed)
+                                feed = new LegacyInvalidationFeed(logicalFeed);
                             if (feed is null)
                                 return;
                             // #3510: a recycle of a root an install is writing under waits for the
@@ -150,7 +161,7 @@ internal static class NodeTypeRebindWatcher
     /// <param name="leases">The mesh's install-lease registry, or null on a host that registers
     /// none — in which case no lease can exist and the recycle posts as it always did.</param>
     public static IDisposable Arm(
-        IMeshChangeFeed feed,
+        IMeshInvalidationFeed feed,
         IMessageHub instanceHub,
         string path,
         string? boundNodeType,

--- a/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
+++ b/src/MeshWeaver.Hosting.Orleans/GrainActivationFailureRegistry.cs
@@ -33,9 +33,8 @@ namespace MeshWeaver.Hosting.Orleans;
 /// recompiled fix re-activates cleanly and the stale error is gone.</para>
 ///
 /// <para><b>Invalidation.</b> The registry also subscribes to the
-/// <see cref="IMeshChangeFeed"/> invalidation broadcast (the same signal a recycle —
-/// <c>MeshOperations.RecycleCore</c> — and every post-commit write publish, relayed
-/// cross-silo by <c>PathCacheInvalidatorGrain</c>): a change event for a path clears any
+/// <see cref="IMeshInvalidationFeed"/> broadcast (the same signal a recycle —
+/// <c>MeshOperations.RecycleCore</c> — and every post-commit write publish): a change event for a path clears any
 /// stored activation error for that grain key. A recycled / just-written node must get a
 /// completely fresh activation attempt — without this, <see cref="RoutingGrain"/>'s
 /// NACK fallback served the STALE pre-recycle error text (e.g. a compile failure that was
@@ -57,8 +56,23 @@ public sealed class GrainActivationFailureRegistry : IDisposable
     /// fixtures) the registry still works, it just never auto-clears on broadcasts.</param>
     public GrainActivationFailureRegistry(IMeshChangeFeed? changeFeed = null)
     {
-        _changeFeedSubscription = changeFeed?.Subscribe(evt => Clear(evt.Path));
+        _changeFeedSubscription = changeFeed?.Subscribe(OnMeshChanged);
     }
+
+    private GrainActivationFailureRegistry(IMeshInvalidationFeed? invalidationFeed)
+    {
+        _changeFeedSubscription = invalidationFeed?.Subscribe(OnMeshChanged);
+    }
+
+    /// <summary>
+    /// Creates the process registry against the cache-only invalidation feed. Kept as a factory so
+    /// the public legacy constructor above retains its exact binary signature.
+    /// </summary>
+    internal static GrainActivationFailureRegistry FromInvalidationFeed(
+        IMeshInvalidationFeed? invalidationFeed)
+        => new(invalidationFeed);
+
+    private void OnMeshChanged(MeshChangeEvent change) => Clear(change.Path);
 
     /// <summary>Record the real activation error for <paramref name="grainKey"/>.</summary>
     public void Record(string grainKey, string error)

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -205,10 +205,11 @@ public static class OrleansServerRegistryExtensions
         // RoutingGrain falls back to it when a persistent activation-fault loop would otherwise
         // NACK the raw Orleans rejection ("DeactivateOnIdle was called … Rejecting now") instead
         // of the actual cause (a compilation failure). See issue #464, Defect 3.
-        // The registry's ctor takes the IMeshChangeFeed (registered below; DI injects it into
-        // the optional parameter) so a recycle / post-commit invalidation broadcast clears the
-        // stored error — stale pre-recycle error text must never be NACKed after a recycle.
-        services.TryAddSingleton<GrainActivationFailureRegistry>();
+        // The registry listens to cache-only invalidations so every replica clears stale errors
+        // without turning a database echo into a second logical event delivery.
+        services.TryAddSingleton(sp => sp.GetService<IMeshInvalidationFeed>() is { } invalidations
+            ? GrainActivationFailureRegistry.FromInvalidationFeed(invalidations)
+            : new GrainActivationFailureRegistry(sp.GetService<IMeshChangeFeed>()));
 
         // Register Orleans-distributed change feed (wraps local feed + Orleans streams).
         // 🚨 The factory captures the ROOT IServiceProvider (sp), never IMessageHub — the feed is

--- a/src/MeshWeaver.Hosting/MeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting/MeshChangeFeed.cs
@@ -15,8 +15,10 @@ namespace MeshWeaver.Hosting;
 /// </summary>
 public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, IDisposable
 {
-    private readonly Subject<MeshChangeEvent> _subject = new();
-    private readonly Subject<MeshChangeEvent> _invalidations = new();
+    private readonly Subject<MeshChangeEvent> _subjectLifetime = new();
+    private readonly Subject<MeshChangeEvent> _invalidationLifetime = new();
+    private readonly ISubject<MeshChangeEvent> _subject;
+    private readonly ISubject<MeshChangeEvent> _invalidations;
     private readonly StorageChangeFeedRelay? _storageRelay;
     private readonly ILogger? logger;
     private bool _disposed;
@@ -27,6 +29,11 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, I
     /// </summary>
     public InProcessMeshChangeFeed()
     {
+        // Publish and PublishLocal have independent callers (hub threads, storage LISTEN and the
+        // additive Orleans relay). Rx Subject is not safe for concurrent OnNext calls; the
+        // synchronized wrappers preserve one ordered callback at a time in this process.
+        _subject = Subject.Synchronize(_subjectLifetime);
+        _invalidations = Subject.Synchronize(_invalidationLifetime);
     }
 
     /// <summary>
@@ -36,7 +43,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, I
     /// </summary>
     public InProcessMeshChangeFeed(
         IStorageAdapter storage,
-        ILogger<InProcessMeshChangeFeed>? logger = null)
+        ILogger<InProcessMeshChangeFeed>? logger = null) : this()
     {
         this.logger = logger;
         _storageRelay = new StorageChangeFeedRelay(storage, PublishInvalidation, logger);
@@ -89,7 +96,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, I
         => Subscribe(_invalidations, handler, filter, "invalidation");
 
     private IDisposable Subscribe(
-        Subject<MeshChangeEvent> subject,
+        ISubject<MeshChangeEvent> subject,
         Action<MeshChangeEvent> handler,
         MeshChangeKind? filter,
         string? channel)
@@ -129,7 +136,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, I
         _storageRelay?.Dispose();
         _subject.OnCompleted();
         _invalidations.OnCompleted();
-        _subject.Dispose();
-        _invalidations.Dispose();
+        _subjectLifetime.Dispose();
+        _invalidationLifetime.Dispose();
     }
 }

--- a/src/MeshWeaver.Hosting/MeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting/MeshChangeFeed.cs
@@ -1,18 +1,42 @@
 using System.Reactive.Subjects;
+using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting;
 
 /// <summary>
 /// In-process implementation of <see cref="IMeshChangeFeed"/>.
-/// Uses Rx Subject for local pub/sub. Suitable for monolith mode.
-/// In Orleans, <c>OrleansMeshChangeFeed</c> wraps this and adds
-/// BroadcastChannel for cross-silo propagation.
+/// Uses an Rx Subject for local pub/sub and relays the storage adapter's process-local change
+/// channel, so monolith and Orleans hosts receive committed changes made by every process that
+/// shares their durable store. The legacy Orleans wrapper can still forward into this feed during
+/// its additive retirement window.
 /// </summary>
 public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
 {
     private readonly Subject<MeshChangeEvent> _subject = new();
+    private readonly StorageChangeFeedRelay? _storageRelay;
     private bool _disposed;
+
+    /// <summary>
+    /// Creates a standalone in-process feed. Retained as a real parameterless constructor so
+    /// already-compiled consumers keep their existing constructor binding.
+    /// </summary>
+    public InProcessMeshChangeFeed()
+    {
+    }
+
+    /// <summary>
+    /// Creates the mesh-scoped feed and attaches the storage-backed per-process relay.
+    /// Dependency injection selects this constructor in a persistence-enabled host; direct
+    /// standalone callers keep using <see cref="InProcessMeshChangeFeed()"/>.
+    /// </summary>
+    public InProcessMeshChangeFeed(
+        IStorageAdapter storage,
+        ILogger<InProcessMeshChangeFeed>? logger = null)
+    {
+        _storageRelay = new StorageChangeFeedRelay(storage, PublishLocal, logger);
+    }
 
     /// <summary>
     /// Publishes a mesh change event to all local subscribers (no-op once disposed).
@@ -59,6 +83,7 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     {
         if (_disposed) return;
         _disposed = true;
+        _storageRelay?.Dispose();
         _subject.OnCompleted();
         _subject.Dispose();
     }

--- a/src/MeshWeaver.Hosting/MeshChangeFeed.cs
+++ b/src/MeshWeaver.Hosting/MeshChangeFeed.cs
@@ -6,16 +6,19 @@ using Microsoft.Extensions.Logging;
 namespace MeshWeaver.Hosting;
 
 /// <summary>
-/// In-process implementation of <see cref="IMeshChangeFeed"/>.
-/// Uses an Rx Subject for local pub/sub and relays the storage adapter's process-local change
-/// channel, so monolith and Orleans hosts receive committed changes made by every process that
-/// shares their durable store. The legacy Orleans wrapper can still forward into this feed during
-/// its additive retirement window.
+/// In-process implementation of <see cref="IMeshChangeFeed"/> and
+/// <see cref="IMeshInvalidationFeed"/>. Logical post-commit events use one subject; direct
+/// publishes additionally fan into the cache subject. The storage adapter's process-local change
+/// channel reaches only the cache subject, so monolith and Orleans hosts invalidate commits made by
+/// every process without duplicating logical side effects. The legacy Orleans wrapper can still
+/// forward into both feeds during its additive retirement window.
 /// </summary>
-public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
+public class InProcessMeshChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed, IDisposable
 {
     private readonly Subject<MeshChangeEvent> _subject = new();
+    private readonly Subject<MeshChangeEvent> _invalidations = new();
     private readonly StorageChangeFeedRelay? _storageRelay;
+    private readonly ILogger? logger;
     private bool _disposed;
 
     /// <summary>
@@ -35,7 +38,8 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
         IStorageAdapter storage,
         ILogger<InProcessMeshChangeFeed>? logger = null)
     {
-        _storageRelay = new StorageChangeFeedRelay(storage, PublishLocal, logger);
+        this.logger = logger;
+        _storageRelay = new StorageChangeFeedRelay(storage, PublishInvalidation, logger);
     }
 
     /// <summary>
@@ -44,19 +48,30 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     /// <param name="change">The change event to publish.</param>
     public void Publish(MeshChangeEvent change)
     {
-        if (!_disposed)
-            _subject.OnNext(change);
+        if (_disposed)
+            return;
+        _subject.OnNext(change);
+        _invalidations.OnNext(change);
     }
 
     /// <summary>
-    /// Publishes locally without re-broadcasting to Orleans streams.
-    /// Used by PathCacheInvalidatorGrain to relay cross-silo events
-    /// to local subscribers without creating an infinite loop.
+    /// Publishes a cross-silo event to this process's invalidators without re-running logical
+    /// consumers or re-broadcasting to Orleans streams. Retains the method's exact public
+    /// signature for already-compiled <c>PathCacheInvalidatorGrain</c> callers.
     /// </summary>
     public void PublishLocal(MeshChangeEvent change)
     {
+        PublishInvalidation(change);
+    }
+
+    /// <summary>
+    /// Publishes only to process-local cache invalidators. Storage relays use this path so a
+    /// database echo cannot re-run logical side effects such as mail or instance synchronization.
+    /// </summary>
+    internal void PublishInvalidation(MeshChangeEvent change)
+    {
         if (!_disposed)
-            _subject.OnNext(change);
+            _invalidations.OnNext(change);
     }
 
     /// <summary>
@@ -66,15 +81,43 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
     /// <param name="filter">When set, only events of this kind are delivered; otherwise all events are delivered.</param>
     /// <returns>A disposable that ends the subscription when disposed.</returns>
     public IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null)
-    {
-        if (filter == null)
-            return _subject.Subscribe(handler);
+        => Subscribe(_subject, handler, filter, null);
 
-        var kind = filter.Value;
-        return _subject.Subscribe(e =>
+    IDisposable IMeshInvalidationFeed.Subscribe(
+        Action<MeshChangeEvent> handler,
+        MeshChangeKind? filter)
+        => Subscribe(_invalidations, handler, filter, "invalidation");
+
+    private IDisposable Subscribe(
+        Subject<MeshChangeEvent> subject,
+        Action<MeshChangeEvent> handler,
+        MeshChangeKind? filter,
+        string? channel)
+    {
+        return subject.Subscribe(e =>
         {
-            if (e.Kind == kind)
+            if (filter is not null && e.Kind != filter.Value)
+                return;
+            // Preserve the logical feed's existing failure semantics: a logical consumer can be
+            // part of a post-commit operation whose caller must see its failure. Invalidation is
+            // idempotent process-local maintenance, so one bad cache must not starve the others.
+            if (channel is null)
+            {
                 handler(e);
+                return;
+            }
+            try
+            {
+                handler(e);
+            }
+            catch (Exception ex)
+            {
+                // One cache must not prevent the remaining process-local subscribers from seeing
+                // this commit, nor tear down the feed for later events.
+                logger?.LogError(ex,
+                    "Mesh {Channel} feed subscriber failed for {Kind} {Path}; continuing",
+                    channel, e.Kind, e.Path);
+            }
         });
     }
 
@@ -85,6 +128,8 @@ public class InProcessMeshChangeFeed : IMeshChangeFeed, IDisposable
         _disposed = true;
         _storageRelay?.Dispose();
         _subject.OnCompleted();
+        _invalidations.OnCompleted();
         _subject.Dispose();
+        _invalidations.Dispose();
     }
 }

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -283,7 +283,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     private readonly TimeSpan readStreamSweepInterval;
     private readonly IDisposable idleSweep;
 
-    // 🚨 Invalidation signal: the SAME IMeshChangeFeed broadcast every write path
+    // 🚨 Invalidation signal: the SAME IMeshInvalidationFeed broadcast every write path
     // already publishes — post-commit storage writes (Created/Updated/Deleted) AND
     // the recycle operation (MeshOperations.RecycleCore publishes an Updated event
     // before posting DisposeRequest; in Orleans the PathCacheInvalidatorGrain
@@ -761,8 +761,10 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
         // Failure-state reset on the EXISTING invalidation broadcast (see the
         // changeFeedReset field doc). Optional service: minimal test fixtures
         // without AddMeshCatalog's feed registration simply have no reset seam.
-        changeFeedReset = meshHub.ServiceProvider.GetService<IMeshChangeFeed>()
-            ?.Subscribe(OnMeshChange);
+        var invalidationFeed = meshHub.ServiceProvider.GetService<IMeshInvalidationFeed>();
+        changeFeedReset = invalidationFeed is not null
+            ? invalidationFeed.Subscribe(OnMeshChange)
+            : meshHub.ServiceProvider.GetService<IMeshChangeFeed>()?.Subscribe(OnMeshChange);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/PathResolutionService.cs
+++ b/src/MeshWeaver.Hosting/PathResolutionService.cs
@@ -87,7 +87,7 @@ namespace MeshWeaver.Hosting;
 /// Repros: <c>PathResolutionCachePoisonTest</c>.</para>
 ///
 /// <para><b>Invalidation</b>: the constructor subscribes the optional
-/// <see cref="IMeshChangeFeed"/> (the same post-commit broadcast
+/// <see cref="IMeshInvalidationFeed"/> (the same post-commit invalidation
 /// <c>MeshNodeStreamCache</c> uses). A <see cref="MeshChangeEvent"/> with path
 /// <c>P</c> sweeps every entry whose key equals <c>P</c> or starts with
 /// <c>P + "/"</c> — but what the sweep DOES depends on the kind, because the cache
@@ -107,7 +107,7 @@ namespace MeshWeaver.Hosting;
 ///     during the boot NodeType bake and saturated its in-flight window.</item>
 /// </list>
 /// Iterating the whole dictionary per event is fine — events are rare
-/// relative to resolutions. When no <see cref="IMeshChangeFeed"/> is registered
+/// relative to resolutions. When no <see cref="IMeshInvalidationFeed"/> is registered
 /// (minimal test fixtures) the service does not cache at all and behaves exactly
 /// like the uncached implementation.</para>
 /// </summary>
@@ -134,7 +134,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// <summary>
     /// Positive-only value cache: joined segment path → the resolved
     /// <see cref="CachedResolution"/> (never null). Non-null ONLY when an
-    /// <see cref="IMeshChangeFeed"/> is registered — without the invalidation
+    /// <see cref="IMeshInvalidationFeed"/> is registered — without the invalidation
     /// signal, caching would serve stale routes forever, so the service then
     /// resolves uncached (exactly the pre-cache behaviour). Storing the VALUE (not
     /// the in-flight observable) means a hung / errored / null resolution caches
@@ -184,12 +184,17 @@ internal class PathResolutionService : IPathResolver, IDisposable
         // Optional service (same pattern as MeshNodeStreamCache): minimal test
         // fixtures without the feed registration get NO cache — never a cache
         // without its invalidation signal.
-        var changeFeed = hub.ServiceProvider.GetService<IMeshChangeFeed>();
-        if (changeFeed is not null)
+        var invalidationFeed = hub.ServiceProvider.GetService<IMeshInvalidationFeed>();
+        var legacyFeed = invalidationFeed is null
+            ? hub.ServiceProvider.GetService<IMeshChangeFeed>()
+            : null;
+        if (invalidationFeed is not null || legacyFeed is not null)
         {
             _resolutionCache = new ConcurrentDictionary<string, CachedResolution>(StringComparer.Ordinal);
             _pendingFills = new ConcurrentDictionary<string, PendingFill>(StringComparer.Ordinal);
-            _changeFeedSubscription = changeFeed.Subscribe(OnMeshChange);
+            _changeFeedSubscription = invalidationFeed is not null
+                ? invalidationFeed.Subscribe(OnMeshChange)
+                : legacyFeed!.Subscribe(OnMeshChange);
         }
         // Gates the partition-root MeshNode synthesis below — we only fall back
         // to a placeholder when at least one writable provider could plausibly
@@ -431,7 +436,7 @@ internal class PathResolutionService : IPathResolver, IDisposable
     /// synchronously on Subscribe — the Blazor skip-progress contract). A miss runs
     /// <see cref="ResolveSegmentsCore"/> and stores ONLY a non-null result, so a
     /// null / errored / never-emitting query caches nothing and can never poison the
-    /// path (see the class doc). Without a registered <see cref="IMeshChangeFeed"/>
+    /// path (see the class doc). Without a registered <see cref="IMeshInvalidationFeed"/>
     /// there is no cache and every call queries.
     ///
     /// <para>🚨 The <see cref="SynthesizePartitionRoot"/> fallback is appended HERE, past

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -799,7 +799,13 @@ public static class PersistenceExtensions
     /// </summary>
     public static IServiceCollection AddMeshCatalog(this IServiceCollection services)
     {
-        services.TryAddSingleton<IMeshChangeFeed, InProcessMeshChangeFeed>();
+        // Register the concrete process-local feed once, then expose that SAME instance through
+        // the public seam. Orleans also resolves the concrete feed for local delivery; registering
+        // the interface implementation separately would construct two Subjects and relay storage
+        // notifications into one while consumers listened to the other.
+        services.TryAddSingleton<InProcessMeshChangeFeed>();
+        services.TryAddSingleton<IMeshChangeFeed>(sp =>
+            sp.GetRequiredService<InProcessMeshChangeFeed>());
         // Mesh-wide content-type resolver: the ONE $type→CLR-Type map for dynamically-compiled
         // NodeTypes, reachable from every hub (incl. the domain-agnostic cache hub) and retained
         // for the process lifetime. Populated at MeshDataSource.WithContentType; consulted by the

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -806,6 +806,8 @@ public static class PersistenceExtensions
         services.TryAddSingleton<InProcessMeshChangeFeed>();
         services.TryAddSingleton<IMeshChangeFeed>(sp =>
             sp.GetRequiredService<InProcessMeshChangeFeed>());
+        services.TryAddSingleton<IMeshInvalidationFeed>(sp =>
+            sp.GetRequiredService<InProcessMeshChangeFeed>());
         // Mesh-wide content-type resolver: the ONE $type→CLR-Type map for dynamically-compiled
         // NodeTypes, reachable from every hub (incl. the domain-agnostic cache hub) and retained
         // for the process lifetime. Populated at MeshDataSource.WithContentType; consulted by the

--- a/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Reactive.Concurrency;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using MeshWeaver.Mesh;
@@ -23,24 +24,32 @@ namespace MeshWeaver.Hosting.Persistence;
 /// </remarks>
 internal sealed class StorageChangeFeedRelay : IDisposable
 {
+    private static readonly TimeSpan DefaultLegacyReadTimeout = TimeSpan.FromSeconds(5);
     private readonly IStorageAdapter storage;
     private readonly Action<MeshChangeEvent> publishLocal;
     private readonly ILogger? logger;
+    private readonly TimeSpan legacyReadTimeout;
+    private readonly IScheduler scheduler;
     private readonly JsonSerializerOptions readOptions = new(JsonSerializerDefaults.Web)
     {
         PropertyNameCaseInsensitive = true,
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+        Converters = { new JsonStringEnumConverter() },
     };
     private readonly IDisposable subscription;
 
     public StorageChangeFeedRelay(
         IStorageAdapter storage,
         Action<MeshChangeEvent> publishLocal,
-        ILogger? logger = null)
+        ILogger? logger = null,
+        TimeSpan? legacyReadTimeout = null,
+        IScheduler? scheduler = null)
     {
         this.storage = storage;
         this.publishLocal = publishLocal;
         this.logger = logger;
+        this.legacyReadTimeout = legacyReadTimeout ?? DefaultLegacyReadTimeout;
+        this.scheduler = scheduler ?? Scheduler.Default;
 
         subscription = storage.Changes
             // Defer the whole conversion, not only the optional storage read. A malformed
@@ -51,10 +60,12 @@ internal sealed class StorageChangeFeedRelay : IDisposable
                 .Catch((Exception ex) =>
                 {
                     logger?.LogWarning(ex,
-                        "Storage change-feed relay could not resolve {Kind} {Path}; "
-                        + "the notification was not published",
+                        "Storage change-feed relay could not enrich {Kind} {Path}; "
+                        + "publishing a path-only invalidation and continuing",
                         notification.Kind, notification.Path);
-                    return Observable.Empty<MeshChangeEvent>();
+                    return TryPathOnly(notification, out var fallback)
+                        ? Observable.Return(fallback)
+                        : Observable.Empty<MeshChangeEvent>();
                 }))
             .Concat()
             .Subscribe(
@@ -66,11 +77,13 @@ internal sealed class StorageChangeFeedRelay : IDisposable
 
     private IObservable<MeshChangeEvent> Resolve(DataChangeNotification notification)
     {
-        var path = notification.Path.Trim('/');
+        var path = NormalizePath(notification.Path);
         if (string.IsNullOrEmpty(path))
             return Observable.Empty<MeshChangeEvent>();
 
-        if (notification.Entity is MeshNode node)
+        var node = notification.Entity.As<MeshNode>(
+            readOptions, logger, $"storage notification {path}");
+        if (node is not null)
             return Observable.Return(ToMeshChange(notification, node));
 
         if (notification.Kind == DataChangeKind.Deleted
@@ -82,6 +95,8 @@ internal sealed class StorageChangeFeedRelay : IDisposable
         // see an "unknown" create/update merely because the notifier was upgraded second.
         return storage.Read(path, readOptions)
             .Take(1)
+            .Timeout(legacyReadTimeout, scheduler)
+            .DefaultIfEmpty(null)
             .Select(nodeAtCommit => ToMeshChange(notification, nodeAtCommit));
     }
 
@@ -105,7 +120,7 @@ internal sealed class StorageChangeFeedRelay : IDisposable
         DataChangeNotification notification,
         MeshNode? node)
     {
-        var path = notification.Path.Trim('/');
+        var path = NormalizePath(notification.Path);
         var (fallbackNamespace, fallbackId) = SplitPath(path);
         var kind = notification.Kind switch
         {
@@ -116,14 +131,38 @@ internal sealed class StorageChangeFeedRelay : IDisposable
                 nameof(notification), notification.Kind, "Unknown storage change kind"),
         };
 
+        var version = kind == MeshChangeKind.Deleted
+            ? 0
+            : notification.Version ?? node?.Version ?? 0;
+        var nodeType = string.IsNullOrEmpty(notification.NodeType)
+            ? node?.NodeType
+            : notification.NodeType;
         return new MeshChangeEvent(
             node?.Namespace ?? fallbackNamespace,
             node?.Id ?? fallbackId,
             path,
             kind,
-            notification.NodeType ?? node?.NodeType,
-            notification.Version ?? node?.Version ?? 0,
+            nodeType,
+            version,
             notification.Timestamp);
+    }
+
+    private static bool TryPathOnly(
+        DataChangeNotification notification,
+        out MeshChangeEvent change)
+    {
+        var path = NormalizePath(notification.Path);
+        if (string.IsNullOrEmpty(path)
+            || notification.Kind is not (DataChangeKind.Created
+                or DataChangeKind.Updated
+                or DataChangeKind.Deleted))
+        {
+            change = default!;
+            return false;
+        }
+
+        change = ToMeshChange(notification, null);
+        return true;
     }
 
     private static (string Namespace, string Id) SplitPath(string path)
@@ -133,6 +172,8 @@ internal sealed class StorageChangeFeedRelay : IDisposable
             ? (string.Empty, path)
             : (path[..separator], path[(separator + 1)..]);
     }
+
+    private static string NormalizePath(string? path) => path?.Trim('/') ?? string.Empty;
 
     public void Dispose() => subscription.Dispose();
 }

--- a/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
@@ -9,9 +9,10 @@ namespace MeshWeaver.Hosting.Persistence;
 
 /// <summary>
 /// Relays the storage adapter's process-local <see cref="IStorageAdapter.Changes"/> stream into
-/// the process-local mesh change feed. Durable backends such as PostgreSQL feed every process's
-/// adapter from their database change channel, so this gives every replica its own cache
-/// invalidation without relying on one cluster-singleton Orleans grain to reach process memory.
+/// the process-local <see cref="IMeshInvalidationFeed"/>. Durable backends such as PostgreSQL feed
+/// every process's adapter from their database change channel, so this gives every replica its own
+/// cache invalidation without relying on one cluster-singleton Orleans grain to reach process
+/// memory or re-running logical event consumers on every replica.
 /// </summary>
 /// <remarks>
 /// The relay is owned by the mesh-scoped <see cref="InProcessMeshChangeFeed"/> and dies with it.

--- a/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StorageChangeFeedRelay.cs
@@ -1,0 +1,137 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Persistence;
+
+/// <summary>
+/// Relays the storage adapter's process-local <see cref="IStorageAdapter.Changes"/> stream into
+/// the process-local mesh change feed. Durable backends such as PostgreSQL feed every process's
+/// adapter from their database change channel, so this gives every replica its own cache
+/// invalidation without relying on one cluster-singleton Orleans grain to reach process memory.
+/// </summary>
+/// <remarks>
+/// The relay is owned by the mesh-scoped <see cref="InProcessMeshChangeFeed"/> and dies with it.
+/// Missing create/update metadata is resolved by one authoritative storage read before the event
+/// reaches type-filtering consumers. Reads remain reactive and are serialised with
+/// <see cref="Observable.Concat{TSource}(IObservable{IObservable{TSource}})"/> so notification order
+/// is preserved while a backend I/O leaf is in flight.
+/// </remarks>
+internal sealed class StorageChangeFeedRelay : IDisposable
+{
+    private readonly IStorageAdapter storage;
+    private readonly Action<MeshChangeEvent> publishLocal;
+    private readonly ILogger? logger;
+    private readonly JsonSerializerOptions readOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+    };
+    private readonly IDisposable subscription;
+
+    public StorageChangeFeedRelay(
+        IStorageAdapter storage,
+        Action<MeshChangeEvent> publishLocal,
+        ILogger? logger = null)
+    {
+        this.storage = storage;
+        this.publishLocal = publishLocal;
+        this.logger = logger;
+
+        subscription = storage.Changes
+            // Defer the whole conversion, not only the optional storage read. A malformed
+            // notification (for example an enum value from a newer backend) can throw while
+            // Resolve builds its observable; without Defer that synchronous throw terminates the
+            // outer Changes subscription and this replica misses every later commit.
+            .Select(notification => Observable.Defer(() => Resolve(notification))
+                .Catch((Exception ex) =>
+                {
+                    logger?.LogWarning(ex,
+                        "Storage change-feed relay could not resolve {Kind} {Path}; "
+                        + "the notification was not published",
+                        notification.Kind, notification.Path);
+                    return Observable.Empty<MeshChangeEvent>();
+                }))
+            .Concat()
+            .Subscribe(
+                PublishSafely,
+                ex => logger?.LogError(ex,
+                    "Storage change-feed relay stopped — this process will no longer receive "
+                    + "storage-backed cache invalidations"));
+    }
+
+    private IObservable<MeshChangeEvent> Resolve(DataChangeNotification notification)
+    {
+        var path = notification.Path.Trim('/');
+        if (string.IsNullOrEmpty(path))
+            return Observable.Empty<MeshChangeEvent>();
+
+        if (notification.Entity is MeshNode node)
+            return Observable.Return(ToMeshChange(notification, node));
+
+        if (notification.Kind == DataChangeKind.Deleted
+            || (!string.IsNullOrEmpty(notification.NodeType) && notification.Version.HasValue))
+            return Observable.Return(ToMeshChange(notification, null));
+
+        // During the additive rollout an older backend payload carries only path/op (or a
+        // backend-private descriptor). Re-read once so consumers that filter by NodeType never
+        // see an "unknown" create/update merely because the notifier was upgraded second.
+        return storage.Read(path, readOptions)
+            .Take(1)
+            .Select(nodeAtCommit => ToMeshChange(notification, nodeAtCommit));
+    }
+
+    private void PublishSafely(MeshChangeEvent change)
+    {
+        try
+        {
+            publishLocal(change);
+        }
+        catch (Exception ex)
+        {
+            // IStorageAdapter.Changes is a shared, isolated fan-out. Never let one mesh-feed
+            // subscriber tear this relay out of that source and starve every later notification.
+            logger?.LogError(ex,
+                "Storage change-feed relay subscriber failed for {Kind} {Path}; continuing",
+                change.Kind, change.Path);
+        }
+    }
+
+    private static MeshChangeEvent ToMeshChange(
+        DataChangeNotification notification,
+        MeshNode? node)
+    {
+        var path = notification.Path.Trim('/');
+        var (fallbackNamespace, fallbackId) = SplitPath(path);
+        var kind = notification.Kind switch
+        {
+            DataChangeKind.Created => MeshChangeKind.Created,
+            DataChangeKind.Updated => MeshChangeKind.Updated,
+            DataChangeKind.Deleted => MeshChangeKind.Deleted,
+            _ => throw new ArgumentOutOfRangeException(
+                nameof(notification), notification.Kind, "Unknown storage change kind"),
+        };
+
+        return new MeshChangeEvent(
+            node?.Namespace ?? fallbackNamespace,
+            node?.Id ?? fallbackId,
+            path,
+            kind,
+            notification.NodeType ?? node?.NodeType,
+            notification.Version ?? node?.Version ?? 0,
+            notification.Timestamp);
+    }
+
+    private static (string Namespace, string Id) SplitPath(string path)
+    {
+        var separator = path.LastIndexOf('/');
+        return separator < 0
+            ? (string.Empty, path)
+            : (path[..separator], path[(separator + 1)..]);
+    }
+
+    public void Dispose() => subscription.Dispose();
+}

--- a/src/MeshWeaver.Mesh.Contract/Services/DataChangeNotification.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/DataChangeNotification.cs
@@ -18,17 +18,38 @@ public record DataChangeNotification(
     DateTimeOffset Timestamp
 )
 {
+    /// <summary>
+    /// Node type carried by the storage backend when it is available without reading the row.
+    /// Cross-process feeds may leave this <see langword="null"/> while an older backend payload is
+    /// still deployed; consumers must then treat the notification as unclassified or re-read it.
+    /// </summary>
+    public string? NodeType { get; init; }
+
+    /// <summary>
+    /// Durable node version carried by the storage backend, or <see langword="null"/> when the
+    /// backend's notification payload predates version metadata.
+    /// </summary>
+    public long? Version { get; init; }
+
     /// <summary>Factory for a Create commit notification.</summary>
     public static DataChangeNotification Created(string path, object? entity) =>
-        new(NormalizePath(path), DataChangeKind.Created, entity, DateTimeOffset.UtcNow);
+        WithEntityMetadata(new(
+            NormalizePath(path), DataChangeKind.Created, entity, DateTimeOffset.UtcNow));
 
     /// <summary>Factory for an Update commit notification.</summary>
     public static DataChangeNotification Updated(string path, object? entity) =>
-        new(NormalizePath(path), DataChangeKind.Updated, entity, DateTimeOffset.UtcNow);
+        WithEntityMetadata(new(
+            NormalizePath(path), DataChangeKind.Updated, entity, DateTimeOffset.UtcNow));
 
     /// <summary>Factory for a Delete commit notification — <paramref name="entity"/> may be null for backends that don't retain a tombstone payload.</summary>
     public static DataChangeNotification Deleted(string path, object? entity = null) =>
-        new(NormalizePath(path), DataChangeKind.Deleted, entity, DateTimeOffset.UtcNow);
+        WithEntityMetadata(new(
+            NormalizePath(path), DataChangeKind.Deleted, entity, DateTimeOffset.UtcNow));
+
+    private static DataChangeNotification WithEntityMetadata(DataChangeNotification notification)
+        => notification.Entity is MeshNode node
+            ? notification with { NodeType = node.NodeType, Version = node.Version }
+            : notification;
 
     private static string NormalizePath(string? path) =>
         path?.Trim('/') ?? "";

--- a/src/MeshWeaver.Mesh.Contract/Services/DataChangeNotification.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/DataChangeNotification.cs
@@ -1,3 +1,6 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
 namespace MeshWeaver.Mesh.Services;
 
 /// <summary>
@@ -18,6 +21,13 @@ public record DataChangeNotification(
     DateTimeOffset Timestamp
 )
 {
+    private static readonly JsonSerializerOptions EntityOptions = new(JsonSerializerDefaults.Web)
+    {
+        PropertyNameCaseInsensitive = true,
+        UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
     /// <summary>
     /// Node type carried by the storage backend when it is available without reading the row.
     /// Cross-process feeds may leave this <see langword="null"/> while an older backend payload is
@@ -47,9 +57,12 @@ public record DataChangeNotification(
             NormalizePath(path), DataChangeKind.Deleted, entity, DateTimeOffset.UtcNow));
 
     private static DataChangeNotification WithEntityMetadata(DataChangeNotification notification)
-        => notification.Entity is MeshNode node
+    {
+        var node = notification.Entity.As<MeshNode>(EntityOptions);
+        return node is not null
             ? notification with { NodeType = node.NodeType, Version = node.Version }
             : notification;
+    }
 
     private static string NormalizePath(string? path) =>
         path?.Trim('/') ?? "";

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshChangeFeed.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshChangeFeed.cs
@@ -33,7 +33,8 @@ public interface IMeshChangeFeed
 /// This is deliberately separate from <see cref="IMeshChangeFeed"/>. Logical event consumers can
 /// send mail, run an instance sync or append an outbox entry and therefore must retain the
 /// publisher's single logical delivery. Cache invalidation is idempotent and must run once in every
-/// process, including replicas that did not perform the write.
+/// process, including replicas that did not perform the write. Implementations serialize concurrent
+/// publishers and isolate each invalidation callback, so one cache cannot starve another.
 /// </remarks>
 public interface IMeshInvalidationFeed
 {

--- a/src/MeshWeaver.Mesh.Contract/Services/IMeshChangeFeed.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IMeshChangeFeed.cs
@@ -4,7 +4,8 @@ namespace MeshWeaver.Mesh.Services;
 /// Change feed for mesh data mutations (create/update/delete).
 /// Producers call <see cref="Publish"/> after each write.
 /// Consumers call <see cref="Subscribe"/> with optional filter.
-/// In monolith: in-process Subject. In Orleans: BroadcastChannel cross-silo.
+/// Logical subscribers run in the publishing process; cache consumers use
+/// <see cref="IMeshInvalidationFeed"/> to observe commits from every process.
 /// </summary>
 public interface IMeshChangeFeed
 {
@@ -20,6 +21,25 @@ public interface IMeshChangeFeed
     /// <param name="handler">Callback invoked for each matching event.</param>
     /// <param name="filter">If set, only events matching this kind are delivered.</param>
     /// <returns>Disposable subscription.</returns>
+    IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null);
+}
+
+/// <summary>
+/// Process-local invalidation feed for caches and live mirrors whose answer becomes stale when a
+/// node commits on any replica. Direct <see cref="IMeshChangeFeed.Publish"/> calls reach this feed
+/// too; durable storage backends additionally relay their cross-process notifications here.
+/// </summary>
+/// <remarks>
+/// This is deliberately separate from <see cref="IMeshChangeFeed"/>. Logical event consumers can
+/// send mail, run an instance sync or append an outbox entry and therefore must retain the
+/// publisher's single logical delivery. Cache invalidation is idempotent and must run once in every
+/// process, including replicas that did not perform the write.
+/// </remarks>
+public interface IMeshInvalidationFeed
+{
+    /// <summary>
+    /// Subscribes a process-local invalidation handler, optionally filtered by change kind.
+    /// </summary>
     IDisposable Subscribe(Action<MeshChangeEvent> handler, MeshChangeKind? filter = null);
 }
 

--- a/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
+++ b/test/MeshWeaver.Graph.Test/ARecycleWaitsForTheInstallHoldingTheRootTest.cs
@@ -63,7 +63,7 @@ public class ARecycleWaitsForTheInstallHoldingTheRootTest(ITestOutputHelper outp
     /// The same hot, non-replaying stand-in <c>NodeTypeRebindWatcherTest</c> uses: the production
     /// <c>InProcessMeshChangeFeed</c> never replays, and that property is load-bearing.
     /// </summary>
-    private sealed class TestChangeFeed : IMeshChangeFeed
+    private sealed class TestChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed
     {
         // 🚨 Instance ConcurrentDictionary, never a mutable List: the repository's collections
         // policy holds in test/ too, and this feed is published from one thread while a watcher's

--- a/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
+++ b/test/MeshWeaver.Graph.Test/NodeTypeRebindWatcherTest.cs
@@ -56,7 +56,7 @@ public class NodeTypeRebindWatcherTest(ITestOutputHelper output) : HubTestBase(o
     /// the state it was armed on — the replay-and-recycle hot loop that forced the overlay
     /// watcher's version gate). This stand-in has the same shape.
     /// </summary>
-    private sealed class TestChangeFeed : IMeshChangeFeed
+    private sealed class TestChangeFeed : IMeshChangeFeed, IMeshInvalidationFeed
     {
         private readonly List<Action<MeshChangeEvent>> handlers = [];
         public void Publish(MeshChangeEvent change)

--- a/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
@@ -54,6 +54,22 @@ public class GrainActivationFailureRegistryTest
     }
 
     [Fact]
+    public void CrossProcessInvalidation_ClearsTheLocalError_WithoutALogicalEvent()
+    {
+        using var feed = new InProcessMeshChangeFeed();
+        using var registry = GrainActivationFailureRegistry.FromInvalidationFeed(feed);
+        var logical = new List<MeshChangeEvent>();
+        using var logicalSubscription = feed.Subscribe(logical.Add);
+        registry.Record(RecycledPath, "old compile failure");
+
+        feed.PublishLocal(RecycleBroadcast(RecycledPath));
+
+        registry.TryGet(RecycledPath).Should().BeNull();
+        logical.Should().BeEmpty(
+            "a cross-process cache reset must not re-run logical consumers in this replica");
+    }
+
+    [Fact]
     public void WithoutChangeFeed_RegistryStillRecordsAndClearsManually()
     {
         using var registry = new GrainActivationFailureRegistry();

--- a/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/GrainActivationFailureRegistryTest.cs
@@ -58,14 +58,14 @@ public class GrainActivationFailureRegistryTest
     {
         using var feed = new InProcessMeshChangeFeed();
         using var registry = GrainActivationFailureRegistry.FromInvalidationFeed(feed);
-        var logical = new List<MeshChangeEvent>();
-        using var logicalSubscription = feed.Subscribe(logical.Add);
+        MeshChangeEvent? logical = null;
+        using var logicalSubscription = feed.Subscribe(change => logical = change);
         registry.Record(RecycledPath, "old compile failure");
 
         feed.PublishLocal(RecycleBroadcast(RecycledPath));
 
         registry.TryGet(RecycledPath).Should().BeNull();
-        logical.Should().BeEmpty(
+        logical.Should().BeNull(
             "a cross-process cache reset must not re-run logical consumers in this replica");
     }
 

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansChangeFeedCompositionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansChangeFeedCompositionTest.cs
@@ -1,0 +1,59 @@
+#pragma warning disable CS1591
+
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins the default Orleans registration order at the production seam. Storage notifications and
+/// direct logical publishes must reach the same process-local invalidation feed even when the
+/// Orleans wrapper registration order changes.
+/// </summary>
+public class OrleansChangeFeedCompositionTest
+{
+    [Fact]
+    public async Task DefaultComposition_UsesOneStorageRelayedLocalInvalidationFeed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddOrleansMeshServices();
+        await using var provider = services.BuildServiceProvider();
+
+        var local = provider.GetRequiredService<InProcessMeshChangeFeed>();
+        var invalidations = provider.GetRequiredService<IMeshInvalidationFeed>();
+        var logical = provider.GetRequiredService<IMeshChangeFeed>();
+        invalidations.Should().BeSameAs(local,
+            "Orleans and AddMeshCatalog must expose the storage-relayed process singleton");
+
+        MeshChangeEvent? last = null;
+        var count = 0;
+        using var subscription = invalidations.Subscribe(change =>
+        {
+            last = change;
+            count++;
+        });
+        var stored = new MeshNode("plugins", "Hosting/PlatformBuilds")
+        {
+            NodeType = "Hosting/Publication",
+            Version = 81,
+            State = MeshNodeState.Active,
+        };
+
+        await provider.GetRequiredService<IStorageAdapter>()
+            .Write(stored, new JsonSerializerOptions())
+            .Should().Emit();
+        count.Should().Be(1);
+        last!.Version.Should().Be(81);
+
+        logical.Publish(MeshChangeEvent.Updated(stored with { Version = 82 }));
+        count.Should().Be(2,
+            "the logical feed selected by Orleans must fan into this same invalidation singleton");
+        last!.Version.Should().Be(82);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
+++ b/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
@@ -1,0 +1,233 @@
+#pragma warning disable CS1591
+
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the process-local half of storage-backed cache invalidation. In production every portal
+/// replica owns a PostgreSQL LISTEN session and therefore its own <see cref="IStorageAdapter.Changes"/>
+/// feed. Each feed must reach that replica's <see cref="InProcessMeshChangeFeed"/> directly; one
+/// Orleans grain activation cannot deliver into the process memory of every silo.
+/// </summary>
+public class StorageChangeFeedRelayTest
+{
+    private readonly JsonSerializerOptions json = new();
+    private const string Path = "Hosting/PlatformBuilds/plugins";
+
+    [Fact]
+    public async Task PersistenceRegistration_RelaysACommittedWriteIntoTheSameLocalFeed()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddInMemoryPersistence(new InMemoryStorageAdapter());
+        await using var provider = services.BuildServiceProvider();
+
+        var contract = provider.GetRequiredService<IMeshChangeFeed>();
+        var local = provider.GetRequiredService<InProcessMeshChangeFeed>();
+        contract.Should().BeSameAs(local,
+            "storage notifications and IMeshChangeFeed consumers must share one process-local Subject");
+
+        MeshChangeEvent? received = null;
+        using var subscription = contract.Subscribe(change => received = change);
+        var node = Node(version: 7, nodeType: "Hosting/Publication");
+
+        await provider.GetRequiredService<IStorageAdapter>()
+            .Write(node, json)
+            .Should().Emit();
+
+        received.Should().NotBeNull();
+        received!.Path.Should().Be(Path);
+        received.Kind.Should().Be(MeshChangeKind.Updated);
+        received.NodeType.Should().Be("Hosting/Publication");
+        received.Version.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task LegacyCrossProcessNotification_RereadsBeforeTypeFilteringConsumersSeeIt()
+    {
+        var durable = new InMemoryStorageAdapter();
+        var stored = Node(version: 12, nodeType: "Hosting/Publication");
+        await durable.Write(stored, json).Should().Emit();
+        using var adapter = new ControllableNotificationAdapter(durable);
+        using var feed = new InProcessMeshChangeFeed(adapter);
+        MeshChangeEvent? received = null;
+        using var subscription = feed.Subscribe(change => received = change);
+        var committedAt = DateTimeOffset.Parse("2026-09-12T13:43:58Z");
+
+        // The first core image may run briefly with an older PostgreSQL notifier whose payload has
+        // path/op but no additive NodeType/Version members. This is the rollout boundary.
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, Timestamp: committedAt));
+
+        received.Should().NotBeNull();
+        received!.Path.Should().Be(Path);
+        received.NodeType.Should().Be("Hosting/Publication");
+        received.Version.Should().Be(12);
+        received.Timestamp.Should().Be(committedAt);
+        adapter.ReadCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task OneMetadataReadFailure_DoesNotStopTheReplicaFromReceivingTheNextCommit()
+    {
+        var durable = new InMemoryStorageAdapter();
+        await durable.Write(Node(version: 20, nodeType: "Hosting/Publication"), json)
+            .Should().Emit();
+        using var adapter = new ControllableNotificationAdapter(durable)
+        {
+            NextReadError = new InvalidOperationException("transient read fault")
+        };
+        using var feed = new InProcessMeshChangeFeed(adapter);
+        var received = new List<MeshChangeEvent>();
+        using var subscription = feed.Subscribe(received.Add);
+
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow));
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 21,
+        });
+
+        received.Should().ContainSingle();
+        received[0].Version.Should().Be(21,
+            "a failed legacy-payload reread may drop that event, but must not terminate the relay");
+    }
+
+    [Fact]
+    public void OneMalformedNotification_DoesNotStopTheReplicaFromReceivingTheNextCommit()
+    {
+        var durable = new InMemoryStorageAdapter();
+        using var adapter = new ControllableNotificationAdapter(durable);
+        using var feed = new InProcessMeshChangeFeed(adapter);
+        var received = new List<MeshChangeEvent>();
+        using var subscription = feed.Subscribe(received.Add);
+
+        adapter.Announce(new DataChangeNotification(
+            Path, (DataChangeKind)int.MaxValue, Entity: null, DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 40,
+        });
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 41,
+        });
+
+        received.Should().ContainSingle();
+        received[0].Version.Should().Be(41,
+            "one unrecognised notification may be dropped, but must not terminate the relay");
+    }
+
+    [Fact]
+    public async Task TwoProcessLocalFeeds_BothReceiveTheirStorageListenerCopy()
+    {
+        var durable = new InMemoryStorageAdapter();
+        await durable.Write(Node(version: 31, nodeType: "Hosting/Publication"), json)
+            .Should().Emit();
+        using var replicaA = new ControllableNotificationAdapter(durable);
+        using var replicaB = new ControllableNotificationAdapter(durable);
+        using var feedA = new InProcessMeshChangeFeed(replicaA);
+        using var feedB = new InProcessMeshChangeFeed(replicaB);
+        var seenA = new List<MeshChangeEvent>();
+        var seenB = new List<MeshChangeEvent>();
+        using var subscriptionA = feedA.Subscribe(seenA.Add);
+        using var subscriptionB = feedB.Subscribe(seenB.Add);
+        var notification = new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 31,
+        };
+
+        // PostgreSQL delivers the same committed NOTIFY to each process's LISTEN session. The
+        // relays are independent; neither depends on where an Orleans grain activation landed.
+        replicaA.Announce(notification);
+        replicaB.Announce(notification);
+
+        seenA.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
+        seenB.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
+    }
+
+    private static MeshNode Node(long version, string nodeType) =>
+        new("plugins", "Hosting/PlatformBuilds")
+        {
+            NodeType = nodeType,
+            Version = version,
+            State = MeshNodeState.Active,
+        };
+
+    /// <summary>
+    /// Two instances over one durable adapter model two process-local PostgreSQL listener feeds:
+    /// reads share the database, notifications do not share process memory.
+    /// </summary>
+    private sealed class ControllableNotificationAdapter(IStorageAdapter inner)
+        : IStorageAdapter, IDisposable
+    {
+        private readonly Subject<DataChangeNotification> changes = new();
+
+        public Exception? NextReadError { get; set; }
+        public int ReadCalls { get; private set; }
+        public IObservable<DataChangeNotification> Changes => changes;
+
+        public void Announce(DataChangeNotification notification) => changes.OnNext(notification);
+
+        public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+        {
+            ReadCalls++;
+            if (NextReadError is { } ex)
+            {
+                NextReadError = null;
+                return Observable.Throw<MeshNode?>(ex);
+            }
+            return inner.Read(path, options);
+        }
+
+        public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+            => inner.Write(node, options);
+
+        public IObservable<string> Delete(string path) => inner.Delete(path);
+
+        public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
+            ListChildPaths(string? parentPath) => inner.ListChildPaths(parentPath);
+
+        public IObservable<bool> Exists(string path) => inner.Exists(path);
+
+        public IObservable<object> GetPartitionObjects(
+            string nodePath, string? subPath, JsonSerializerOptions options)
+            => inner.GetPartitionObjects(nodePath, subPath, options);
+
+        public IObservable<Unit> SavePartitionObjects(
+            string nodePath,
+            string? subPath,
+            IReadOnlyCollection<object> objects,
+            JsonSerializerOptions options)
+            => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+        public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+            => inner.DeletePartitionObjects(nodePath, subPath);
+
+        public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(
+            string nodePath, string? subPath = null)
+            => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+
+        public void Dispose()
+        {
+            changes.OnCompleted();
+            changes.Dispose();
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
+++ b/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
@@ -25,7 +25,7 @@ public class StorageChangeFeedRelayTest
     private const string Path = "Hosting/PlatformBuilds/plugins";
 
     [Fact]
-    public async Task PersistenceRegistration_RelaysACommittedWriteIntoTheSameLocalFeed()
+    public async Task PersistenceRegistration_RelaysStorageOnlyToTheSameLocalInvalidationFeed()
     {
         var services = new ServiceCollection();
         services.AddLogging();
@@ -33,23 +33,38 @@ public class StorageChangeFeedRelayTest
         await using var provider = services.BuildServiceProvider();
 
         var contract = provider.GetRequiredService<IMeshChangeFeed>();
+        var invalidations = provider.GetRequiredService<IMeshInvalidationFeed>();
         var local = provider.GetRequiredService<InProcessMeshChangeFeed>();
         contract.Should().BeSameAs(local,
-            "storage notifications and IMeshChangeFeed consumers must share one process-local Subject");
+            "logical events and direct cache invalidations must share one process-local owner");
+        invalidations.Should().BeSameAs(local,
+            "storage notifications and cache consumers must share that same process-local owner");
 
-        MeshChangeEvent? received = null;
-        using var subscription = contract.Subscribe(change => received = change);
+        var logical = new List<MeshChangeEvent>();
+        var invalidated = new List<MeshChangeEvent>();
+        using var logicalSubscription = contract.Subscribe(logical.Add);
+        using var faultingInvalidator = invalidations.Subscribe(_ =>
+            throw new InvalidOperationException("one broken cache"));
+        using var invalidationSubscription = invalidations.Subscribe(invalidated.Add);
         var node = Node(version: 7, nodeType: "Hosting/Publication");
 
         await provider.GetRequiredService<IStorageAdapter>()
             .Write(node, json)
             .Should().Emit();
 
-        received.Should().NotBeNull();
-        received!.Path.Should().Be(Path);
-        received.Kind.Should().Be(MeshChangeKind.Updated);
-        received.NodeType.Should().Be("Hosting/Publication");
-        received.Version.Should().Be(7);
+        logical.Should().BeEmpty(
+            "a durable-store echo must not re-run mail, instance sync or other logical consumers");
+        invalidated.Should().ContainSingle();
+        invalidated[0].Path.Should().Be(Path);
+        invalidated[0].Kind.Should().Be(MeshChangeKind.Updated);
+        invalidated[0].NodeType.Should().Be("Hosting/Publication");
+        invalidated[0].Version.Should().Be(7);
+
+        contract.Publish(MeshChangeEvent.Updated(Node(version: 8, nodeType: "Hosting/Publication")));
+
+        logical.Select(e => e.Version).Should().Equal(8L);
+        invalidated.Select(e => e.Version).Should().Equal(new[] { 7L, 8L },
+            "the writer's explicit logical publish must invalidate its own process too");
     }
 
     [Fact]
@@ -61,7 +76,8 @@ public class StorageChangeFeedRelayTest
         using var adapter = new ControllableNotificationAdapter(durable);
         using var feed = new InProcessMeshChangeFeed(adapter);
         MeshChangeEvent? received = null;
-        using var subscription = feed.Subscribe(change => received = change);
+        using var subscription = ((IMeshInvalidationFeed)feed)
+            .Subscribe(change => received = change);
         var committedAt = DateTimeOffset.Parse("2026-09-12T13:43:58Z");
 
         // The first core image may run briefly with an older PostgreSQL notifier whose payload has
@@ -89,7 +105,7 @@ public class StorageChangeFeedRelayTest
         };
         using var feed = new InProcessMeshChangeFeed(adapter);
         var received = new List<MeshChangeEvent>();
-        using var subscription = feed.Subscribe(received.Add);
+        using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
 
         adapter.Announce(new DataChangeNotification(
             Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow));
@@ -112,7 +128,7 @@ public class StorageChangeFeedRelayTest
         using var adapter = new ControllableNotificationAdapter(durable);
         using var feed = new InProcessMeshChangeFeed(adapter);
         var received = new List<MeshChangeEvent>();
-        using var subscription = feed.Subscribe(received.Add);
+        using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
 
         adapter.Announce(new DataChangeNotification(
             Path, (DataChangeKind)int.MaxValue, Entity: null, DateTimeOffset.UtcNow)
@@ -144,8 +160,12 @@ public class StorageChangeFeedRelayTest
         using var feedB = new InProcessMeshChangeFeed(replicaB);
         var seenA = new List<MeshChangeEvent>();
         var seenB = new List<MeshChangeEvent>();
-        using var subscriptionA = feedA.Subscribe(seenA.Add);
-        using var subscriptionB = feedB.Subscribe(seenB.Add);
+        var logicalA = new List<MeshChangeEvent>();
+        var logicalB = new List<MeshChangeEvent>();
+        using var subscriptionA = ((IMeshInvalidationFeed)feedA).Subscribe(seenA.Add);
+        using var subscriptionB = ((IMeshInvalidationFeed)feedB).Subscribe(seenB.Add);
+        using var logicalSubscriptionA = feedA.Subscribe(logicalA.Add);
+        using var logicalSubscriptionB = feedB.Subscribe(logicalB.Add);
         var notification = new DataChangeNotification(
             Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow)
         {
@@ -160,6 +180,8 @@ public class StorageChangeFeedRelayTest
 
         seenA.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
         seenB.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
+        logicalA.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
+        logicalB.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
     }
 
     private static MeshNode Node(long version, string nodeType) =>

--- a/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
+++ b/test/MeshWeaver.Hosting.Test/StorageChangeFeedRelayTest.cs
@@ -1,14 +1,17 @@
 #pragma warning disable CS1591
 
+using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using MeshWeaver.Fixture;
 using MeshWeaver.Hosting.Persistence;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Reactive.Testing;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Test;
@@ -40,8 +43,8 @@ public class StorageChangeFeedRelayTest
         invalidations.Should().BeSameAs(local,
             "storage notifications and cache consumers must share that same process-local owner");
 
-        var logical = new List<MeshChangeEvent>();
-        var invalidated = new List<MeshChangeEvent>();
+        var logical = new ImmutableSignal<MeshChangeEvent>();
+        var invalidated = new ImmutableSignal<MeshChangeEvent>();
         using var logicalSubscription = contract.Subscribe(logical.Add);
         using var faultingInvalidator = invalidations.Subscribe(_ =>
             throw new InvalidOperationException("one broken cache"));
@@ -52,18 +55,18 @@ public class StorageChangeFeedRelayTest
             .Write(node, json)
             .Should().Emit();
 
-        logical.Should().BeEmpty(
+        logical.Items.Should().BeEmpty(
             "a durable-store echo must not re-run mail, instance sync or other logical consumers");
-        invalidated.Should().ContainSingle();
-        invalidated[0].Path.Should().Be(Path);
-        invalidated[0].Kind.Should().Be(MeshChangeKind.Updated);
-        invalidated[0].NodeType.Should().Be("Hosting/Publication");
-        invalidated[0].Version.Should().Be(7);
+        invalidated.Items.Should().ContainSingle();
+        invalidated.Items[0].Path.Should().Be(Path);
+        invalidated.Items[0].Kind.Should().Be(MeshChangeKind.Updated);
+        invalidated.Items[0].NodeType.Should().Be("Hosting/Publication");
+        invalidated.Items[0].Version.Should().Be(7);
 
         contract.Publish(MeshChangeEvent.Updated(Node(version: 8, nodeType: "Hosting/Publication")));
 
-        logical.Select(e => e.Version).Should().Equal(8L);
-        invalidated.Select(e => e.Version).Should().Equal(new[] { 7L, 8L },
+        logical.Items.Select(e => e.Version).Should().Equal(8L);
+        invalidated.Items.Select(e => e.Version).Should().Equal(new[] { 7L, 8L },
             "the writer's explicit logical publish must invalidate its own process too");
     }
 
@@ -94,7 +97,7 @@ public class StorageChangeFeedRelayTest
     }
 
     [Fact]
-    public async Task OneMetadataReadFailure_DoesNotStopTheReplicaFromReceivingTheNextCommit()
+    public async Task OneMetadataReadFailure_StillInvalidatesThePath_AndDoesNotStopTheNextCommit()
     {
         var durable = new InMemoryStorageAdapter();
         await durable.Write(Node(version: 20, nodeType: "Hosting/Publication"), json)
@@ -104,7 +107,7 @@ public class StorageChangeFeedRelayTest
             NextReadError = new InvalidOperationException("transient read fault")
         };
         using var feed = new InProcessMeshChangeFeed(adapter);
-        var received = new List<MeshChangeEvent>();
+        var received = new ImmutableSignal<MeshChangeEvent>();
         using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
 
         adapter.Announce(new DataChangeNotification(
@@ -116,9 +119,9 @@ public class StorageChangeFeedRelayTest
             Version = 21,
         });
 
-        received.Should().ContainSingle();
-        received[0].Version.Should().Be(21,
-            "a failed legacy-payload reread may drop that event, but must not terminate the relay");
+        received.Items.Select(e => (e.Path, e.Version, e.NodeType)).Should().Equal(
+            (Path, 0L, (string?)null),
+            (Path, 21L, "Hosting/Publication"));
     }
 
     [Fact]
@@ -127,7 +130,7 @@ public class StorageChangeFeedRelayTest
         var durable = new InMemoryStorageAdapter();
         using var adapter = new ControllableNotificationAdapter(durable);
         using var feed = new InProcessMeshChangeFeed(adapter);
-        var received = new List<MeshChangeEvent>();
+        var received = new ImmutableSignal<MeshChangeEvent>();
         using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
 
         adapter.Announce(new DataChangeNotification(
@@ -143,8 +146,8 @@ public class StorageChangeFeedRelayTest
             Version = 41,
         });
 
-        received.Should().ContainSingle();
-        received[0].Version.Should().Be(41,
+        received.Items.Should().ContainSingle();
+        received.Items[0].Version.Should().Be(41,
             "one unrecognised notification may be dropped, but must not terminate the relay");
     }
 
@@ -158,10 +161,10 @@ public class StorageChangeFeedRelayTest
         using var replicaB = new ControllableNotificationAdapter(durable);
         using var feedA = new InProcessMeshChangeFeed(replicaA);
         using var feedB = new InProcessMeshChangeFeed(replicaB);
-        var seenA = new List<MeshChangeEvent>();
-        var seenB = new List<MeshChangeEvent>();
-        var logicalA = new List<MeshChangeEvent>();
-        var logicalB = new List<MeshChangeEvent>();
+        var seenA = new ImmutableSignal<MeshChangeEvent>();
+        var seenB = new ImmutableSignal<MeshChangeEvent>();
+        var logicalA = new ImmutableSignal<MeshChangeEvent>();
+        var logicalB = new ImmutableSignal<MeshChangeEvent>();
         using var subscriptionA = ((IMeshInvalidationFeed)feedA).Subscribe(seenA.Add);
         using var subscriptionB = ((IMeshInvalidationFeed)feedB).Subscribe(seenB.Add);
         using var logicalSubscriptionA = feedA.Subscribe(logicalA.Add);
@@ -178,10 +181,97 @@ public class StorageChangeFeedRelayTest
         replicaA.Announce(notification);
         replicaB.Announce(notification);
 
-        seenA.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
-        seenB.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
-        logicalA.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
-        logicalB.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
+        seenA.Items.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
+        seenB.Items.Select(e => (e.Path, e.Version)).Should().Equal((Path, 31L));
+        logicalA.Items.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
+        logicalB.Items.Should().BeEmpty("a storage listener copy is cache invalidation, not a logical event");
+    }
+
+    [Fact]
+    public void NeverAnsweringLegacyRead_IsBounded_AndCannotBlockTheNextHintedInvalidation()
+    {
+        var scheduler = new TestScheduler();
+        var durable = new InMemoryStorageAdapter();
+        using var adapter = new ControllableNotificationAdapter(durable) { NeverRead = true };
+        var received = new ImmutableSignal<MeshChangeEvent>();
+        using var relay = new StorageChangeFeedRelay(
+            adapter, received.Add, legacyReadTimeout: TimeSpan.FromTicks(10), scheduler: scheduler);
+
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow));
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 52,
+        });
+
+        received.Items.Should().BeEmpty(
+            "Concat preserves order while the first compatibility read remains inside its budget");
+        scheduler.AdvanceBy(11);
+
+        received.Items.Select(e => (e.Path, e.Version)).Should().Equal(
+            (Path, 0L),
+            (Path, 52L));
+    }
+
+    [Fact]
+    public void JsonEntityAndStringEnumReadback_BothRecoverMetadata()
+    {
+        var serialization = new JsonSerializerOptions(JsonSerializerDefaults.Web)
+        {
+            Converters = { new JsonStringEnumConverter() },
+        };
+        var entity = JsonSerializer.SerializeToElement(
+            Node(version: 61, nodeType: "Hosting/Publication"), serialization);
+        var factoryNotification = DataChangeNotification.Updated(Path, entity);
+        factoryNotification.NodeType.Should().Be("Hosting/Publication");
+        factoryNotification.Version.Should().Be(61L);
+
+        var durable = new InMemoryStorageAdapter();
+        using var adapter = new ControllableNotificationAdapter(durable)
+        {
+            SerializedRead = JsonSerializer.Serialize(
+                Node(version: 62, nodeType: "Hosting/Publication"), serialization),
+        };
+        using var feed = new InProcessMeshChangeFeed(adapter);
+        var received = new ImmutableSignal<MeshChangeEvent>();
+        using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
+
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: entity, DateTimeOffset.UtcNow));
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Updated, Entity: null, DateTimeOffset.UtcNow));
+
+        received.Items.Select(e => (e.NodeType, e.Version)).Should().Equal(
+            ("Hosting/Publication", 61L),
+            ("Hosting/Publication", 62L));
+        adapter.ReadCalls.Should().Be(1,
+            "the JSON entity is self-contained; only the legacy path-only event needs a read");
+    }
+
+    [Fact]
+    public void DeleteInvalidation_IsAlwaysVersionless_EvenWhenTheTombstoneCarriesAClock()
+    {
+        var durable = new InMemoryStorageAdapter();
+        using var adapter = new ControllableNotificationAdapter(durable);
+        using var feed = new InProcessMeshChangeFeed(adapter);
+        var received = new ImmutableSignal<MeshChangeEvent>();
+        using var subscription = ((IMeshInvalidationFeed)feed).Subscribe(received.Add);
+
+        adapter.Announce(new DataChangeNotification(
+            Path, DataChangeKind.Deleted,
+            Entity: Node(version: 71, nodeType: "Hosting/Publication"),
+            DateTimeOffset.UtcNow)
+        {
+            NodeType = "Hosting/Publication",
+            Version = 71,
+        });
+
+        received.Items.Should().ContainSingle();
+        received.Items[0].Kind.Should().Be(MeshChangeKind.Deleted);
+        received.Items[0].Version.Should().Be(0,
+            "remote-stream invalidation treats zero as the unconditional deletion signal");
     }
 
     private static MeshNode Node(long version, string nodeType) =>
@@ -202,6 +292,8 @@ public class StorageChangeFeedRelayTest
         private readonly Subject<DataChangeNotification> changes = new();
 
         public Exception? NextReadError { get; set; }
+        public bool NeverRead { get; set; }
+        public string? SerializedRead { get; set; }
         public int ReadCalls { get; private set; }
         public IObservable<DataChangeNotification> Changes => changes;
 
@@ -215,6 +307,10 @@ public class StorageChangeFeedRelayTest
                 NextReadError = null;
                 return Observable.Throw<MeshNode?>(ex);
             }
+            if (NeverRead)
+                return Observable.Never<MeshNode?>();
+            if (SerializedRead is { } serialized)
+                return Observable.Return(JsonSerializer.Deserialize<MeshNode>(serialized, options));
             return inner.Read(path, options);
         }
 
@@ -251,5 +347,17 @@ public class StorageChangeFeedRelayTest
             changes.OnCompleted();
             changes.Dispose();
         }
+    }
+
+    private sealed class ImmutableSignal<T>
+    {
+        private ImmutableList<T> items = ImmutableList<T>.Empty;
+
+        public ImmutableList<T> Items => Volatile.Read(ref items);
+
+        public void Add(T item) => ImmutableInterlocked.Update(
+            ref items,
+            static (current, next) => current.Add(next),
+            item);
     }
 }


### PR DESCRIPTION
## What & why

A committed node could remain permanently stale on one portal replica. The default Orleans composition can resolve the process-local change feed before its wrapper, and the fallback invalidator grain is a cluster singleton for its key, so it cannot update every process's cache.

Each `InProcessMeshChangeFeed` now relays that process's durable storage notifications into a separate `IMeshInvalidationFeed`. Path resolution, node-stream, remote-stream, query deletion, node-type rebind, and activation-error caches subscribe to this process-local invalidation channel. Every PostgreSQL listener can therefore invalidate its own replica after the same commit.

The separation is deliberate: a direct `IMeshChangeFeed.Publish` reaches logical consumers and the writer's local invalidators, while a storage or Orleans echo reaches invalidators only. This prevents a database notification from running `AccessGrantNotifier`, `InstanceSyncCoordinator`, or another logical side effect once per replica. A faulting invalidator is isolated from the remaining cache subscribers; logical-feed failure semantics remain unchanged.

`DataChangeNotification` gains additive node-type and version hints. During the mixed-version rollout, notifications without both hints re-read the committed row once. A failed or malformed notification is isolated so later cache invalidations continue. Existing public constructors and the legacy `PublishLocal` entry point retain their exact signatures.

## Merge preconditions

- [x] **(a) Build is green with warnings-as-errors** — affected projects build cleanly on the merged tree.
- [x] **(b) Tests are green locally** — Hosting 637/637, Graph 1,568/1,568, Data 508/508, Documentation 434/434, Orleans 261/261 under the CI locale; focused relay 8/8.
- [ ] **(c) Required CI and review are green** — awaiting the exact-head run and ruleset review.
- [x] **(d) Review comments dealt with** — all current threads have exact-head fixes, replies, and resolution.

## Notes for reviewers

The production reproduction was an exact lookup of `Hosting/PlatformBuilds/plugins` returning the old v7 row while the children query returned the current v1 durable row on the same two-replica portal. The relay regressions model two independent process listeners and prove that both invalidate while neither receives a logical event. They also pin a silent-read deadline, path-only fallback, JSON/string-enum metadata recovery, versionless deletes, subscriber isolation, and the default Orleans DI composition. The architecture record and a user-facing change note are committed with the fix.

The PostgreSQL module can add the new version field after this additive core contract lands. Until then the bounded fallback read preserves compatibility with its current notification payload.
