### PR TITLE
ci(module-pack): give the self-hosted suite legs a headless browser (unblocks Plugins#1736)

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -300,6 +300,20 @@ name: node-repo module pack
 #     the ONE that needs Docker (the `docker cp` fallback, taken only when the
 #     `platform-refs-<digest>` cache `prepare` filled minutes earlier has been evicted) both fail
 #     RED naming what is missing; neither skips.
+#   * 🚨 AND IT SHIPS NO BROWSER — the fact that cost six tests, 2026-09-12. `ubuntu-latest` carries
+#     Google Chrome, so the pixel-faithful export suites have always found one without anyone
+#     arranging it; the ARC image has nothing at any of the five paths they read
+#     (`/usr/bin/{chromium,chromium-browser,google-chrome,google-chrome-stable,microsoft-edge}`,
+#     after `CHROME_BIN` and `PUPPETEER_EXECUTABLE_PATH`). The first leg moved to `aks-silos-dind`
+#     turned 6 of 201 `MeshWeaver.Markdown.Export` tests red with "Pixel-faithful export needs a
+#     headless Chromium on the server and none is configured" (MeshWeaver.Plugins#1736, run
+#     34700003866) — and `apt-get install chromium` does NOT fix it: noble has no such package, and
+#     its `chromium-browser` is a snap TRANSITIONAL (`Pre-Depends: snapd`) that cannot work in a
+#     pod. So `pack` and `tests` each install google-chrome-stable and export `CHROME_BIN` before
+#     their suite whenever `runner` is anything but `ubuntu-latest`, LAUNCH it to prove it, and go
+#     RED by name when they cannot. Measured cost on a live `aks-silos-dind` runner: see the step.
+#     INTERIM — Systemorph/Memex#323 bakes the browser into our own runner image and deletes both
+#     steps; until then the step's PRESENT branch is already the shape it degrades to.
 #
 # The runner POD is not the node. The scale set requests 500m / 4Gi and LIMITS each runner to
 # 2 vCPU / 6 GiB (the node behind it is 16 vCPU / 62 GiB, shared with the portals). A suite that
@@ -2530,6 +2544,96 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      # ─────── A HEADLESS BROWSER — SELF-HOSTED RUNNERS ONLY (interim: Memex#323) ───────
+      # 🚨 INTERIM, and it has a named end: Systemorph/Memex#323 ("bake the toolchain into our own
+      # runner image") puts a browser in the image the ARC scale sets run, and DELETES this step
+      # whole. Until then every self-hosted leg pays the install.
+      #
+      # `ubuntu-latest` ships Google Chrome and is excluded here, so the default caller's behaviour
+      # is byte-identical to before this step existed. The stock
+      # `ghcr.io/actions/actions-runner:2.337.0` image (Ubuntu 24.04, uid 1001, passwordless sudo,
+      # EMPTY apt lists) carries NOTHING at any of the five paths the pixel-faithful export suites
+      # read — so the first leg moved to `aks-silos-dind` turned 6 of 201
+      # `MeshWeaver.Markdown.Export` tests red with "Pixel-faithful export needs a headless
+      # Chromium on the server and none is configured" (MeshWeaver.Plugins#1736, run 34700003866).
+      #
+      # 🚨 INLINE, not a script in `.github/scripts/`, and that is not a style choice. Both jobs
+      # check core out at `inputs.platform-ref` — the newest SEALED set, hours behind this lane,
+      # which arrives from `@main` (MeshWeaver#3842, and the `select` job's own note about "a
+      # workflow newer than the checkout"). A new file would be absent from that checkout and this
+      # step would die `exit 127` until a set seals. `github.job_workflow_sha` cannot rescue it
+      # either: measured EMPTY inside a reusable called from another repo (Plugins#1566). The block
+      # is therefore duplicated in `pack` and `tests` — BYTE-IDENTICAL, and
+      # ModuleSuiteLaneGuard.TheBrowserStep_IsOneImplementation refuses a run where it is not.
+      #
+      # google-chrome-stable, NOT `apt-get install chromium`: measured inside the runner image,
+      # noble has no `chromium` package at all and `chromium-browser` is `2:1snap1-0ubuntu2`,
+      # `Pre-Depends: snapd`, "Transitional package - chromium-browser -> chromium snap" — in a pod
+      # that gets you a snap stub and no browser. The .deb straight from dl.google.com is one HTTPS
+      # fetch from the same host that would serve the repository key (the image ships no `gnupg`).
+      #
+      # WHAT IT COSTS, measured on live runners on 2026-09-12 (Memex runner-proof dispatches, both
+      # labels, Ubuntu 24.04 pods, cold — an ARC runner is EPHEMERAL, so every leg pays it):
+      #     aks-silos-dind (6 vCPU/20 GiB pod): apt-get update 4.7s + download 2.2s + install 46.2s
+      #     aks-silos      (4 vCPU/12 GiB pod): apt-get update 4.7s + download 2.7s + install 51.0s
+      # ⇒ ~53-58 s per leg, nearly all of it dpkg unpacking Chrome and its ~25 dependencies. That
+      # is the price of the interim, and it is the number Memex#323 buys back.
+      #
+      # 🚨 AND IT PROVES THE RESULT BY LAUNCHING IT, on both branches. A browser that is present but
+      # cannot spawn its zygote reads to the suite exactly like a missing one — six tests later, in
+      # a module nobody was editing. So this step renders `about:blank` the way the suite will and
+      # goes RED BY NAME when it cannot, naming the sandbox when that is what the stderr says.
+      - name: A headless browser for the pixel-export suites
+        # Same `if:` as the inline suite below, plus the runner gate: on a PUBLISHING run the
+        # suite runs HERE, so the browser must be here too or trunk breaks the way the PR lane did.
+        if: ${{ inputs.runner != 'ubuntu-latest' && inputs.publish && matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}
+        env:
+          CHROME_DEB: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        run: |
+          set -euo pipefail
+          # The five paths, in this order, behind the same two environment variables, as
+          # MeshWeaver.Plugins src/MeshWeaver.Markdown.Export/Pixel/PixelRenderingOptions.cs. This
+          # list is a COPY OF A CONTRACT: a browser installed anywhere that file does not look is
+          # not installed at all.
+          paths=("${CHROME_BIN:-}" "${PUPPETEER_EXECUTABLE_PATH:-}"
+                 /usr/bin/chromium /usr/bin/chromium-browser
+                 /usr/bin/google-chrome /usr/bin/google-chrome-stable /usr/bin/microsoft-edge)
+          find_browser() { local p; for p in "${paths[@]}"; do if [ -n "$p" ] && [ -x "$p" ]; then printf '%s' "$p"; return 0; fi; done; return 1; }
+          browser="$(find_browser || true)"
+          if [ -n "$browser" ]; then
+            took="PRESENT — the image already carries $browser; nothing installed"
+          else
+            [ "$(uname -m)" = "x86_64" ] || { echo "::error::no browser at any path the export suite reads and this runner is $(uname -m); the google-chrome-stable .deb is amd64-only. Bake one into the runner image (Systemorph/Memex#323) or run this leg on ubuntu-latest."; exit 1; }
+            command -v sudo > /dev/null || { echo "::error::no browser on this runner and no sudo with which to install one."; exit 1; }
+            sudo -n true || { echo "::error::no browser on this runner and sudo is not passwordless here, so one cannot be installed."; exit 1; }
+            echo "no browser at any of: ${paths[*]} — installing google-chrome-stable"
+            sudo apt-get update -qq || { echo "::error::apt-get update failed, so google-chrome-stable's runtime dependencies cannot be resolved and no browser can be installed."; exit 1; }
+            curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused -o "$RUNNER_TEMP/chrome.deb" "$CHROME_DEB" || { echo "::error::could not download the google-chrome-stable .deb from dl.google.com."; exit 1; }
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends "$RUNNER_TEMP/chrome.deb" || { echo "::error::apt-get could not install the google-chrome-stable .deb (its ~25 runtime dependencies come from the Ubuntu archive)."; exit 1; }
+            browser="$(find_browser || true)"
+            [ -n "$browser" ] || { echo "::error::google-chrome-stable installed without error, yet none of ${paths[*]} is executable. The suite reads exactly those paths, so this is still a runner with no browser."; exit 1; }
+            took="INSTALLED google-chrome-stable in ${SECONDS}s"
+          fi
+          # 🚨 THE ASSERTION. Launched the way the suite will launch it: the renderer adds
+          # `--no-sandbox` only when it runs as ROOT (HeadlessChromiumPdfRenderer, "as root the
+          # sandbox is not a choice"), and a self-hosted runner is uid 1001 — so if this pod cannot
+          # give Chromium a sandbox, the suite dies and this must die with it, HERE, by name.
+          # (Measured 2026-09-12 on both labels: the SUID sandbox at /opt/google/chrome/chrome-sandbox
+          # works in these pods — headless render and --print-to-pdf both exit 0 WITHOUT the flag —
+          # so nothing here needs MarkdownExport:PixelRendering:NoSandbox today. The day a pod
+          # hardens past it, this line is what says so instead of six red tests.)
+          work="$RUNNER_TEMP/chrome-smoke"; rm -rf "$work"; mkdir -p "$work"
+          if ! "$browser" --headless=new --disable-gpu --no-first-run --no-default-browser-check \
+                 --user-data-dir="$work/profile" --dump-dom about:blank \
+                 > "$work/dom.html" 2> "$work/stderr.txt"; then
+            echo "----- the browser's own stderr -----"; tail -20 "$work/stderr.txt"
+            echo "::error::'$browser' is on the runner but did NOT start headless (its stderr is above). A present-but-unlaunchable browser reads to the suite exactly like a missing one, six tests later. If that stderr names the zygote or the sandbox, this pod cannot give Chromium a namespace or SUID sandbox and the module needs MarkdownExport:PixelRendering:NoSandbox — a decision for the module, not one this step may take silently."
+            exit 1
+          fi
+          grep -q "<html" "$work/dom.html" || { echo "::error::'$browser' exited 0 but rendered no document (--dump-dom of about:blank produced $(wc -c < "$work/dom.html") bytes with no <html>). It is not a usable headless browser."; exit 1; }
+          printf 'CHROME_BIN=%s\n' "$browser" >> "$GITHUB_ENV"
+          echo "$took"
+          echo "CHROME_BIN=$browser ($("$browser" --version)) — launched headless OK; ${SECONDS}s in this step"
       # ═══════ THE SUITE, INLINE — ON A PUBLISHING RUN ONLY (see the `tests` job below) ═══════
       # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
       # because the caller's gates compose it — carries test=false from the selection, and its
@@ -3116,6 +3220,94 @@ jobs:
       - uses: actions/setup-dotnet@v6
         with:
           dotnet-version: "10.0.x"
+      # ─────── A HEADLESS BROWSER — SELF-HOSTED RUNNERS ONLY (interim: Memex#323) ───────
+      # 🚨 INTERIM, and it has a named end: Systemorph/Memex#323 ("bake the toolchain into our own
+      # runner image") puts a browser in the image the ARC scale sets run, and DELETES this step
+      # whole. Until then every self-hosted leg pays the install.
+      #
+      # `ubuntu-latest` ships Google Chrome and is excluded here, so the default caller's behaviour
+      # is byte-identical to before this step existed. The stock
+      # `ghcr.io/actions/actions-runner:2.337.0` image (Ubuntu 24.04, uid 1001, passwordless sudo,
+      # EMPTY apt lists) carries NOTHING at any of the five paths the pixel-faithful export suites
+      # read — so the first leg moved to `aks-silos-dind` turned 6 of 201
+      # `MeshWeaver.Markdown.Export` tests red with "Pixel-faithful export needs a headless
+      # Chromium on the server and none is configured" (MeshWeaver.Plugins#1736, run 34700003866).
+      #
+      # 🚨 INLINE, not a script in `.github/scripts/`, and that is not a style choice. Both jobs
+      # check core out at `inputs.platform-ref` — the newest SEALED set, hours behind this lane,
+      # which arrives from `@main` (MeshWeaver#3842, and the `select` job's own note about "a
+      # workflow newer than the checkout"). A new file would be absent from that checkout and this
+      # step would die `exit 127` until a set seals. `github.job_workflow_sha` cannot rescue it
+      # either: measured EMPTY inside a reusable called from another repo (Plugins#1566). The block
+      # is therefore duplicated in `pack` and `tests` — BYTE-IDENTICAL, and
+      # ModuleSuiteLaneGuard.TheBrowserStep_IsOneImplementation refuses a run where it is not.
+      #
+      # google-chrome-stable, NOT `apt-get install chromium`: measured inside the runner image,
+      # noble has no `chromium` package at all and `chromium-browser` is `2:1snap1-0ubuntu2`,
+      # `Pre-Depends: snapd`, "Transitional package - chromium-browser -> chromium snap" — in a pod
+      # that gets you a snap stub and no browser. The .deb straight from dl.google.com is one HTTPS
+      # fetch from the same host that would serve the repository key (the image ships no `gnupg`).
+      #
+      # WHAT IT COSTS, measured on live runners on 2026-09-12 (Memex runner-proof dispatches, both
+      # labels, Ubuntu 24.04 pods, cold — an ARC runner is EPHEMERAL, so every leg pays it):
+      #     aks-silos-dind (6 vCPU/20 GiB pod): apt-get update 4.7s + download 2.2s + install 46.2s
+      #     aks-silos      (4 vCPU/12 GiB pod): apt-get update 4.7s + download 2.7s + install 51.0s
+      # ⇒ ~53-58 s per leg, nearly all of it dpkg unpacking Chrome and its ~25 dependencies. That
+      # is the price of the interim, and it is the number Memex#323 buys back.
+      #
+      # 🚨 AND IT PROVES THE RESULT BY LAUNCHING IT, on both branches. A browser that is present but
+      # cannot spawn its zygote reads to the suite exactly like a missing one — six tests later, in
+      # a module nobody was editing. So this step renders `about:blank` the way the suite will and
+      # goes RED BY NAME when it cannot, naming the sandbox when that is what the stderr says.
+      - name: A headless browser for the pixel-export suites
+        if: inputs.runner != 'ubuntu-latest'
+        env:
+          CHROME_DEB: https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+        run: |
+          set -euo pipefail
+          # The five paths, in this order, behind the same two environment variables, as
+          # MeshWeaver.Plugins src/MeshWeaver.Markdown.Export/Pixel/PixelRenderingOptions.cs. This
+          # list is a COPY OF A CONTRACT: a browser installed anywhere that file does not look is
+          # not installed at all.
+          paths=("${CHROME_BIN:-}" "${PUPPETEER_EXECUTABLE_PATH:-}"
+                 /usr/bin/chromium /usr/bin/chromium-browser
+                 /usr/bin/google-chrome /usr/bin/google-chrome-stable /usr/bin/microsoft-edge)
+          find_browser() { local p; for p in "${paths[@]}"; do if [ -n "$p" ] && [ -x "$p" ]; then printf '%s' "$p"; return 0; fi; done; return 1; }
+          browser="$(find_browser || true)"
+          if [ -n "$browser" ]; then
+            took="PRESENT — the image already carries $browser; nothing installed"
+          else
+            [ "$(uname -m)" = "x86_64" ] || { echo "::error::no browser at any path the export suite reads and this runner is $(uname -m); the google-chrome-stable .deb is amd64-only. Bake one into the runner image (Systemorph/Memex#323) or run this leg on ubuntu-latest."; exit 1; }
+            command -v sudo > /dev/null || { echo "::error::no browser on this runner and no sudo with which to install one."; exit 1; }
+            sudo -n true || { echo "::error::no browser on this runner and sudo is not passwordless here, so one cannot be installed."; exit 1; }
+            echo "no browser at any of: ${paths[*]} — installing google-chrome-stable"
+            sudo apt-get update -qq || { echo "::error::apt-get update failed, so google-chrome-stable's runtime dependencies cannot be resolved and no browser can be installed."; exit 1; }
+            curl -fsSL --retry 3 --retry-delay 2 --retry-connrefused -o "$RUNNER_TEMP/chrome.deb" "$CHROME_DEB" || { echo "::error::could not download the google-chrome-stable .deb from dl.google.com."; exit 1; }
+            sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --no-install-recommends "$RUNNER_TEMP/chrome.deb" || { echo "::error::apt-get could not install the google-chrome-stable .deb (its ~25 runtime dependencies come from the Ubuntu archive)."; exit 1; }
+            browser="$(find_browser || true)"
+            [ -n "$browser" ] || { echo "::error::google-chrome-stable installed without error, yet none of ${paths[*]} is executable. The suite reads exactly those paths, so this is still a runner with no browser."; exit 1; }
+            took="INSTALLED google-chrome-stable in ${SECONDS}s"
+          fi
+          # 🚨 THE ASSERTION. Launched the way the suite will launch it: the renderer adds
+          # `--no-sandbox` only when it runs as ROOT (HeadlessChromiumPdfRenderer, "as root the
+          # sandbox is not a choice"), and a self-hosted runner is uid 1001 — so if this pod cannot
+          # give Chromium a sandbox, the suite dies and this must die with it, HERE, by name.
+          # (Measured 2026-09-12 on both labels: the SUID sandbox at /opt/google/chrome/chrome-sandbox
+          # works in these pods — headless render and --print-to-pdf both exit 0 WITHOUT the flag —
+          # so nothing here needs MarkdownExport:PixelRendering:NoSandbox today. The day a pod
+          # hardens past it, this line is what says so instead of six red tests.)
+          work="$RUNNER_TEMP/chrome-smoke"; rm -rf "$work"; mkdir -p "$work"
+          if ! "$browser" --headless=new --disable-gpu --no-first-run --no-default-browser-check \
+                 --user-data-dir="$work/profile" --dump-dom about:blank \
+                 > "$work/dom.html" 2> "$work/stderr.txt"; then
+            echo "----- the browser's own stderr -----"; tail -20 "$work/stderr.txt"
+            echo "::error::'$browser' is on the runner but did NOT start headless (its stderr is above). A present-but-unlaunchable browser reads to the suite exactly like a missing one, six tests later. If that stderr names the zygote or the sandbox, this pod cannot give Chromium a namespace or SUID sandbox and the module needs MarkdownExport:PixelRendering:NoSandbox — a decision for the module, not one this step may take silently."
+            exit 1
+          fi
+          grep -q "<html" "$work/dom.html" || { echo "::error::'$browser' exited 0 but rendered no document (--dump-dom of about:blank produced $(wc -c < "$work/dom.html") bytes with no <html>). It is not a usable headless browser."; exit 1; }
+          printf 'CHROME_BIN=%s\n' "$browser" >> "$GITHUB_ENV"
+          echo "$took"
+          echo "CHROME_BIN=$browser ($("$browser" --version)) — launched headless OK; ${SECONDS}s in this step"
       # The same command, the same evidence trail and the same tolerance for a module that ships
       # no suite as the inline step in `pack` — this is a MOVE, not a rewrite. See that step for
       # what each environment variable buys when a flake has to be diagnosed from the artifacts.

--- a/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
@@ -149,6 +149,68 @@ public class ModuleSuiteLaneGuard
         Assert.Contains("else (.test != false) end", select, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// The interim headless-browser step (Systemorph/Memex#323 deletes it) is ONE implementation
+    /// living in two places, and this is what keeps it one.
+    ///
+    /// <para>It cannot be a script under <c>.github/scripts/</c>: both jobs check core out at
+    /// <c>inputs.platform-ref</c> — the newest SEALED set, hours behind the lane text, which
+    /// arrives from <c>@main</c> — so a new file would be absent there and the step would die
+    /// <c>exit 127</c> until a set seals (MeshWeaver#3842; and <c>github.job_workflow_sha</c> is
+    /// measured EMPTY inside a reusable called from another repo, Plugins#1566). So the block is
+    /// duplicated between <c>pack</c> (publishing runs, where the suite is inline) and
+    /// <c>tests</c> (every other run) — and duplication that nothing checks is duplication that
+    /// drifts, which here means one lane of the fleet quietly losing its browser.</para>
+    /// </summary>
+    [Fact]
+    public void TheBrowserStep_IsOneImplementation_InBothJobsThatRunASuite()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var steps = Regex.Matches(
+            text,
+            @"      - name: A headless browser for the pixel-export suites\n(?<body>(?:        .*\n|\n)+)");
+        // BOTH jobs that can run a module's suite on a self-hosted runner, or the fleet has a lane
+        // where the browser is missing again: `pack` owns the suite when the call publishes,
+        // `tests` owns it otherwise, and `runner` moves both.
+        Assert.Equal(2, steps.Count);
+
+        var runs = steps.Select(m =>
+        {
+            var body = m.Groups["body"].Value;
+            var i = body.IndexOf("        run: |\n", StringComparison.Ordinal);
+            Assert.True(i >= 0, "the browser step must carry a `run:` block");
+            return body[i..];
+        }).ToList();
+        Assert.Equal(runs[0], runs[1]);
+
+        // Gated OFF on ubuntu-latest in both, so GitHub's image — which ships Chrome — is
+        // byte-identical to before this step existed.
+        foreach (var m in steps.Cast<Match>())
+            Assert.Contains("inputs.runner != 'ubuntu-latest'", m.Groups["body"].Value, StringComparison.Ordinal);
+
+        var run = runs[0];
+        // The discovery list is a COPY OF A CONTRACT: MeshWeaver.Plugins'
+        // src/MeshWeaver.Markdown.Export/Pixel/PixelRenderingOptions.cs reads exactly these, in
+        // this order, behind exactly these two environment variables. Installing a browser
+        // anywhere that file does not look is not installing a browser.
+        foreach (var path in new[]
+                 {
+                     "\"${CHROME_BIN:-}\"", "\"${PUPPETEER_EXECUTABLE_PATH:-}\"",
+                     "/usr/bin/chromium", "/usr/bin/chromium-browser",
+                     "/usr/bin/google-chrome", "/usr/bin/google-chrome-stable", "/usr/bin/microsoft-edge",
+                 })
+            Assert.Contains(path, run, StringComparison.Ordinal);
+        // 🚨 It must LAUNCH the thing, not merely find it — a present-but-unlaunchable browser
+        // reads to the suite exactly like a missing one, six tests later — and it must go red BY
+        // NAME when it cannot. Both halves of that, and the export the suite actually consumes.
+        Assert.Contains("--dump-dom about:blank", run, StringComparison.Ordinal);
+        Assert.Contains("did NOT start headless", run, StringComparison.Ordinal);
+        Assert.Contains("rendered no document", run, StringComparison.Ordinal);
+        Assert.Contains("printf 'CHROME_BIN=%s\\n' \"$browser\" >> \"$GITHUB_ENV\"", run, StringComparison.Ordinal);
+        // No silent branch: every exit from this step is an ::error:: or a proven browser.
+        Assert.DoesNotContain("continue-on-error", run, StringComparison.Ordinal);
+    }
+
     private static string JobBody(string job)
     {
         var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));


### PR DESCRIPTION
## The measured failure

MeshWeaver.Plugins#1736 moves the `Module bundle` / `Module tests` legs to the self-hosted
`aks-silos-dind` scale set. Run **34700003866**, job `Module bundles / Module tests
(MeshWeaver.Markdown.Export)` on `aks-silos-dind-flgft-runner-*`: **6 of 201 tests fail** with

```
Script execution failed: Pixel-faithful export needs a headless Chromium on the server and none is
configured. Set MarkdownExport PixelRendering ExecutablePath (or the CHROME_BIN environment
variable) to a Chromium/Chrome/Edge executable, or export with content fidelity instead.
```

`ubuntu-latest` ships Google Chrome, so the pixel-faithful export suites have always found one
without anyone arranging it. `ghcr.io/actions/actions-runner:2.337.0` does not — **measured on the
live runner** (`aks-silos-dind-7h2ql-runner-fqljf`, 2026-09-12), all five discovery paths absent:

```
absent  /usr/bin/chromium            absent  /usr/bin/google-chrome
absent  /usr/bin/chromium-browser    absent  /usr/bin/google-chrome-stable
absent  /usr/bin/microsoft-edge
```

Plugins cannot fix this from its side: the suite runs inside this lane, ONE call, no per-module
runner and no env passthrough (#3732). So it belongs here.

## The change

A step in **both** jobs that can run a module's suite, gated `inputs.runner != 'ubuntu-latest'`:

* `tests` — every non-publishing run (this is the one #1736 needs);
* `pack` — publishing runs, where the suite is inline. Without it, `main` would break exactly the
  way the PR lane did the moment the repo variable is set.

Plus the lane header's "Where the heavy legs run" section, which now records the missing browser
alongside the missing dotnet/gh/az/Docker.

### Which install path, and the evidence for it

| order | candidate | verdict |
|---|---|---|
| (a) | already at a discovery path | **kept as the first branch** — a no-op today, and exactly the shape this degrades to when Memex#323 bakes one in. ARC runners are ephemeral, so it does not hit yet. |
| (b) | `apt-get install chromium` / `chromium-browser` | **refused, on evidence.** Measured in the image: noble has **no `chromium` package at all**; `chromium-browser` is `Version: 2:1snap1-0ubuntu2`, `Pre-Depends: debconf, snapd`, `Description: Transitional package - chromium-browser -> chromium snap`. In a pod that is a snap stub and no browser. |
| (b′) | **`google-chrome-stable` via apt** | **chosen.** `apt-get update` + the `.deb` straight from `dl.google.com`, installed with apt so its ~25 runtime dependencies resolve from the Ubuntu archive (the bare image has few of them). Taking the `.deb` rather than adding an apt source is one HTTPS fetch from the same host that would serve the repository key — the image ships no `gnupg` either. It lands at `/usr/bin/google-chrome` **and** `/usr/bin/google-chrome-stable`, two of the five paths the suite reads. |
| (c) | a pinned download | not needed; (b′) is the distro mechanism and resolves deps. |

### The cost of the interim, measured

Two live dispatches on 2026-09-12, **cold** — an ARC runner is ephemeral, so every leg pays this:

| label | pod | `apt-get update` | download | `apt install` | **total** |
|---|---|---|---|---|---|
| `aks-silos-dind` | 6 vCPU / 20 GiB | 4.7 s | 2.2 s | 46.2 s | **~53 s** |
| `aks-silos` | 4 vCPU / 12 GiB | 4.7 s | 2.7 s | 51.0 s | **~58 s** |

Nearly all of it is dpkg unpacking Chrome and its dependencies. Against a `Module tests` leg that
runs minutes, that is the price of the interim — and the number **Systemorph/Memex#323** buys back
by baking the browser into our own runner image, which deletes both steps whole. The step's comment
says so, in both copies.

Same dispatches also answered the sandbox question before it could cost anything: the SUID sandbox
at `/opt/google/chrome/chrome-sandbox` **works** in these pods — headless render and
`--print-to-pdf` both exit 0 **without** `--no-sandbox` (13,714 bytes written) — so nothing needs
`MarkdownExport:PixelRendering:NoSandbox` today. The renderer adds `--no-sandbox` only when it runs
as root, and a runner pod is uid 1001, so the step launches the browser the same way the suite will.

### Why inline, and not a script in `.github/scripts/`

Not a style choice. Both jobs check core out at `inputs.platform-ref` — the newest **sealed** set,
hours behind this lane, which arrives from `@main` (#3842, and `select`'s own note about "a workflow
newer than the checkout"). A new file would be **absent** from that checkout and the step would die
`exit 127` until a set seals — i.e. #1736 would stay red. `github.job_workflow_sha` cannot rescue it
either: measured **EMPTY** inside a reusable called from another repo (Plugins#1566).

So the block is duplicated in `pack` and `tests`, **byte-identical**, and duplication that nothing
checks is duplication that drifts — so a new C# lane guard,
`ModuleSuiteLaneGuard.TheBrowserStep_IsOneImplementation_InBothJobsThatRunASuite`, compares the two
`run:` blocks byte for byte, asserts there are exactly two, asserts both are gated off on
`ubuntu-latest`, and asserts the discovery list still matches the contract in
`PixelRenderingOptions.cs`.

## "Could this assertion fail?" — the guard-deletion proof

The step does not just *find* a browser, it **launches** it and goes red by name if it cannot. Here
is that assertion deleted, on identical input — the `run:` block extracted verbatim from this diff,
`CHROME_BIN` pointed at a stub that exists, is executable, and dies on launch:

```
===== (1) ASSERTION PRESENT =====
----- the browser's own stderr -----
clone: Invalid argument
Zygote process exited prematurely with exit code 1
::error::'…/dead' is on the runner but did NOT start headless (its stderr is above). A
present-but-unlaunchable browser reads to the suite exactly like a missing one, six tests later. …
exit=1
GITHUB_ENV now: []

===== (2) SAME INPUT, assertion deleted =====
PRESENT — the image already carries …/dead; nothing installed
CHROME_BIN=…/dead () — launched headless OK; 0s in this step      <-- a LIE, and green
exit=0
GITHUB_ENV now: [CHROME_BIN=…/dead]
```

Deleted, the step passes, exports a broken `CHROME_BIN`, **claims it launched**, and the failure
resurfaces six tests later in a module nobody was editing. Present, it is one red line naming the
browser and the likely cause. The sibling case is proven the same way — a stub that exits 0 and
renders nothing is refused with `rendered no document (… 0 bytes with no <html>)`, because a zero
exit is not evidence of a document — and a stub that behaves is **accepted** and exported, so the
gate is not one that simply refuses everything.

The new C# guard was likewise proven to fire: adding a one-character drift to the `pack` copy reds
it with `Assert.Equal() Failure: Strings differ`.

## Guards

| guard | result |
|---|---|
| `actionlint` (CI's flags, `-shellcheck= -pyflakes=`) | clean; with its embedded shellcheck on, **7 info findings — identical to `origin/main`**, none in the new block |
| `check-workflow-shell` (`--self-test`, `--root .`) | OK · 0 live, 1 allow-listed, 0 stale |
| `check-workflow-timeouts` | OK · 86 jobs, 0 violations |
| `check-workflow-yaml-keys` | OK · 35 workflows, 0 violations |
| `check-pr-secret-preflight` | OK · 2 secrets, 2 asserted, 0 violations |
| `check-workflow-permission-pairing` (`--root .` **and** `--fleet`) | OK · 5 pairs, 0 violations · 27/27 self-test controls |
| `dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror` | **440 passed**, 0 failed (439 before; +1 new lane guard) |

## What still has to happen

Nothing ships from this merge. Once it is on `main`, MeshWeaver.Plugins#1736 re-runs **only its
failed jobs** (`gh run rerun --failed`) and picks the lane up from `@main`. Nothing was re-run or
opened in Plugins from here — that repo's queue is jammed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
