### PR TITLE
ci(probe): assert the public page on the PUBLIC host, and the app host's 301

### DIFF
--- a/.github/workflows/prod-synthetic-probe.yml
+++ b/.github/workflows/prod-synthetic-probe.yml
@@ -5,7 +5,8 @@
 #   content hop (collection-config GetDataRequest to the owning node's hub) — the transport that
 #   actually wedges in the incidents we have had (#1729, the 2026-08-31 store outage). /api/og/…
 #   is the documented NEGATIVE control (it proves gate+resolver, crosses nothing) and is
-#   deliberately NOT used here. The Store page adds a Blazor-shell 200 as a secondary signal.
+#   deliberately NOT used here. A public page adds a Blazor-shell 200 as a secondary signal — on
+#   the PUBLIC host, because that is where a public page is served (assertion 4).
 #
 # 🚨 WHAT THIS FILE MAY NOT CONTAIN, and why it used to (#3578).
 #   Until 2026-09-08 the matrix paired each portal with a hard-coded asset of an INSTALLED PACKAGE:
@@ -22,7 +23,7 @@
 #   a course. It names HOSTS. Everything it asserts is either shipped by the platform image or read
 #   from the deployment at probe time.
 #
-# THE THREE ASSERTIONS, and what each is honestly worth:
+# THE FOUR ASSERTIONS, and what each is honestly worth:
 #
 #   1. PLATFORM FLOOR — /api/content/Doc/Architecture/content/platform-overview.svg.
 #      Present on every deployment BY CONSTRUCTION: the bytes are an EmbeddedResource in
@@ -54,6 +55,33 @@
 #      over an empty list exits 0 having asserted nothing, which is the "green on no evidence" shape
 #      AGENTS.md forbids; the count is asserted BEFORE the loop and printed either way, so a zero is
 #      readable rather than silent.
+#
+#   4. THE TWO-HOST SPLIT — a public page on the PUBLIC host, and the app host's 301 to it.
+#      🚨 A deployment may serve two hosts from one process (core #4056, Doc/Architecture/
+#      PublicWebPresence): a PUBLIC host that is the canonical address of everything a signed-out
+#      visitor may read, and an APP host carrying sign-in, the APIs, MCP and the registry. On the
+#      app host a stranger's HTML GET for a public page answers 301 to the same path on the public
+#      host, and robots.txt says `Disallow: /` — both BY DESIGN, both shipped in the platform image
+#      (PublicSite.UsePublicHostRedirect, SeoEndpoints.MapSeo).
+#
+#      So a public-page assertion belongs on the PUBLIC host, and the app host is asserted for the
+#      REDIRECT — status 301 AND the exact target. This probe asserted `/Store` == 200 on the app
+#      host and went red the day memex.meshweaver.cloud gained a public host: a true statement about
+#      a healthy portal, the #3578 shape again. The fix is NOT `curl -L`: following the redirect
+#      makes a real outage and the intended 301 look identical, and drops the only evidence that the
+#      canonicalisation still works.
+#
+#      🚨 WHICH host is public is a per-DEPLOYMENT decision this repo cannot see — the same reason
+#      a package name may not appear here. It is therefore READ FROM THE DEPLOYMENT at probe time,
+#      from the `Sitemap:` line of its own robots.txt, which is built on PublicSite.CanonicalBaseUrl
+#      and so names the public host on either host (measured 2026-09-12: memex.meshweaver.cloud
+#      declares www.meshweaver.cloud; memex.systemorph.com declares itself). A single-host portal
+#      declares ITSELF and is then asserted exactly as before — 200, no redirect — with no entry
+#      here to keep in step. Reading the value is asserted before it is used: an unreadable robots
+#      or one with no Sitemap: line is a FAILURE, never a skipped assertion.
+#
+#      What this buys is self-consistency, and that is the honest claim: the portal names its own
+#      public host and is then held to it, exactly as assertion 3 holds it to its own sitemap.
 #
 # HOW it fails (no skip-trapdoors, per AGENTS "a gate never tests its own inputs"):
 #   - no secrets, no `if:` on configuration, no credential — the probe always runs, on every portal;
@@ -89,7 +117,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # HOSTS ONLY. Anything content-shaped here is the #3578 defect coming back.
+        # HOSTS ONLY, and only APP hosts — the address the fleet is reached at. Anything
+        # content-shaped here is the #3578 defect coming back, and a PUBLIC host pinned here would
+        # be the same shape (a per-deployment decision frozen in the platform repo): each portal
+        # names its own, and the probe reads it. See assertion 4.
         portal:
           - memex.meshweaver.cloud
           - memex.systemorph.com
