### PR TITLE
fix(PluginCatalog): a mixed package's src/<Module>/ sources are not nodes (#4101)

### DIFF
--- a/src/MeshWeaver.PluginCatalog/InstallCompleteness.cs
+++ b/src/MeshWeaver.PluginCatalog/InstallCompleteness.cs
@@ -44,7 +44,7 @@ public static class InstallCompleteness
     ///
     /// <para>🚨 <b>The population is the whole point, and getting it wrong is #3659.</b> This used
     /// to apply only the by-design exclusions (<c>README.md</c>, the <c>manifest.lock</c> sidecar,
-    /// <c>content/**</c>) while the installer ALSO skipped every file whose extension no registered
+    /// <c>content/**</c>; since #4101 also <c>src/**</c> module sources) while the installer ALSO skipped every file whose extension no registered
     /// parser claims. So a package's ordinary carry-along files counted as nodes the install owed
     /// the mesh: <c>Chess</c> ships <c>Chess/gui/rn/chess.tsx</c>, nothing ever wrote it, and the
     /// sweep reported <c>Chess/gui/rn/chess</c> ABSENT at Error on every pod boot — indefinitely,
@@ -118,11 +118,10 @@ public static class InstallCompleteness
         // nodes" is a bare number that reads identically whether it was taken over the right set or
         // the wrong one — which is exactly how a `.tsx` asset was reported as a missing node on
         // every boot for as long as the sweep existed.
-        var declaredFiles = record.InstalledFiles?.Count ?? 0;
-        var nonNodeFiles = declaredFiles - (record.InstalledFiles?.Keys
-            .Count(f => PackageInstaller.NodePathForFile(f, parsers) is not null) ?? 0);
+        var population = PopulationOf(record, parsers);
+        var declaredFiles = population.DeclaredFiles;
         InstallCompletenessVerdict WithPopulation(InstallCompletenessVerdict verdict) =>
-            verdict with { DeclaredFiles = declaredFiles, NonNodeFiles = nonNodeFiles };
+            population.Apply(verdict);
         if (declared.Count == 0)
             return WithPopulation(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.Undeclared, 0, 0,
@@ -133,8 +132,9 @@ public static class InstallCompleteness
                       + "stamped, or by a lane that does not stamp one. The next real install "
                       + "writes one."
                     : $"all {declaredFiles} file(s) the record declares are non-node files (a "
-                      + "README, the manifest sidecar, a content/** asset, or an extension no "
-                      + "parser claims), so this package declares no node to compare against"));
+                      + "README, the manifest sidecar, a content/** asset, a src/** module source, "
+                      + "or an extension no parser claims), so this package declares no node to "
+                      + "compare against"));
 
         // 🚨 A file map that does not map ONTO this partition cannot be compared against it, and
         // guessing a rebase would manufacture a shortfall out of a naming difference. Say so
