### PR TITLE
hosting-signin-app: keep, verify and add the sign-in app's client secret — never rotate, never show (Plugins#1719)

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -65,8 +65,8 @@ jobs:
         run: |
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
-          if [ "$tracked" -lt 23 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 23 (20 commands + run.sh + _common.sh + _audit.jq). The floor is the REAL count — raise it with every command added, or a lost file passes."
+          if [ "$tracked" -lt 25 ]; then
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 25 (22 commands + run.sh + _common.sh + _audit.jq). The floor is the REAL count — raise it with every command added, or a lost file passes."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1
@@ -116,6 +116,7 @@ jobs:
           hosting-redirect
           hosting-registry-key
           hosting-restore
+          hosting-signin-app
           hosting-tls
           hosting-verify
           hosting-verify-backup
@@ -192,7 +193,7 @@ jobs:
         # through to a REAL az/kubectl on a runner that has one.
         run: |
           set -euo pipefail
-          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl deploy/aks/operator/test/stubs/inline-env/kubectl deploy/aks/operator/test/stubs/kv-rotate/az; do
+          for f in deploy/aks/operator/test/stubs/pull-secret/az deploy/aks/operator/test/stubs/pull-secret/kubectl deploy/aks/operator/test/stubs/pv-resize/kubectl deploy/aks/operator/test/stubs/inline-env/kubectl deploy/aks/operator/test/stubs/kv-rotate/az deploy/aks/operator/test/stubs/signin-app/az; do
             git ls-files --error-unmatch "$f" >/dev/null 2>&1 || { echo "::error::${f} is not tracked"; git check-ignore -v "$f" || true; exit 1; }
             [ "$(git ls-files -s "$f" | awk '{print $1}')" = "100755" ] || { echo "::error::${f} is not committed executable (mode 100755)"; exit 1; }
           done

--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -117,6 +117,15 @@ rule is in the mesh's pure, unit-tested plan. What the scripts themselves guaran
   teardown is never retried from the top, where it would re-dump over a verified archive.
 - **`hosting-kv-ensure` never overwrites an existing master key.** Regenerating it would make every
   stored `enc:` value in that instance's database permanently unreadable.
+- **`hosting-signin-app` never rotates the sign-in app's secret and never shows one**
+  (MeshWeaver.Plugins#1719). A present `<prefix>Authentication-Microsoft-ClientSecret` is kept and
+  the app the record names is VERIFIED to redirect to `https://<host>/signin-microsoft` (an identity
+  without Graph `Application.Read.All` reports `signin_app_verify=unknown` with the hand command,
+  not a failure; a readable app missing the URI is RED naming `az ad app update`). An absent object
+  for a named app gets a credential ADDED (`--append`, stderr discarded, `--file` to the vault) —
+  needs Graph `Application.ReadWrite.OwnedBy` on an app the identity owns, else RED with the exact
+  hand commands. Registering the app itself (no client id on the record) stays a hand step, and the
+  step says so with the runbook's commands.
 - **`hosting-export` never prints the URL it mints.** A user-delegation SAS is a bearer credential;
   it goes into a one-shot Secret the mesh reads once and deletes.
 - **`hosting-verify-catalog` proves the plugin mounts took.** An instance with green pods and an

--- a/deploy/aks/operator/bin/hosting-signin-app
+++ b/deploy/aks/operator/bin/hosting-signin-app
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# hosting-signin-app --name <id> --host <host> --vault <vault> --object <prefix>Authentication-Microsoft-ClientSecret
+#                    [--client-id <Entra app id>] [--years 1]
+#
+# The SIGN-IN (Entra) app's client secret, in the vault, for the app the record names
+# (MeshWeaver.Plugins#1719). Runbook step 1 registered the multi-tenant app, minted a secret and
+# wrote it under <prefix>Authentication-Microsoft-ClientSecret by hand. What this step can and
+# cannot do is decided by two facts and stated rather than papered over:
+#
+#   • A vault object that EXISTS is KEPT — never minted over, never rotated (the master-key rule).
+#     With --client-id the app is then VERIFIED: its redirect URIs must carry
+#     https://<host>/signin-microsoft, or every Microsoft sign-in fails with AADSTS50011 and nothing
+#     names this step. Reading the app needs Graph `Application.Read.All`; an identity without it
+#     cannot verify, SAYS so with the hand command, and does not fail the provision on a right it
+#     was never granted (`signin_app_verify=unknown`).
+#   • A vault object that is ABSENT and a record that NAMES the app → a NEW credential is ADDED to
+#     the app (`az ad app credential reset --append`: existing credentials stay valid — this adds,
+#     it never rotates) and written through --file. That needs Graph `Application.ReadWrite.OwnedBy`
+#     on an app the operator identity OWNS (or `Application.ReadWrite.All`); without it the step is
+#     RED with the exact hand commands.
+#   • ABSENT and NO client id on the record → the app does not exist yet. Registering it is NOT
+#     automated here: it needs the same Graph right AND writing the new client id back to the
+#     git-owned record — RED with the runbook's exact commands and what to set on the record.
+#
+# 🚨 NEVER PRINTS THE SECRET. `az ad app credential reset` prints the minted secret on STDERR as
+# well as in its output (measured, runbook step 1) — stderr is discarded, the value goes from az's
+# stdout into a mode-600 temporary and reaches the vault through --file, never argv, never a log.
+# shellcheck source=_common.sh
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-signin-app"
+
+name="" host="" vault="" object="" client_id="" years="1"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --name)      name="${2:-}";      shift 2 ;;
+    --host)      host="${2:-}";      shift 2 ;;
+    --vault)     vault="${2:-}";     shift 2 ;;
+    --object)    object="${2:-}";    shift 2 ;;
+    --client-id) client_id="${2:-}"; shift 2 ;;
+    --years)     years="${2:-}";     shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+hosting::need_flag name "$name"
+hosting::need_flag host "$host"
+hosting::need_flag vault "$vault"
+hosting::need_flag object "$object"
+hosting::safe_name name "$name"
+hosting::safe_host host "$host"
+hosting::safe_name vault "$vault"
+hosting::safe_name object "$object"
+[[ "$years" =~ ^[1-9]$ ]] || hosting::die "years '${years}' is not a small whole number (1–9)"
+if [ -n "$client_id" ] && ! [[ "$client_id" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+  hosting::die "client-id '${client_id}' is not an Entra application (client) id — refusing to interpolate it into a command"
+fi
+
+redirect="https://${host}/signin-microsoft"
+display="${name} Portal (${host})"
+register_by_hand="APP_ID=\$(az ad app create --display-name \"${display}\" --sign-in-audience AzureADMultipleOrgs --web-redirect-uris \"${redirect}\" --query appId -o tsv); az ad sp create --id \"\$APP_ID\" --output none; az ad app credential reset --id \"\$APP_ID\" --display-name ${name} --years ${years} --query password -o tsv > <file> 2>/dev/null; az keyvault secret set --vault-name ${vault} --name ${object} --file <file> --output none; rm <file>; then set signIn.microsoftClientId: \"\$APP_ID\" on the record"
+mint_by_hand="az ad app credential reset --id ${client_id:-<client id>} --append --display-name ${name} --years ${years} --query password -o tsv > <file> 2>/dev/null; az keyvault secret set --vault-name ${vault} --name ${object} --file <file> --output none; rm <file>"
+
+kv_exists() { az keyvault secret show --vault-name "$vault" --name "$1" --query id -o tsv >/dev/null 2>&1; }
+
+# verify_app — with a client id: the redirect must be on the app. Unreadable → said, not failed.
+verify_app() {
+  [ -n "$client_id" ] || { hosting::say signin_app_verify skipped; return 0; }
+  hosting::step "Verify the sign-in app's redirect URI"
+  local uris
+  if ! uris="$(az ad app show --id "$client_id" --query 'web.redirectUris' -o tsv 2>/dev/null)"; then
+    hosting::log "could not read app ${client_id} — the operator identity lacks Graph Application.Read.All. Verify by hand: az ad app show --id ${client_id} --query web.redirectUris (must list ${redirect})"
+    hosting::say signin_app_verify unknown
+    return 0
+  fi
+  if printf '%s\n' "$uris" | grep -qxF "$redirect"; then
+    hosting::log "verified  app ${client_id} redirects to ${redirect}"
+    hosting::say signin_app_verify true
+    return 0
+  fi
+  hosting::die "app ${client_id} does not list ${redirect} among its web redirect URIs (it lists: $(printf '%s' "$uris" | tr '\n' ' ')) — every Microsoft sign-in would fail with AADSTS50011. Add it by hand: az ad app update --id ${client_id} --web-redirect-uris ${redirect} <existing URIs…>, then re-request."
+}
+
+if kv_exists "$object"; then
+  hosting::log "keep    ${object} (exists — never minted over, never rotated)"
+  hosting::say signin_secret kept
+  if hosting::dry; then
+    hosting::log "(dry run) would verify app ${client_id:-<none on the record>} lists ${redirect}"
+    hosting::say signin_app_verify dry-run
+    exit 0
+  fi
+  verify_app
+  exit 0
+fi
+
+# ── absent ────────────────────────────────────────────────────────────────────────────────────
+if [ -z "$client_id" ]; then
+  hosting::die "${object} is absent from vault ${vault} and the record names no signIn.microsoftClientId — the sign-in app does not exist yet. Registering it is a hand step: it needs Graph Application.ReadWrite.OwnedBy (the operator identity holds no Graph right) AND the new client id written back to the git-owned record. Run: ${register_by_hand}; then re-request the action (this step then keeps the object and verifies the app)."
+fi
+if hosting::dry; then
+  hosting::log "(dry run) ${object} is absent — a real run ADDS a credential to app ${client_id} (--append: nothing existing is rotated), stores it under ${object} through --file and verifies ${redirect}"
+  hosting::say signin_secret would-create
+  hosting::say signin_app_verify dry-run
+  exit 0
+fi
+
+hosting::step "Add a client secret to the sign-in app"
+umask 077
+secret_file="$(mktemp)"
+trap 'rm -f "$secret_file"' EXIT
+# 🚨 stderr DISCARDED: az prints the minted secret there too. --append: an existing credential
+# stays valid — this adds a secret for THIS vault, it never rotates the app.
+if ! az ad app credential reset --id "$client_id" --append --display-name "$name" --years "$years" \
+       --query password -o tsv > "$secret_file" 2>/dev/null; then
+  rm -f "$secret_file"
+  hosting::die "could not add a credential to app ${client_id} — the operator identity needs Graph Application.ReadWrite.OwnedBy on an app it OWNS (or Application.ReadWrite.All); it holds neither today. Nothing was changed. Run by hand: ${mint_by_hand}; then re-request."
+fi
+[ -s "$secret_file" ] || { rm -f "$secret_file"; hosting::die "az ad app credential reset returned no password for app ${client_id} — nothing was stored"; }
+# A trailing newline from -o tsv would become part of the secret the portal presents.
+printf '%s' "$(cat "$secret_file")" > "$secret_file"
+hosting::log "added     a credential '${name}' to app ${client_id} (valid ${years} year(s); the secret is not shown, here or anywhere)"
+
+hosting::step "Store the client secret in Key Vault"
+az keyvault secret set --vault-name "$vault" --name "$object" --file "$secret_file" --output none \
+  || { rm -f "$secret_file"; hosting::die "the credential was added to app ${client_id} but could not be stored under ${object} in vault ${vault} — remove it (az ad app credential delete --id ${client_id} --key-id <the '${name}' credential>) or store it by hand, then re-request."; }
+rm -f "$secret_file"
+kv_exists "$object" || hosting::die "${object} was written to vault ${vault} but cannot be read back — refusing to report a secret the CSI driver will not find"
+hosting::log "stored    ${object} in vault ${vault} (read back by id)"
+expires="$(az ad app credential list --id "$client_id" --query "[?displayName=='${name}'].endDateTime | [0]" -o tsv 2>/dev/null || true)"
+hosting::say signin_secret created
+hosting::say signin_secret_expires "${expires:-unknown}"
+verify_app

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -325,6 +325,97 @@ case "$_ps_out" in *"pull_secret_verify=true"*) bad "a dry-run pull-secret never
 unset _ps_out _ps_rc _ps_dir _ps_log _ns_line _sec_line
 
 echo
+echo "── hosting-signin-app: the client secret is kept, added never rotated, never shown ──"
+# MeshWeaver.Plugins#1719 — runbook step 1 registered the Entra app and minted its secret by hand.
+# The stub answers Graph and the vault from a state and — like the real az — prints a minted
+# secret on STDERR too, so the no-leak arm proves the script discards it. 🚨 The stub is FIRST on
+# PATH for every case: a laptop with a real, logged-in az would otherwise read a real vault.
+SA_STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs/signin-app" && pwd)"
+sa() {  # sa [env…] -- <args…>
+  local envs=()
+  while [ "$1" != "--" ]; do envs+=("$1"); shift; done; shift
+  _sa_state="$(mktemp -d)"
+  _sa_out="$(env "${envs[@]}" PATH="$SA_STUBS:$PATH" HOSTING_SA_STATE="$_sa_state" hosting-signin-app "$@" 2>&1)"; _sa_rc=$?
+  _sa_log="$(cat "$_sa_state/az.log" 2>/dev/null || true)"
+}
+SA_ARGS=(--name acme --host acme.meshweaver.cloud --vault Systemorph --object acme-Authentication-Microsoft-ClientSecret)
+SA_ID=66d36350-397d-420f-97b2-ae173fc97d05
+
+# Present + app readable + redirect on it → kept, verified.
+sa HOSTING_SA_EXISTING=acme-Authentication-Microsoft-ClientSecret -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -eq 0 ] && ok "a PRESENT client secret is kept and the app verified" || bad "present + verified" "exited ${_sa_rc}: ${_sa_out}"
+case "$_sa_log" in *"credential reset"*|*"secret set"*) bad "…nothing minted, nothing written" "az saw: ${_sa_log}" ;; *) ok "…nothing minted, nothing written" ;; esac
+case "$_sa_out" in *"::hosting:: signin_secret=kept"*"::hosting:: signin_app_verify=true"*) ok "…reported kept + verify=true" ;; *) bad "kept facts" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+
+# Present, app unreadable (no Graph right) → kept, verify UNKNOWN, not red, hand command named.
+sa HOSTING_SA_EXISTING=acme-Authentication-Microsoft-ClientSecret HOSTING_SA_GRAPH_DENIED=1 -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -eq 0 ] && ok "an identity without Graph read keeps the secret and does NOT fail the provision" || bad "no Graph read is not red" "exited ${_sa_rc}: ${_sa_out}"
+case "$_sa_out" in *"::hosting:: signin_app_verify=unknown"*"az ad app show --id ${SA_ID} --query web.redirectUris"*|*"az ad app show --id ${SA_ID} --query web.redirectUris"*"::hosting:: signin_app_verify=unknown"*) ok "…reports verify=unknown and the hand command" ;; *) bad "unknown verify" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+
+# Present, app readable, redirect MISSING → RED naming az ad app update.
+sa HOSTING_SA_EXISTING=acme-Authentication-Microsoft-ClientSecret HOSTING_SA_REDIRECTS="https://other.example.test/signin-microsoft" -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -ne 0 ] && ok "a readable app WITHOUT the redirect URI is a failed step (AADSTS50011 otherwise)" || bad "missing redirect fails" "exited 0: ${_sa_out}"
+case "$_sa_out" in *"az ad app update --id ${SA_ID} --web-redirect-uris https://acme.meshweaver.cloud/signin-microsoft"*) ok "…naming the exact hand command" ;; *) bad "names az ad app update" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+
+# Present, no client id on the record → kept, verify skipped.
+sa HOSTING_SA_EXISTING=acme-Authentication-Microsoft-ClientSecret -- "${SA_ARGS[@]}"
+[ "$_sa_rc" -eq 0 ] && ok "present with no client id on the record is kept (verify skipped)" || bad "present no id" "exited ${_sa_rc}: ${_sa_out}"
+case "$_sa_out" in *"signin_app_verify=skipped"*) ok "…and says so" ;; *) bad "skipped fact" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+
+# Absent + client id → a credential is ADDED (--append), stored through --file, never printed.
+sa -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -eq 0 ] && ok "an ABSENT secret with a named app gets a credential added" || bad "absent + id mints" "exited ${_sa_rc}: ${_sa_out}"
+case "$_sa_log" in *"ad app credential reset --id ${SA_ID} --append --display-name acme --years 1"*) ok "…with --append: nothing existing is rotated" ;; *) bad "append" "az saw: ${_sa_log}" ;; esac
+[ "$(cat "$_sa_state/set.acme-Authentication-Microsoft-ClientSecret" 2>/dev/null)" = "fake-client-secret-NEVER-PRINTED" ] && ok "…the secret is stored under the object, byte-for-byte, no trailing newline" || bad "secret stored" "vault got: '$(cat "$_sa_state/set.acme-Authentication-Microsoft-ClientSecret" 2>/dev/null)'"
+case "$_sa_out" in *NEVER-PRINTED*) bad "signin-app never prints the secret (az's stderr echo is discarded)" "it did: ${_sa_out}" ;; *) ok "signin-app never prints the secret (az's stderr echo is discarded)" ;; esac
+case "$_sa_log" in *NEVER-PRINTED*) bad "…and never puts it on an az command line" "az saw: ${_sa_log}" ;; *) ok "…and never puts it on an az command line" ;; esac
+case "$_sa_out" in *"::hosting:: signin_secret=created"*"::hosting:: signin_secret_expires=2027-09-12T00:00:00Z"*"::hosting:: signin_app_verify=true"*) ok "…reported created + expiry + verified" ;; *) bad "created facts" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+
+# Absent + client id, Graph denied → RED with the exact hand commands; nothing written.
+sa HOSTING_SA_GRAPH_DENIED=1 -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -ne 0 ] && ok "without Application.ReadWrite.OwnedBy the mint is a RED step" || bad "denied mint is red" "exited 0: ${_sa_out}"
+case "$_sa_out" in *"Application.ReadWrite.OwnedBy"*"az ad app credential reset --id ${SA_ID} --append --display-name acme --years 1 --query password -o tsv > <file> 2>/dev/null; az keyvault secret set --vault-name Systemorph --name acme-Authentication-Microsoft-ClientSecret --file <file>"*) ok "…naming the right and the exact hand commands" ;; *) bad "denied message" "said: ${_sa_out}" ;; esac
+[ ! -f "$_sa_state/set.acme-Authentication-Microsoft-ClientSecret" ] && ok "…and writes nothing" || bad "denied writes nothing" "it wrote"
+rm -rf "$_sa_state"
+
+# Absent + NO client id → RED: registering the app is the hand step, with the runbook's commands.
+sa -- "${SA_ARGS[@]}"
+[ "$_sa_rc" -ne 0 ] && ok "absent secret and no app on the record is a RED step — registering the app is not automated" || bad "no app is red" "exited 0: ${_sa_out}"
+case "$_sa_out" in *"az ad app create --display-name \"acme Portal (acme.meshweaver.cloud)\" --sign-in-audience AzureADMultipleOrgs --web-redirect-uris \"https://acme.meshweaver.cloud/signin-microsoft\""*"set signIn.microsoftClientId"*) ok "…naming the runbook's exact commands and the record field to set" ;; *) bad "register-by-hand message" "said: ${_sa_out}" ;; esac
+case "$_sa_log" in *"ad app"*) bad "…without calling Graph" "az saw: ${_sa_log}" ;; *) ok "…without calling Graph" ;; esac
+rm -rf "$_sa_state"
+
+# Vault refuses the write after the mint → RED, names the credential to remove, no secret printed.
+sa HOSTING_SA_SET_FAIL=1 -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -ne 0 ] && ok "a vault that refuses the write fails the step" || bad "set fail" "exited 0"
+case "$_sa_out" in *NEVER-PRINTED*) bad "…without printing the secret on the failure path" "it did: ${_sa_out}" ;; *) ok "…without printing the secret on the failure path" ;; esac
+rm -rf "$_sa_state"
+
+refuses_hard "signin-app needs --host"                 "missing required flag --host"   hosting-signin-app --name a --vault V --object o
+refuses_hard "signin-app needs --object"               "missing required flag --object" hosting-signin-app --name a --host a.test --vault V
+refuses_hard "signin-app refuses a host with a space"  "is not a hostname"              hosting-signin-app --name a --host 'a.test x' --vault V --object o
+refuses_hard "signin-app refuses a client id that is not a GUID" "is not an Entra application"  hosting-signin-app --name a --host a.test --vault V --object o --client-id 'x;id'
+refuses_hard "signin-app refuses a name with a metacharacter" "is not a plain name"     hosting-signin-app --name 'a`id`' --host a.test --vault V --object o
+refuses_hard "signin-app rejects unknown flags"        "unknown argument"               hosting-signin-app --name a --host a.test --vault V --object o --nope 1
+
+# Dry runs: present → kept + verify dry-run; absent + id → would-create; neither Graph nor vault written.
+sa HOSTING_DRY_RUN=true HOSTING_SA_EXISTING=acme-Authentication-Microsoft-ClientSecret -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -eq 0 ] && ok "a dry run over a present secret succeeds" || bad "dry present" "exited ${_sa_rc}"
+case "$_sa_out" in *"signin_secret=kept"*"signin_app_verify=dry-run"*) ok "…reports kept + verify=dry-run" ;; *) bad "dry present facts" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+sa HOSTING_DRY_RUN=true -- "${SA_ARGS[@]}" --client-id $SA_ID
+[ "$_sa_rc" -eq 0 ] && ok "a dry run over an absent secret succeeds" || bad "dry absent" "exited ${_sa_rc}: ${_sa_out}"
+case "$_sa_log" in *"ad app"*|*"secret set"*) bad "…and touches neither Graph nor the vault" "az saw: ${_sa_log}" ;; *) ok "…and touches neither Graph nor the vault" ;; esac
+case "$_sa_out" in *"signin_secret=would-create"*) ok "…reporting would-create" ;; *) bad "would-create" "said: ${_sa_out}" ;; esac
+rm -rf "$_sa_state"
+unset _sa_out _sa_rc _sa_log _sa_state
+
+echo
 echo "── the ::hosting:: contract the mesh parses ──────────────────────"
 emits "dry-run backup announces the object" "::hosting:: object=arch-1" \
   env HOSTING_DRY_RUN=true hosting-backup --database d --server s --store-uri https://x/y/z --object arch-1