@@ -154,6 +185,55 @@ jobs:
           fi
           echo "content route OK on ${PORTAL} (platform asset 200, impossible path 404)"
 
+      - name: Public host — read the deployment's own declaration, then the app/public split
+        env:
+          PORTAL: ${{ matrix.portal }}
+        run: |
+          set -euo pipefail
+          url="https://${PORTAL}/robots.txt"
+          body=$(mktemp)
+          code=$(curl -sS -o "$body" -w '%{http_code}' --max-time 20 "$url") || code=000
+          if [ "$code" != "200" ]; then
+            echo "::error::GET $url -> HTTP $code. robots.txt is anonymous, unconditional and served" \
+                 "from the platform image on every portal, and it is where this deployment names its" \
+                 "own public host. It could not be read, so the host split was NOT checked — that is" \
+                 "a failure, not an absence of findings."
+            exit 1
+          fi
+
+          # `Sitemap: {CanonicalBaseUrl}/sitemap.xml` — SeoEndpoints.MapSeo builds it from
+          # PublicSite.CanonicalBaseUrl, which IS the public host when one is configured and the
+          # request's own host when none is. So this one line answers "is this portal two-host, and
+          # if so which name is public" without this repo knowing either.
+          public=$(sed -nE 's|^[[:space:]]*[Ss]itemap:[[:space:]]*https://([^/[:space:]]+)/.*$|\1|p' "$body" | head -1)
+          if [ -z "$public" ]; then
+            echo "::error::${PORTAL} served robots.txt with no parseable 'Sitemap: https://…/sitemap.xml'" \
+                 "line, so this deployment did not name a public host and nothing downstream may assume" \
+                 "one. The line ships in the platform image; its absence is a portal defect, not a" \
+                 "configuration choice. Body was:" "$(tr '\n' ' ' < "$body")"
+            exit 1
+          fi
+          echo "PUBLIC_HOST=$public" >> "$GITHUB_ENV"
+          echo "public host declared by ${PORTAL}: $public" | tee -a "$GITHUB_STEP_SUMMARY"
+
+          if [ "$public" = "${PORTAL}" ]; then
+            echo "single-host deployment — ${PORTAL} is its own public host; no redirect is expected"
+            exit 0
+          fi
+
+          # Two hosts ⇒ the app host is the same site under a second name, and MUST be closed to the
+          # index or it competes with the public host for its own ranking. This assertion is about
+          # the APP host and stays here; it is platform behaviour (IsAppOnlyHost ⇒ "Disallow: /"),
+          # not a per-deployment choice.
+          if ! grep -qiE '^[[:space:]]*Disallow:[[:space:]]*/[[:space:]]*$' "$body"; then
+            echo "::error::${PORTAL} declares $public as its public host but its own robots.txt does" \
+                 "NOT say 'Disallow: /'. The app host is the public site under a second address —" \
+                 "leaving it crawlable is the duplicate-content exposure the two-host split exists to" \
+                 "prevent. Body was:" "$(tr '\n' ' ' < "$body")"
+            exit 1
+          fi
+          echo "two-host deployment — ${PORTAL} is app-only (Disallow: /), $public is public"
+
       - name: Declared content — read the deployment's sitemap, then hold it to it
         env:
           PORTAL: ${{ matrix.portal }}
@@ -182,7 +262,11 @@ jobs:
             exit 1
           fi
 
-          # One <loc> per declared public root. `grep` exits 1 on no match, which under `set -e`
+          # One <loc> per declared public root, ABSOLUTE and canonical: BuildSitemap builds every
+          # entry on PublicSite.CanonicalBaseUrl, so on a two-host portal these already name the
+          # PUBLIC host and this step therefore already probes public pages where they are served.
+          # That is why it stayed green through the change that broke the Store assertion below.
+          # `grep` exits 1 on no match, which under `set -e`
           # would kill the step before the zero could be REPORTED — and "the step died" and "the
           # portal declares nothing" must not look the same. So the no-match case is made explicit
           # and falls through to the denominator assertion below, which says so by name.
@@ -243,15 +327,68 @@ jobs:
           fi
           echo "all $checked sampled root(s) of $count declared serve 200 on ${PORTAL}"
 
-      - name: Probe Store page
+      - name: Public page — served by the public host, and the app host sends strangers to it
         env:
           PORTAL: ${{ matrix.portal }}
         run: |