@@ -214,15 +214,12 @@ public static class InstallCompleteness
     {
         ArgumentNullException.ThrowIfNull(parsers);
         var declared = DeclaredNodePaths(record, parsers);
-        var files = record?.InstalledFiles?.Count ?? 0;
-        var nonNode = files - (record?.InstalledFiles?.Keys
-            .Count(f => PackageInstaller.NodePathForFile(f, parsers) is not null) ?? 0);
+        var population = PopulationOf(record, parsers);
         if (persistence is null)
-            return Observable.Return(new InstallCompletenessVerdict(
+            return Observable.Return(population.Apply(new InstallCompletenessVerdict(
                 packageId, partition, InstallCompletenessKind.NotObserved, declared.Count, 0,
                 ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
-                "this host registers no storage adapter, so the mesh was NOT read")
-            { DeclaredFiles = files, NonNodeFiles = nonNode });
+                "this host registers no storage adapter, so the mesh was NOT read")));
         // Nothing declared ⇒ nothing to read. Compare against an EMPTY observation rather than a
         // null one: the verdict is Undeclared either way, and reading the mesh to learn that would
         // be a round-trip that cannot change the answer.
@@ -236,12 +233,128 @@ public static class InstallCompleteness
             .Select(paths => Compare(packageId, partition, record,
                 paths.ToImmutableHashSet(StringComparer.Ordinal), parsers))
             .Catch<InstallCompletenessVerdict, Exception>(ex => Observable.Return(
-                new InstallCompletenessVerdict(
+                population.Apply(new InstallCompletenessVerdict(
                     packageId, partition, InstallCompletenessKind.NotObserved, declared.Count, 0,
                     ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal),
                     $"reading the mesh failed, so completeness was NOT checked — this is not a "
-                    + $"pass. Cause: {ex.Message}")
-                { DeclaredFiles = files, NonNodeFiles = nonNode }));
+                    + $"pass. Cause: {ex.Message}"))));
+    }
+
+    /// <summary>
+    /// The population a verdict was taken over, computed ONCE per record: how many files the
+    /// record declares, how many of them are not node candidates, and — separately — how many of
+    /// those are module sources (#4101), so the line can say what the non-node files ARE.
+    /// </summary>
+    private readonly record struct Population(
+        int DeclaredFiles, int NonNodeFiles, int ModuleSourceFiles,
+        ImmutableSortedSet<string> ModuleSourceDirectories)
+    {
+        public InstallCompletenessVerdict Apply(InstallCompletenessVerdict verdict) => verdict with
+        {
+            DeclaredFiles = DeclaredFiles,
+            NonNodeFiles = NonNodeFiles,
+            ModuleSourceFiles = ModuleSourceFiles,
+            ModuleSourceDirectories = ModuleSourceDirectories,
+        };
+    }
+
+    private static Population PopulationOf(PackageManifest? record, FileFormatParserRegistry parsers)
+    {
+        if (record?.InstalledFiles is not { Count: > 0 } files)
+            return new Population(0, 0, 0,
+                ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal));
+        var nonNode = files.Keys.Count(f => PackageInstaller.NodePathForFile(f, parsers) is null);
+        var sources = files.Keys.Where(PackageInstaller.IsModuleSourcePath).ToList();
+        var directories = sources
+            .Select(ModuleSourceDirectoryOf)
+            .ToImmutableSortedSet(StringComparer.Ordinal);
+        return new Population(files.Count, nonNode, sources.Count, directories);
+    }
+
+    /// <summary><c>src/X/a/b.cs</c> → <c>src/X</c>: the module directory a declared source
+    /// belongs to, for the population line.</summary>
+    private static string ModuleSourceDirectoryOf(string relativePath)
+    {
+        var rest = relativePath[PackageInstaller.ModuleSourcePrefix.Length..];
+        var slash = rest.IndexOf('/');
+        return slash < 0
+            ? relativePath
+            : PackageInstaller.ModuleSourcePrefix + rest[..slash];
+    }
+
+    /// <summary>
+    /// The MODULE half of a mixed package's completeness (#4101): whether the compiled module the
+    /// record declares (<see cref="PackageManifest.Module"/>) is active on THIS pod.
+    ///
+    /// <para>🚨 <b>What this can and cannot answer.</b> The sources the lock declares under
+    /// <c>src/&lt;Module&gt;/</c> are compiled into the module bundle by the pack lane; the volume
+    /// holds ASSEMBLIES, not sources, so they cannot be checked file-by-file the way node files
+    /// are. What CAN be asked is the activation record (<see cref="ModuleLandingService.GetActivation"/>)
+    /// and this process's loaded assemblies — the same two the pending-restart surface reads
+    /// (<see cref="ModuleActivationStatus"/>). So "active" here means "an enabled entry names it
+    /// AND an assembly of that name is loaded in this process"; it is NOT "every source file
+    /// arrived", and the wording of every verdict says so. Pure and total: the caller supplies the
+    /// list and the loaded set, so the rule is testable with no host.</para>
+    /// </summary>
+    /// <param name="packageId">The package the record belongs to.</param>
+    /// <param name="record">The install record's manifest.</param>
+    /// <param name="activation">The persisted activation list, or null when it could not be read
+    /// (no landing service on this host, or the read faulted) — which yields
+    /// <see cref="ModuleActivationVerdictKind.NotObserved"/>, never a pass.</param>
+    /// <param name="loadedAssemblyNames">Assembly SIMPLE names loaded in this process
+    /// (<see cref="ModuleActivationStatus.LoadedAssemblyNames()"/> in production).</param>
+    /// <param name="baseDirectory">The deployment root the <c>modules/</c> tree lives under
+    /// (<see cref="ModuleLandingService.BaseDirectory"/>), so the line can name the directory.</param>
+    /// <returns>A verdict, or null when the record declares no module — nothing to ask.</returns>
+    public static ModuleActivationVerdict? ModuleActivation(
+        string packageId,
+        PackageManifest? record,
+        ModuleActivationList? activation,
+        IReadOnlySet<string> loadedAssemblyNames,
+        string? baseDirectory)
+    {
+        ArgumentNullException.ThrowIfNull(loadedAssemblyNames);
+        var module = record?.Module;
+        if (string.IsNullOrWhiteSpace(module))
+            return null;
+        var sources = record!.InstalledFiles?.Keys.Count(PackageInstaller.IsModuleSourcePath) ?? 0;
+        var caveat = sources > 0
+            ? $"the {sources} source file(s) the record declares under src/ are compiled into the "
+              + "module bundle and cannot be checked file-by-file on the volume — 'active' is not "
+              + "'every source file arrived'"
+            : "the module's sources are compiled into the bundle and cannot be checked file-by-file "
+              + "on the volume — 'active' is not 'every source file arrived'";
+
+        if (activation is null)
+            return new ModuleActivationVerdict(packageId, module, ModuleActivationVerdictKind.NotObserved,
+                null, sources,
+                $"the activation record could not be read, so whether module '{module}' is active "
+                + $"was NOT checked — this is not a pass; and {caveat}");
+
+        var entry = activation.Entries.LastOrDefault(e =>
+            string.Equals(e.Name, module, StringComparison.OrdinalIgnoreCase));
+        if (entry is null || !entry.Enabled)
+            return new ModuleActivationVerdict(packageId, module, ModuleActivationVerdictKind.NotActive,
+                null, sources,
+                entry is null
+                    ? $"module '{module}' is declared by the install record but has NO activation "
+                      + "entry — the bundle never landed on this volume, or its entry was removed"
+                    : $"module '{module}' is declared by the install record but its activation entry "
+                      + "is DISABLED — it was uninstalled after the record was written");
+
+        var directory = string.IsNullOrWhiteSpace(baseDirectory)
+            ? null
+            : ModuleLandingService.ModuleDirectoryFor(baseDirectory, module, entry);
+        var loaded = loadedAssemblyNames.Contains(module);
+        return loaded
+            ? new ModuleActivationVerdict(packageId, module, ModuleActivationVerdictKind.Active,
+                directory, sources,
+                $"module '{module}' active from '{directory ?? entry.Directory ?? module}'; {caveat}")
+            : new ModuleActivationVerdict(packageId, module, ModuleActivationVerdictKind.LandedNotLoaded,
+                directory, sources,
+                $"module '{module}' is landed at '{directory ?? entry.Directory ?? module}' but "
+                + "NOT loaded in this process — it activates on this pod's next restart; not a "
+                + $"pass; and {caveat}");
     }
 
     /// <summary>