--- a/deploy/aks/operator/test/stubs/signin-app/az
+++ b/deploy/aks/operator/test/stubs/signin-app/az
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# A stand-in `az` for hosting-signin-app's behaviour tests (MeshWeaver.Plugins#1719). Records every
+# invocation VERBATIM (argv is how the test proves the minted secret never travels on a command
+# line) and answers Graph and the vault from a small state:
+#
+#   HOSTING_SA_STATE          directory: az.log (every argv), set.<name> (what a `set --file` wrote)
+#   HOSTING_SA_EXISTING       space-separated vault objects `keyvault secret show` answers with an id
+#   HOSTING_SA_REDIRECTS      newline-separated redirect URIs `ad app show` answers
+#   HOSTING_SA_GRAPH_DENIED=1 every `ad app …` call fails as an identity with no Graph right does
+#   HOSTING_SA_SET_FAIL=1     every `keyvault secret set` refuses
+#
+# 🚨 `ad app credential reset` prints the minted secret on STDERR as well as stdout — exactly as
+# the real az does (runbook step 1 measured it) — so the test can prove the script discards it.
+set -uo pipefail
+state="${HOSTING_SA_STATE:?the az stub needs HOSTING_SA_STATE}"
+printf 'az %s\n' "$*" >> "$state/az.log"
+SECRET="fake-client-secret-NEVER-PRINTED"
+case "${1:-} ${2:-} ${3:-}" in
+  "ad app show")
+    [ "${HOSTING_SA_GRAPH_DENIED:-0}" = "1" ] && { echo "ERROR: Insufficient privileges to complete the operation." >&2; exit 1; }
+    printf '%s\n' "${HOSTING_SA_REDIRECTS-https://acme.meshweaver.cloud/signin-microsoft}"; exit 0 ;;
+  "ad app credential")
+    [ "${HOSTING_SA_GRAPH_DENIED:-0}" = "1" ] && { echo "ERROR: Insufficient privileges to complete the operation." >&2; exit 1; }
+    case "${4:-}" in
+      reset) for a in "$@"; do [ "$a" = "--append" ] && appended=1; done
+             [ "${appended:-0}" = "1" ] || { echo "az stub: credential reset WITHOUT --append would revoke the app's other credentials — refusing" >&2; exit 1; }
+             echo "WARNING: The output includes credentials that you must protect. $SECRET" >&2
+             printf '%s\n' "$SECRET"; exit 0 ;;
+      list)  printf '2027-09-12T00:00:00Z\n'; exit 0 ;;
+    esac ;;
+  "keyvault secret show")
+    name=""; while [ $# -gt 0 ]; do case "$1" in --name) name="${2:-}"; shift 2 ;; *) shift ;; esac; done
+    for e in ${HOSTING_SA_EXISTING:-}; do [ "$e" = "$name" ] && { printf 'https://vault.test/secrets/%s/0\n' "$name"; exit 0; }; done
+    [ -f "$state/set.$name" ] && { printf 'https://vault.test/secrets/%s/1\n' "$name"; exit 0; }
+    echo "ERROR: (SecretNotFound) A secret with (name/id) ${name} was not found in this key vault." >&2; exit 3 ;;
+  "keyvault secret set")
+    [ "${HOSTING_SA_SET_FAIL:-0}" = "1" ] && { echo "ERROR: (Forbidden) secrets set permission" >&2; exit 1; }
+    name="" file=""; while [ $# -gt 0 ]; do case "$1" in --name) name="${2:-}"; shift 2 ;; --file) file="${2:-}"; shift 2 ;; *) shift ;; esac; done
+    [ -n "$file" ] || { echo "az stub: hosting-signin-app must write through --file, never --value" >&2; exit 1; }
+    [ -f "$file" ] || { echo "az stub: --file ${file} does not exist" >&2; exit 1; }
+    cp "$file" "$state/set.$name"; exit 0 ;;
+esac
+echo "az stub: unexpected invocation: $*" >&2
+exit 1


### PR DESCRIPTION
Operator half of MeshWeaver.Plugins#1719 (the plan half — an "Ensure sign-in app secret" step after the vault step — is the paired Plugins PR; `Pairs-with: none — this PR removes no public surface`).

## The hand step it replaces (partly — read on)

Memex `docs/new-deployment.md` step 1, *"The sign-in app → `<prefix>Authentication-Microsoft-ClientSecret`"*:

> `APP_ID=$(az ad app create --display-name "<Name> Portal (<host>)" --sign-in-audience AzureADMultipleOrgs --web-redirect-uris "https://<host>/signin-microsoft" …)` · `az ad sp create` · `az ad app credential reset … --query password -o tsv > /tmp/<id>-secret 2>/dev/null` · `az keyvault secret set … --file`

## What is automated, what is verification-only, and why

New command `hosting-signin-app --name <id> --host <host> --vault … --object … [--client-id <app id>] [--years 1]`:

| State | What the step does | Right it needs |
|---|---|---|
| vault object **present** | **kept** (never minted over, never rotated) and, with `--client-id`, the app is **verified** to list `https://<host>/signin-microsoft` — a readable app missing it is RED naming `az ad app update`; an identity that cannot read the app reports `signin_app_verify=unknown` with the hand command and does **not** fail the provision | Graph `Application.Read.All` for the verify — **not granted** to `hosting-operator` today, so on the fleet this reports `unknown` until it is |
| **absent**, record names the app | a credential is **added** (`az ad app credential reset --append` — existing credentials stay valid; this adds, it never rotates), az's stderr echo of the secret discarded, the value stored through a mode-600 `--file`, read back, `signin_secret=created` + expiry | Graph `Application.ReadWrite.OwnedBy` on an app the identity **owns** (or `Application.ReadWrite.All`) — **not granted**; without it the step is RED with the exact hand commands |
| **absent**, no `signIn.microsoftClientId` | **RED, deliberately**: registering the app needs the Graph right AND writing the new client id back to the git-owned record — the message carries the runbook's exact commands and the record field to set | — |

So today, on the fleet, the step is the **verification half** for the two absent cases (RED with the manual command) and a no-op keep for the present case. Granting `hosting-operator` `Application.ReadWrite.OwnedBy` + making it an owner of each instance's app turns the middle row on with no code change.

## Gates run

```
$ bash deploy/aks/operator/test/run-tests.sh
325 passed, 0 failed          (291 on main; +34 new hosting-signin-app cases — the stub prints the minted secret on stderr like the real az, proving it is discarded)
$ shellcheck -S warning deploy/aks/operator/bin/hosting-* deploy/aks/operator/test/stubs/signin-app/az
(clean)
```

`hosting-operator.yml`: plan list, tracked-file floor 23 → 24 (will need `main` merged and the floor re-counted once the sibling PRs land), stub list.

## Ships how

Hop (C): `hosting-operator:<sha>` on merge to `main`; reaches a Provision when `operator.image` on `Deployments/memex` moves. Merging is not shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