-          set -eu
-          url="https://${PORTAL}/Store"
-          code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$url") || code=000
-          echo "Store: $code  $url" | tee -a "$GITHUB_STEP_SUMMARY"
+          set -euo pipefail
+          # /Store is a PLATFORM route (the store root ships in the image), not a package, a space
+          # or a course — the one thing this file is allowed to name besides hosts.
+          path="/Store"
+          pub="https://${PUBLIC_HOST}${path}"
+
+          # (a) THE PUBLIC PAGE, ON THE PUBLIC HOST. A Blazor-shell 200 for a signed-out visitor at
+          #     the address search engines are pointed at. This is the assertion that used to sit on
+          #     the app host, where the page is deliberately not served.
+          code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$pub") || code=000
           if [ "$code" != "200" ]; then
-            echo "::error::Store page returned $code on ${PORTAL}"
+            # One retry, same reasoning as the declared-roots sample: a single slow first render of
+            # the Blazor shell is not a portal defect (measured once at 20 s while building this),
+            # but a page that fails twice is. The retry is only ever reached by a failure, so it can
+            # never mask a healthy-looking red.
+            sleep 3
+            code=$(curl -sS -o /dev/null -w '%{http_code}' --max-time 20 "$pub") || code=000
+          fi
+          echo "public page: $code  $pub" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$code" != "200" ]; then
+            echo "::error::the PUBLIC host does not serve $pub — HTTP $code. This is the canonical" \
+                 "address ${PORTAL} names in its own robots.txt and sitemap, so a signed-out visitor" \
+                 "and every crawler following those links get this answer."
             exit 1
           fi