@@ -522,18 +635,83 @@ public sealed record InstallCompletenessVerdict(
     /// </summary>
     public int NonNodeFiles { get; init; }
 
+    /// <summary>
+    /// How many of <see cref="NonNodeFiles"/> are module SOURCES (<c>src/&lt;Module&gt;/…</c>,
+    /// #4101) — declared by the lock because a source change must move the module version, compiled
+    /// into the module bundle by the pack lane, never written as nodes. Counted separately so the
+    /// population line says what they are instead of folding 14 sources in with the README.
+    /// Init-only, for the same binary-compatibility reason as <see cref="DeclaredFiles"/>.
+    /// </summary>
+    public int ModuleSourceFiles { get; init; }
+
+    /// <summary>The <c>src/&lt;Module&gt;</c> directories those sources live under, ordinal-sorted;
+    /// empty when the record declares none.</summary>
+    public ImmutableSortedSet<string> ModuleSourceDirectories { get; init; } =
+        ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal);
+
     /// <summary>What this verdict counted, and over what — one clause, on every line that reports
     /// a verdict, so a wrong population is visible instead of silent.</summary>
     public string Population =>
         $"{DeclaredFiles} file(s) declared, {NonNodeFiles} of them not node files "
-        + $"(README/manifest/content assets, or an extension no parser claims) → {Declared} "
-        + "distinct node path(s) compared";
+        + "(README/manifest/content assets, module sources, or an extension no parser claims)"
+        + (ModuleSourceFiles == 0
+            ? ""
+            : $", {ModuleSourceFiles} of them module sources "
+              + $"({string.Join(", ", ModuleSourceDirectories)}), compiled into the module bundle, "
+              + "not compared as nodes")
+        + $" → {Declared} distinct node path(s) compared";
 
     /// <inheritdoc />
     public override string ToString() =>
         $"{PackageId} [{Kind}] {Present}/{Declared} present ({Population})"
         + (Missing.Count == 0 ? "" : $" — missing: {string.Join(", ", Missing.Take(10))}"
                                      + (Missing.Count > 10 ? $" (+{Missing.Count - 10} more)" : ""));
+}
+
+/// <summary>
+/// What <see cref="InstallCompleteness.ModuleActivation"/> concluded about a mixed package's
+/// compiled module on THIS pod. 🚨 Only <see cref="Active"/> is a pass, and even that pass is
+/// about the activation record and the loaded assembly — not about the declared sources, which
+/// cannot be checked (#4101).
+/// </summary>
+public enum ModuleActivationVerdictKind
+{
+    /// <summary>An enabled activation entry names the module and an assembly of that name is
+    /// loaded in this process.</summary>
+    Active,
+
+    /// <summary>An enabled entry names it but no assembly of that name is loaded here — it
+    /// activates on this pod's next restart. NOT a pass.</summary>
+    LandedNotLoaded,
+
+    /// <summary>No enabled activation entry names the module. NOT a pass.</summary>
+    NotActive,
+
+    /// <summary>The activation record could not be read. NOT a pass: it was not checked.</summary>
+    NotObserved,
+}
+
+/// <summary>One mixed package's module-activation verdict (#4101).</summary>
+/// <param name="PackageId">The package the record belongs to.</param>
+/// <param name="Module">The module the record declares (<see cref="PackageManifest.Module"/>).</param>
+/// <param name="Kind">The verdict.</param>
+/// <param name="Directory">The module directory the activation entry resolves to
+/// (<see cref="ModuleLandingService.ModuleDirectoryFor"/>), when an enabled entry exists and the
+/// base directory was known.</param>
+/// <param name="DeclaredSourceFiles">How many <c>src/**</c> files the record declares — the
+/// population this verdict explicitly does NOT check.</param>
+/// <param name="Because">Why, in one sentence, for the log line — always naming what was not
+/// checked.</param>
+public sealed record ModuleActivationVerdict(
+    string PackageId,
+    string Module,
+    ModuleActivationVerdictKind Kind,
+    string? Directory,
+    int DeclaredSourceFiles,
+    string Because)
+{
+    /// <summary>🚨 True ONLY for <see cref="ModuleActivationVerdictKind.Active"/>.</summary>
+    public bool IsActive => Kind is ModuleActivationVerdictKind.Active;
 }
 
 /// <summary>The sweep's denominator.</summary>

--- a/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs
@@ -80,7 +80,8 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                             "[PackageRepair] reconciled declared access + install hooks for {Count} "
                             + "installed partition(s)", records.Count)))
                 .Do(_ => ReportDeclaredModulesWithNoBinary(records, logger))
-                .SelectMany(_ => VerifyCompleteness(records, logger)))
+                .SelectMany(_ => VerifyCompleteness(records, logger))
+                .SelectMany(_ => VerifyModules(records, logger)))
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex, "[PackageRepair] repair pass failed"));
@@ -371,6 +372,81 @@ public sealed class InstalledPackageRepairService(IMessageHub hub) : IHostedServ
                     "[InstallCompleteness] the completeness sweep failed — NOTHING was verified "
                     + "this boot. Absence of a report here is not evidence that the installs are "
                     + "whole.");
+                return Observable.Return(Unit.Default);
+            });
+    }
+
+    /// <summary>
+    /// The MODULE half of the sweep (#4101): for every record that declares a compiled module
+    /// (<see cref="PackageManifest.Module"/>), ask the activation record whether that module is
+    /// active on THIS pod and say so on one line.
+    ///
+    /// <para>🚨 <b>"active" ≠ "every source file arrived".</b> A mixed package's lock declares its
+    /// <c>src/&lt;Module&gt;/…</c> sources so a source-only change moves the module version, but no
+    /// install ever writes them — the pack lane compiles them into the bundle, and the volume holds
+    /// assemblies. So this half cannot compare file-by-file the way <see cref="VerifyCompleteness"/>
+    /// does; it can only ask the two things this pod knows — the activation entry and the loaded
+    /// assembly — and every line it prints says which of the two questions it answered.</para>
+    ///
+    /// <para>Reports; never repairs. Never fails the sweep: a record that cannot be read yields a
+    /// NOT-OBSERVED line, which is a warning and not a pass.</para>
+    /// </summary>
+    private IObservable<Unit> VerifyModules(
+        IReadOnlyList<InstalledRecord> records, ILogger? logger)
+    {
+        var withModule = records
+            .Where(r => !string.IsNullOrWhiteSpace(r.Manifest.Module))
+            .ToList();
+        if (withModule.Count == 0)
+            return Observable.Return(Unit.Default);
+
+        var landing = hub.ServiceProvider.GetService<ModuleLandingService>();
+        var activation = landing is null
+            ? Observable.Return<ModuleActivationList?>(null)
+            : landing.GetActivation()
+                .Select(list => (ModuleActivationList?)list)
+                .Catch<ModuleActivationList?, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[InstallCompleteness] reading the module activation record failed — the "
+                        + "module half of the sweep was NOT checked for {Count} package(s).",
+                        withModule.Count);
+                    return Observable.Return<ModuleActivationList?>(null);
+                })
+                .DefaultIfEmpty(null);
+        if (landing is null)
+            logger?.LogWarning(
+                "[InstallCompleteness] this host registers no ModuleLandingService, so whether the "
+                + "{Count} declared module(s) are active was NOT checked.", withModule.Count);
+
+        return activation
+            .Take(1)
+            .Do(list =>
+            {
+                var loaded = ModuleActivationStatus.LoadedAssemblyNames();
+                foreach (var record in withModule)
+                {
+                    var verdict = InstallCompleteness.ModuleActivation(
+                        record.PackageId, record.Manifest, list, loaded, landing?.BaseDirectory);
+                    if (verdict is null)
+                        continue;
+                    if (verdict.IsActive)
+                        logger?.LogInformation(
+                            "[InstallCompleteness] {Package} → module '{Module}': ACTIVE — {Because}.",
+                            verdict.PackageId, verdict.Module, verdict.Because);
+                    else
+                        logger?.LogWarning(
+                            "[InstallCompleteness] {Package} → module '{Module}': NOT ACTIVE ({Kind}) — "
+                            + "{Because}. This is not a clean bill of health; it is an absence of one.",
+                            verdict.PackageId, verdict.Module, verdict.Kind, verdict.Because);
+                }
+            })
+            .Select(_ => Unit.Default)
+            .Catch<Unit, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[InstallCompleteness] the module half of the sweep failed — NOTHING about "
+                    + "declared modules was verified this boot.");
                 return Observable.Return(Unit.Default);
             });
     }

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -3730,11 +3730,43 @@ public static class PackageInstaller
     /// "3 of 200 skipped" reads very differently when 150 of the 200 were never node candidates
     /// (Copilot review, #1781). Two copies of this list would drift, and the drift would show up as
     /// a quietly wrong count rather than as a failure.</para>