+
+          if [ "${PUBLIC_HOST}" = "${PORTAL}" ]; then
+            echo "single-host deployment — public page asserted on ${PORTAL} itself; no redirect expected"
+            exit 0
+          fi
+
+          # (b) THE APP HOST, ASSERTED FOR THE REDIRECT ITSELF. 🚨 Deliberately WITHOUT `-L`: the
+          #     301 is the behaviour under test (core #4056), so it is asserted by status AND by
+          #     exact target. Following it would make an outage on the public host and a correct
+          #     canonicalisation produce the identical green, and would assert neither.
+          app="https://${PORTAL}${path}"
+          out=$(curl -sS -o /dev/null -w '%{http_code} %{redirect_url}' --max-time 20 "$app") || out="000 "
+          code=${out%% *}
+          location=${out#* }
+          echo "app host: $code -> ${location:-(no redirect)}  $app" | tee -a "$GITHUB_STEP_SUMMARY"
+          if [ "$code" = "200" ]; then
+            echo "::error::${PORTAL} SERVED the public page $app (HTTP 200) instead of redirecting to" \
+                 "$pub. It declares $PUBLIC_HOST as its public host, so the same page now answers on" \
+                 "two addresses — PublicSite.UsePublicHostRedirect is not running, or is registered" \
+                 "after the page endpoints. That is the duplicate-content split-ranking this redirect" \
+                 "exists to prevent."
+            exit 1
+          fi
+          if [ "$code" != "301" ]; then
+            echo "::error::${PORTAL} answered HTTP $code for $app; a stranger's HTML GET for a public" \
+                 "page must be a PERMANENT redirect (301) to $pub. A 302/307 is not the canonical" \
+                 "signal crawlers need; a 000, 4xx or 5xx is the app host failing to answer at all."
+            exit 1
+          fi
+          if [ "$location" != "$pub" ]; then
+            echo "::error::${PORTAL} redirected $app to '${location:-(empty)}' — expected exactly $pub." \
+                 "The redirect must preserve the path and target the host the portal itself declares;" \
+                 "a different target sends every stranger and every crawler somewhere else."
+            exit 1
+          fi
+          echo "public page OK: $pub serves 200 and $app 301s to it"

--- a/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PublicWebPresence.md
@@ -154,6 +154,23 @@ curl -s https://memex.meshweaver.cloud/robots.txt | grep -c 'Disallow: /$'
 curl -sI https://www.meshweaver.cloud/Doc | head -1
 ```
 
+### It is watched continuously, and the 301 is the assertion
+
+`prod-synthetic-probe.yml` runs those two app-host checks against every portal every 15 minutes: the
+public page must answer **200 on the public host**, and the app host must answer **301 to exactly
+that URL** — never `curl -L`, because following the redirect makes a real outage and a correct
+canonicalisation produce the identical green.
+
+🚨 **Which host is public is a per-deployment decision, so the probe READS it rather than pinning
+it**, from the `Sitemap:` line of the portal's own `robots.txt` — the one line that names
+`CanonicalBaseUrl` on either host. That makes the two-host split machine-readable at probe time and
+a single-host portal (which declares itself) assert 200 with no redirect, with nothing to keep in
+step in CI. Two consequences for anyone editing `SeoEndpoints.MapSeo`: that line is a contract, and
+so is `Disallow: /` on an app host that differs from the public one. Before this, the probe asserted
+`200` for a public page **on the app host** and went red for three runs on a healthy portal the day
+`Portal:PublicHost` was set — the shape of a check that is true about a broken portal and false
+about a working one.
+
 Search Console's URL inspection, "rendered HTML" view, is the acceptance test for the whole design:
 it must show the article text for a documentation page, a course cover, a course lesson and a plugin
 cover. Indexing before that view shows text only fills the report with "crawled, currently not


### PR DESCRIPTION
## The red

Core `main` has been red on the scheduled job **`Probe memex.meshweaver.cloud`** for three
consecutive runs today (e.g. [run 34700966572](https://github.com/Systemorph/MeshWeaver/actions/runs/34700966572/job/103572543546)):

```
##[error]Store page returned 301 on memex.meshweaver.cloud
```

## The site is right; the probe was stale

Measured 2026-09-12:

| Request | Answer |
|---|---|
| `https://memex.meshweaver.cloud/` | `301` → `https://www.meshweaver.cloud/` |
| `https://memex.meshweaver.cloud/Store` | `301` → `https://www.meshweaver.cloud/Store` |
| `https://www.meshweaver.cloud/AI` | `200`; `https://www.meshweaver.cloud/Store` serves the portal |

The instance is healthy — `/health` answers, and the content-route and sitemap assertions of this
same probe were green throughout.

**The 301 is the designed behaviour**, introduced by #4056 and configured in
`Systemorph/Memex → deployments/aks/memex-cloud/values.memexcloud.public.yaml`
(`Portal__PublicHost: "www.meshweaver.cloud"`, `Portal__LandingPath: "Home"`), whose own comment says:

> `www.meshweaver.cloud` is this portal's PUBLIC host: every canonical, og:url and sitemap entry is
> built on it, `memex.meshweaver.cloud` is the app host (noindex, robots `Disallow: /`, a stranger's
> HTML GET for a public page 301s to www)

`PublicSite.UsePublicHostRedirect` implements exactly that, and `SeoEndpoints.MapSeo` emits
`Disallow: /` on the app host. So the probe asserted `200` for a **public page on the APP host** —
a check that is false about a working portal and would be true about a broken one. That is the
#3578 shape this file's header already warns about, arriving from a different direction.

## The fix, by content

Not `curl -L`. Following the redirect would make a real outage on the public host and a correct
canonicalisation produce the identical green, and would assert neither. Each assertion moved to the
host it is actually about:

| Assertion | Before | After |
|---|---|---|
| Content route + negative control | app host | **unchanged** — app host (`/api/…` is not redirected) |
| Declared roots from `/sitemap.xml` | app host's sitemap, roots curled | **unchanged** — the `<loc>`s are built on `CanonicalBaseUrl`, so they *already* named the public host (which is why this step stayed green); now commented as such |
| Public page (`/Store`) == 200 | **app host** → red on the intended 301 | **PUBLIC host** |
| The 301 itself | not asserted | **app host**: status must be `301` *and* `Location` must equal `https://{public}/Store` exactly. A `200` there is its own red ("serving the public page under a second address") |
| `robots.txt` `Disallow: /` | not asserted | **app host**, only when it differs from the public host — platform behaviour (`IsAppOnlyHost`), not a per-deployment choice |

## Which host is public: read, not pinned

Item 3 of the ask — I chose **read at probe time over an explicit matrix entry**, and deliberately:

the public host is a **per-deployment** decision this repo cannot see (the same reason the header
forbids naming a package — #3578). Pinning `www.meshweaver.cloud` in the matrix would be that defect
in a new costume: wrong the moment a deployment changes it, and wrong by default for the next portal
added. So a new step reads it from the portal's own `robots.txt` `Sitemap:` line — built on
`PublicSite.CanonicalBaseUrl`, so it names the public host from *either* host — and asserts it
before use (unreadable robots, or no `Sitemap:` line, is a **failure**, never a skipped assertion).

A single-host portal declares **itself**, and is then asserted exactly as before: `200`, no redirect,
no entry here to keep in step. The matrix keeps naming app hosts only.

What this buys is **self-consistency**: the portal names its own public host and is held to it —
the same contract assertion 3 already has with its own sitemap.

## Local proof — the probe's own steps, against the live hosts

Each step's `run:` block extracted from the workflow and executed verbatim (matrix expanded,
`GITHUB_ENV`/`GITHUB_STEP_SUMMARY` emulated). `shellcheck -S warning`: clean on all four steps.

```
===== [memex.meshweaver.cloud] step: Content route — platform floor, with a negative control =====
round 1: platform=200  absent-control=404
round 2: platform=200  absent-control=404
round 3: platform=200  absent-control=404
content route OK on memex.meshweaver.cloud (platform asset 200, impossible path 404)

===== [memex.meshweaver.cloud] step: Public host — read the deployment's own declaration, then the app/public split =====
public host declared by memex.meshweaver.cloud: www.meshweaver.cloud
two-host deployment — memex.meshweaver.cloud is app-only (Disallow: /), www.meshweaver.cloud is public

===== [memex.meshweaver.cloud] step: Declared content — read the deployment's sitemap, then hold it to it =====
sitemap declares 1790 public root(s) on memex.meshweaver.cloud
declared[0]: 200  https://www.meshweaver.cloud/AI
declared[895]: 200  https://www.meshweaver.cloud/Doc/WhatsNew/2026-08-11-one-persons-view-of-a-page-can-no-longer-be-shown-to-another
declared[1789]: 200  https://www.meshweaver.cloud/Skill/README
all 3 sampled root(s) of 1790 declared serve 200 on memex.meshweaver.cloud

===== [memex.meshweaver.cloud] step: Public page — served by the public host, and the app host sends strangers to it =====
public page: 200  https://www.meshweaver.cloud/Store
app host: 301 -> https://www.meshweaver.cloud/Store  https://memex.meshweaver.cloud/Store
public page OK: https://www.meshweaver.cloud/Store serves 200 and https://memex.meshweaver.cloud/Store 301s to it

##### memex.meshweaver.cloud: overall exit 0 #####
```

The single-host portal, unchanged in behaviour and now explicitly so:

```
===== [memex.systemorph.com] step: Public host — read the deployment's own declaration, then the app/public split =====
public host declared by memex.systemorph.com: memex.systemorph.com
single-host deployment — memex.systemorph.com is its own public host; no redirect is expected

===== [memex.systemorph.com] step: Declared content — read the deployment's sitemap, then hold it to it =====
sitemap declares 1732 public root(s) on memex.systemorph.com
declared[0]: 200  https://memex.systemorph.com/AI
declared[866]: 200  https://memex.systemorph.com/Doc/WhatsNew/2026-08-12-moved-node-redirects
declared[1731]: 200  https://memex.systemorph.com/ThinkInStreams
all 3 sampled root(s) of 1732 declared serve 200 on memex.systemorph.com

===== [memex.systemorph.com] step: Public page — served by the public host, and the app host sends strangers to it =====
public page: 200  https://memex.systemorph.com/Store
single-host deployment — public page asserted on memex.systemorph.com itself; no redirect expected

##### memex.systemorph.com: overall exit 0 #####
```

### Falsified, not just observed green

A green run proves nothing about a check that cannot go red, so each new red was fired against the
live fleet by feeding the step a host pairing that violates it:

```
# the app host serves the public page instead of redirecting
::error::memex.systemorph.com SERVED the public page https://memex.systemorph.com/Store (HTTP 200)
instead of redirecting to https://www.meshweaver.cloud/Store. … PublicSite.UsePublicHostRedirect is
not running, or is registered after the page endpoints. …

# the redirect names a different target
::error::memex.meshweaver.cloud redirected https://memex.meshweaver.cloud/Store to
'https://www.meshweaver.cloud/Store' — expected exactly https://memex.systemorph.com/Store. …

# the public host does not serve the page (fired for real, on a 20 s timeout)
::error::the PUBLIC host does not serve https://www.meshweaver.cloud/Store — HTTP 000. …
```

That last one fired on a genuine transient timeout while this was being built, which is why the
public-page check got the **single retry** the declared-roots sample already has — reached only by a
failure, so it can never mask a red.

## Also

`Doc/Architecture/PublicWebPresence` gains "It is watched continuously, and the 301 is the
assertion" under *Verifying a deployment*: the manual curls there are now run every 15 minutes, and
two things `SeoEndpoints.MapSeo` emits are contracts a machine reads — the `Sitemap:` line naming
`CanonicalBaseUrl`, and `Disallow: /` on an app host.

No public surface changes. `Pairs-with: none — CI workflow and documentation only.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