+    ///
+    /// <para>🚨 <b>A module SOURCE file (<c>src/&lt;Module&gt;/…</c>) is not a node either</b>
+    /// (#4101). The canonical <c>gen-manifests.py</c> folds a mixed package's module sources into
+    /// the SAME <c>files</c> map as its node files (<c>hashModuleSources</c>, Plugins#878 — a
+    /// <c>src/</c>-only change must move the module version), so a lock like
+    /// <c>Hosting/manifest.lock</c> carries 14 <c>src/MeshWeaver.SelfUpdate.Aks/…</c> entries next
+    /// to 176 <c>Hosting/…</c> ones. No install ever writes one as a node —
+    /// <see cref="NodeRepoPackageSource.FetchPackageFiles"/> keeps only <c>{Id}/…</c>, and the
+    /// sources are compiled into the module bundle the pack lane ships — but <c>.cs</c> IS a
+    /// claimed extension, so without this clause <c>src/X/AcrTagLister.cs</c> mapped to the node
+    /// path <c>src/X/AcrTagLister</c>, which is off-partition, and the completeness sweep answered
+    /// <c>NOT VERIFIED (Undeclared)</c> for EVERY mixed package (38 of 63 in MeshWeaver.Plugins) on
+    /// every fresh mesh. The delta prune runs the same rule on removed files, so a removed source
+    /// no longer asks to prune a node path that never existed.</para>
     /// </summary>
     private static bool IsNotANodeFile(string relativePath) =>
         string.Equals(relativePath, "README.md", StringComparison.OrdinalIgnoreCase)
         || ModuleManifest.IsManifestPath(relativePath)
-        || ContentAssetMapper.IsContentPath(relativePath);
+        || ContentAssetMapper.IsContentPath(relativePath)
+        || IsModuleSourcePath(relativePath);
+
+    /// <summary>The directory prefix under which <c>gen-manifests.py</c> declares a mixed
+    /// package's module sources (<c>module_source_files</c>) — and the ONLY place it ever puts
+    /// them.</summary>
+    public const string ModuleSourcePrefix = "src/";
+
+    /// <summary>
+    /// Whether a declared file is a module SOURCE (<c>src/&lt;Module&gt;/…</c>) — compiled into the
+    /// module bundle by the pack lane, never written to the mesh as a node, and therefore neither
+    /// installed nor compared by the completeness sweep (#4101). The one predicate
+    /// <see cref="IsNotANodeFile"/>, the delta prune and <see cref="InstallCompleteness"/> share;
+    /// public so the verdict can COUNT these separately from a README rather than lumping them.
+    /// </summary>
+    /// <param name="relativePath">The file's repo-relative path as the lock declares it.</param>
+    public static bool IsModuleSourcePath(string relativePath) =>
+        relativePath is not null
+        && relativePath.StartsWith(ModuleSourcePrefix, StringComparison.Ordinal);
 
     private static MeshNode? ParseCanonical(
         FileFormatParserRegistry parsers, PackageFile file, ILogger? logger,
@@ -3975,7 +4007,7 @@ public static class PackageInstaller
     /// <para>🚨 <b>TWO reasons for null, and #3659 is what happened when only the first was
     /// asked.</b> A file is not a node candidate when it is a non-node file BY DESIGN
     /// (<see cref="IsNotANodeFile"/> — the README, the manifest sidecar, a <c>content/**</c>
-    /// asset) <b>or</b> when NO REGISTERED PARSER CLAIMS ITS EXTENSION, which is how a package's
+    /// asset, a <c>src/**</c> module source) <b>or</b> when NO REGISTERED PARSER CLAIMS ITS EXTENSION, which is how a package's
     /// ordinary carry-along files (<c>.tsx</c>, <c>.png</c>, <c>.py</c>, an extension-less
     /// <c>LICENSE</c>) are silently skipped by the install. Until #3659 this method asked only the
     /// first question while <c>ParseCanonical</c> asked both, so the two disagreed about the very

--- a/test/Memex.Portal.Shared.Test/InstallCompletenessTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstallCompletenessTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -584,6 +585,168 @@ public class InstallCompletenessTest(ITestOutputHelper output) : MonolithMeshTes
     private static InstallCompletenessVerdict Verdict(InstallCompletenessKind kind) =>
         new("x", "x", kind, 0, 0,
             ImmutableSortedSet<string>.Empty.WithComparer(StringComparer.Ordinal), "");
+
+    // ── #4101: a MIXED package's src/<Module>/ sources are not nodes ────────────────────────────
+
+    private const string Module = "MeshWeaver.SelfUpdate.Aks";
+    private const string ModuleSourceDir = $"src/{Module}";
+
+    /// <summary>Three node files under the partition plus two module sources — the shape the
+    /// canonical <c>gen-manifests.py</c> produces for a mixed package with
+    /// <c>hashModuleSources: true</c> (Plugins#878), which is 38 of the 63 locks in MeshWeaver.Plugins.</summary>
+    private static PackageManifest MixedRecord(ImmutableSortedDictionary<string, string>? extra = null) => new()
+    {
+        Id = Package,
+        TargetPartition = Package,
+        Module = Module,
+        InstalledFiles = (extra ?? ImmutableSortedDictionary<string, string>.Empty)
+            .Add($"{Package}/Guide.md", "aaa")
+            .Add($"{Package}/Other.md", "bbb")
+            .Add($"{Package}/Third.md", "ccc")
+            .Add($"{ModuleSourceDir}/AcrTagLister.cs", "ddd")
+            .Add($"{ModuleSourceDir}/{Module}.csproj", "eee"),
+    };
+
+    /// <summary>
+    /// 🚨 <b>THE repro of #4101.</b> Measured 2026-09-12 on <c>build.meshweaver.cloud</c>, first boot
+    /// after the Hosting package landed: <c>NOT VERIFIED (Undeclared) — 13 of 189 declared file(s)
+    /// map outside the target partition 'Hosting' (e.g. 'src/MeshWeaver.SelfUpdate.Aks/AcrTagLister')</c>.
+    /// <c>.cs</c> is a claimed extension, so a declared module source mapped to an off-partition
+    /// node path and the whole record became uncomparable — for every mixed package, on every fresh
+    /// mesh. No install ever writes a <c>src/</c> file as a node (<c>NodeRepoPackageSource</c> keeps
+    /// only <c>{Id}/…</c>); the pack lane compiles them into the bundle.
+    /// </summary>
+    [Fact]
+    public void ModuleSources_AreNotNodes_AndTheVerdictCountsThemSeparately()
+    {
+        var record = MixedRecord();
+        var parsers = Parsers();
+
+        InstallCompleteness.DeclaredNodePaths(record, parsers).Should().Equal(
+            [GuidePath, OtherPath, $"{Package}/Third"],
+            "a src/<Module>/ source is compiled into the module bundle, never written as a node — "
+            + "counting it made every mixed package read NOT VERIFIED (Undeclared) on every fresh mesh");
+
+        var verdict = InstallCompleteness.Compare(
+            Package, Package, record,
+            ImmutableHashSet.Create(StringComparer.Ordinal, GuidePath, OtherPath, $"{Package}/Third"),
+            parsers);
+
+        verdict.Kind.Should().Be(InstallCompletenessKind.Complete,
+            "every node the record declares is present; the two module sources are not nodes it owes the mesh");
+        verdict.IsComplete.Should().BeTrue();
+        verdict.Declared.Should().Be(3);
+        verdict.DeclaredFiles.Should().Be(5);
+        verdict.NonNodeFiles.Should().Be(2);
+        verdict.ModuleSourceFiles.Should().Be(2,
+            "the sources are counted SEPARATELY from a README so the line says what they are");
+        verdict.ModuleSourceDirectories.Should().ContainSingle().Which.Should().Be(ModuleSourceDir);
+        verdict.Population.Should().Contain("5 file(s) declared, 2 of them not node files")
+            .And.Contain($"2 of them module sources ({ModuleSourceDir})")
+            .And.Contain("not compared as nodes")
+            .And.Contain("3 distinct node path(s) compared",
+                "an operator reading the line must see both counts, or a wrong population is silent again");
+
+        // The install-time rule is the SAME predicate — a removed source must never ask the delta
+        // prune to delete a node path that never existed.
+        PackageInstaller.NodePathForFile($"{ModuleSourceDir}/AcrTagLister.cs", parsers).Should().BeNull();
+        PackageInstaller.IsModuleSourcePath($"{ModuleSourceDir}/AcrTagLister.cs").Should().BeTrue();
+        PackageInstaller.IsModuleSourcePath($"{Package}/src/NotASource.md").Should().BeFalse(
+            "only the lock's top-level src/ is the module-source directory; a package folder named "
+            + "src inside the partition is ordinary content");
+    }
+
+    /// <summary>
+    /// 🚨 The negative control: excluding <c>src/</c> must not buy a VERIFIED for a record that
+    /// genuinely maps outside its partition. A mixed record plus one rogue partition file still
+    /// reads <c>Undeclared</c>, naming the rogue file and NOT any module source.
+    /// </summary>
+    [Fact]
+    public void AGenuinelyUndeclaredPartitionFile_StillReads_NotVerified()
+    {
+        var record = MixedRecord(ImmutableSortedDictionary<string, string>.Empty
+            .Add("SomewhereElse/Rogue.md", "fff"));
+
+        var verdict = InstallCompleteness.Compare(
+            Package, Package, record,
+            ImmutableHashSet.Create(StringComparer.Ordinal, GuidePath, OtherPath, $"{Package}/Third"),
+            Parsers());
+
+        verdict.Kind.Should().Be(InstallCompletenessKind.Undeclared,
+            "a file map that maps outside the target partition still cannot be compared against it");
+        verdict.IsComplete.Should().BeFalse("the negative control must stay red");
+        verdict.Missing.Should().ContainSingle(
+                "the off-partition path named is the rogue node file — never a src/ source")
+            .Which.Should().Be("SomewhereElse/Rogue");
+        verdict.Missing.Should().NotContain(p => p.StartsWith("src/", StringComparison.Ordinal));
+        verdict.ModuleSourceFiles.Should().Be(2);
+        verdict.Because.Should().Contain("1 of 4 declared file(s) map outside the target partition");
+    }
+
+    /// <summary>
+    /// The module half of the sweep reads the REAL activation record through
+    /// <see cref="ModuleLandingService.GetActivation"/> and answers "active on this pod" from the
+    /// entry plus the loaded assembly set — and every wording says the sources themselves were NOT
+    /// checked, because the volume holds assemblies, not sources.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task TheModuleLine_ReadsTheActivationRecord_AndSaysWhatItDidNotCheck()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-4101-" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(root);
+        using var landing = new ModuleLandingService(baseDirectory: root);
+        try
+        {
+            var entry = new ModuleActivationEntry { Name = Module, Directory = $"{Module}@gen1" };
+            ModuleActivationSidecar.WriteEntry(root, entry);
+            var activation = await landing.GetActivation()
+                .Take(1)
+                .Timeout(TestTimeouts.Convergence)
+                .Await();
+            var record = MixedRecord();
+            var loaded = ImmutableHashSet.Create(StringComparer.Ordinal, Module);
+            var expectedDirectory = ModuleLandingService.ModuleDirectoryFor(root, Module, entry);
+
+            var active = InstallCompleteness.ModuleActivation(
+                Package, record, activation, loaded, landing.BaseDirectory);
+            active.Should().NotBeNull();
+            active!.Kind.Should().Be(ModuleActivationVerdictKind.Active);
+            active.IsActive.Should().BeTrue();
+            active.Directory.Should().Be(expectedDirectory,
+                "the line names the generation directory the entry resolves to");
+            active.DeclaredSourceFiles.Should().Be(2);
+            active.Because.Should().Contain($"module '{Module}' active from '{expectedDirectory}'")
+                .And.Contain("cannot be checked file-by-file",
+                    "'active' must never read as 'every source file arrived'");
+
+            var notLoaded = InstallCompleteness.ModuleActivation(
+                Package, record, activation, ImmutableHashSet<string>.Empty, landing.BaseDirectory);
+            notLoaded!.Kind.Should().Be(ModuleActivationVerdictKind.LandedNotLoaded,
+                "an enabled entry whose assembly is not in this process is a restart away, not active");
+            notLoaded.IsActive.Should().BeFalse();
+            notLoaded.Because.Should().Contain("NOT loaded").And.Contain("not a pass");
+
+            var noEntry = InstallCompleteness.ModuleActivation(
+                Package, record with { Module = "MeshWeaver.Nowhere" }, activation, loaded, landing.BaseDirectory);
+            noEntry!.Kind.Should().Be(ModuleActivationVerdictKind.NotActive);
+            noEntry.Because.Should().Contain("NO activation entry");
+
+            var unread = InstallCompleteness.ModuleActivation(
+                Package, record, activation: null, loaded, landing.BaseDirectory);
+            unread!.Kind.Should().Be(ModuleActivationVerdictKind.NotObserved);
+            unread.IsActive.Should().BeFalse("not checked is not a pass");
+            unread.Because.Should().Contain("NOT checked");
+
+            InstallCompleteness.ModuleActivation(
+                    Package, record with { Module = null }, activation, loaded, landing.BaseDirectory)
+                .Should().BeNull("a record that declares no module has nothing to ask");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); }
+            catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        }
+    }
 
     /// <summary>
     /// Waits until <paramref name="path"/> is present (or absent) in STORAGE — a condition, never a


### PR DESCRIPTION
Closes #4101

Filed from Systemorph/MeshWeaver.Plugins#1740: a package whose `manifest.lock` lists module source files (`src/<Module>/…`, generated by the canonical `gen-manifests.py` with `hashModuleSources: true`, the Plugins#878 answer) installs NOT VERIFIED because the completeness check treats `src/` entries as node files. 38 of the 63 Plugins locks are mixed packages, so every one of them installs NOT VERIFIED (Undeclared) on a fresh mesh.

## Evidence (verbatim, `build.meshweaver.cloud`, 2026-09-12 13:52:42Z, first boot after the Hosting package landed)

```
[InstallCompleteness] Hosting → 'Hosting': NOT VERIFIED (Undeclared) — 13 of 189 declared file(s) map outside the
target partition 'Hosting' (e.g. 'src/MeshWeaver.SelfUpdate.Aks/AcrTagLister'), so the record cannot be compared
against it. Counted over: 190 file(s) declared, 1 of them not node files … → 189 distinct node path(s) compared.
This is not a clean bill of health; it is an absence of one.
```

`.cs` is a claimed extension, so a declared source mapped to the off-partition node path `src/MeshWeaver.SelfUpdate.Aks/AcrTagLister` and `Compare` answered Undeclared. No install ever writes one as a node — `NodeRepoPackageSource.FetchPackageFiles` keeps only `{Id}/…`; the pack lane compiles them into the module bundle.

## The change

1. **One predicate, the one the install and the sweep already share** — `src/MeshWeaver.PluginCatalog/PackageInstaller.cs:3748` `IsNotANodeFile` gains `|| IsModuleSourcePath(relativePath)` (`:3767`, `src/` prefix, ordinal). `NodePathForFile`, the delta prune and `InstallCompleteness.DeclaredNodePaths` all go through it, so a removed `src/…` entry no longer asks to prune a node path that never existed either.
2. **Say what the sources are instead of lumping them with the README** — `src/MeshWeaver.PluginCatalog/InstallCompleteness.cs:645` `InstallCompletenessVerdict.ModuleSourceFiles` + `ModuleSourceDirectories` (init-only, computed once in `PopulationOf` `:261`), printed by `Population` (`:654`): `… 2 of them module sources (src/MeshWeaver.SelfUpdate.Aks), compiled into the module bundle, not compared as nodes → 3 distinct node path(s) compared`. A fresh Hosting install now compares 176 node paths and reads `190 file(s) declared, 15 of them not node files, 14 of them module sources (…)`.
3. **"active" ≠ "every source file arrived"** — `InstallCompleteness.ModuleActivation` (`:309`, pure; verdict kinds at `:677`) answers the module half from `ModuleLandingService.GetActivation()` plus the loaded assembly set, naming `ModuleDirectoryFor(...)`. The sweep calls it from `src/MeshWeaver.PluginCatalog/InstalledPackageRepairService.cs:394` `VerifyModules` (chained at `:84`): `ACTIVE — module 'X' active from '<dir>'; the 14 source file(s) the record declares under src/ are compiled into the module bundle and cannot be checked file-by-file on the volume — 'active' is not 'every source file arrived'`, or a warning (`LandedNotLoaded` / `NotActive` / `NotObserved`) that is explicitly not a pass.

Not the fix: moving `src/` entries out of the lock's `files` — `ModuleManifest.DiffFrom` would then report every previously-declared source as REMOVED on the next update of every mixed package.

## Tests (`test/Memex.Portal.Shared.Test/InstallCompletenessTest.cs`)

- `ModuleSources_AreNotNodes_AndTheVerdictCountsThemSeparately` (`:620`) — 3 partition files + 2 `src/` files → VERIFIED, `ModuleSourceFiles = 2`, population line names both counts; `NodePathForFile` answers null for the source.
- `AGenuinelyUndeclaredPartitionFile_StillReads_NotVerified` (`:665`) — the negative control: one rogue off-partition file keeps the verdict `Undeclared`, naming the rogue path and no `src/` path.
- `TheModuleLine_ReadsTheActivationRecord_AndSaysWhatItDidNotCheck` (`:693`) — writes a real activation entry, reads it through `ModuleLandingService.GetActivation()`, and pins all four verdict kinds plus the "cannot be checked file-by-file" wording.

Verified locally: `dotnet test test/Memex.Portal.Shared.Test -c Release -warnaserror --filter InstallCompletenessTest` → 14/14; ratchet guards `MeshWeaver.Documentation.Test` 301/301 and `Memex.Portal.Shared.Test` 38/38; `check-record-signatures.py`, `check-type-forwards.py`, `check-parser-delta.py` green.

Implementers: none — no interface member was added.
Mirror-sync: none — no i18n catalog change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
