### PR TITLE
ci(module-pack): keep lane tooling on the workflow ref

### DIFF
--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -428,7 +428,8 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             problems.append(f"{job} needs exactly one platform-ref checkout at meshweaver")
         if len(logic_checkouts) != 1:
             problems.append(f"{job} needs exactly one build-logic-ref checkout at build-logic")
-        declaration = "MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py"
+        declaration = ("MODULE_PACK_BATCH: ${{ github.workspace }}"
+                       "/build-logic/.github/scripts/module-pack-batch.py")
         if block.count(declaration) != 1:
             problems.append(f"{job} must declare its batching helper exactly once from build-logic")
         if "meshweaver/.github/scripts/module-pack-batch.py" in block:

--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -43,7 +43,7 @@ and the ledger, upstream in `select`), never talks to the registry or the ledger
 never hides a failure — `fail` prints a `::error` naming the module and the phase, and `verdict`
 refuses to exit 0 over one.
 
-    python3 module-pack-batch.py --self-test
+    python3 module-pack-batch.py --self-test --workflow node-repo-module-pack.yml
     python3 module-pack-batch.py chunk --modules @selection.json --size 6 --github-output "$GITHUB_OUTPUT"
     python3 module-pack-batch.py --state S init --batch @batch.json
     python3 module-pack-batch.py --state S list --ok --where decision=build
@@ -396,11 +396,12 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
 
     The two refs deliberately move independently. The 2026-09-12 batching rollout put this helper
     in a new lane while `pack` and `tests` still invoked it from the older platform checkout; every
-    module-test batch then failed before its first suite. This reads the real workflow beside this
-    script, rather than a copied fixture, so the self-test run by every caller catches that split.
+    module-test batch then failed before its first suite. The caller passes the exact reusable
+    workflow identified by `job.workflow_sha`, so this checks the YAML GitHub loaded rather than a
+    copy beside either independently moving checkout.
     """
     problems: list[str] = []
-    boundaries = {"pack": "tests", "tests": "verify"}
+    boundaries = {"select": "prepare", "pack": "tests", "tests": "verify"}
     for job, next_job in boundaries.items():
         start_marker = f"\n  {job}:\n"
         end_marker = f"\n  {next_job}:\n"
@@ -422,10 +423,11 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             and "repository: Systemorph/MeshWeaver" in step
             and "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}" in step
             and "path: build-logic" in step
-            and "sparse-checkout: .github/scripts" in step
+            and (job == "select" or "sparse-checkout: .github/scripts" in step)
         ]
-        if len(platform_checkouts) != 1:
-            problems.append(f"{job} needs exactly one platform-ref checkout at meshweaver")
+        expected_platform = 0 if job == "select" else 1
+        if len(platform_checkouts) != expected_platform:
+            problems.append(f"{job} needs exactly {expected_platform} platform-ref checkout(s) at meshweaver")
         if len(logic_checkouts) != 1:
             problems.append(f"{job} needs exactly one build-logic-ref checkout at build-logic")
         declaration = ("MODULE_PACK_BATCH: ${{ github.workspace }}"
@@ -434,11 +436,44 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             problems.append(f"{job} must declare its batching helper exactly once from build-logic")
         if "meshweaver/.github/scripts/module-pack-batch.py" in block:
             problems.append(f"{job} invokes the batching helper from platform-ref")
-        if block.count('"$MODULE_PACK_BATCH"') < 2:
+        required_calls = 3 if job == "select" else 2
+        if block.count('"$MODULE_PACK_BATCH"') < required_calls:
             problems.append(f"{job} does not drive its batch through MODULE_PACK_BATCH")
+        if job == "select":
+            workflow_checkouts = [
+                step for step in steps
+                if "uses: actions/checkout@" in step
+                and "repository: ${{ steps.workflow.outputs.repository }}" in step
+                and "ref: ${{ steps.workflow.outputs.sha }}" in step
+                and "path: lane-definition" in step
+                and "sparse-checkout: .github/workflows" in step
+            ]
+            if len(workflow_checkouts) != 1:
+                problems.append("select must check out the exact job.workflow_sha at lane-definition")
+            if block.count("JOB_CONTEXT: ${{ toJSON(job) }}") != 1:
+                problems.append("select must resolve the reusable workflow from the job context")
+            if ".workflow_repository // empty" not in block or ".workflow_sha // empty" not in block:
+                problems.append("select must read both reusable-workflow identity fields")
+            if ('echo "repository=$repository" >> "$GITHUB_OUTPUT"' not in block
+                    or 'echo "sha=$sha" >> "$GITHUB_OUTPUT"' not in block):
+                problems.append("select must expose the validated job workflow identity to checkout")
+            executing = ("EXECUTING_WORKFLOW: ${{ github.workspace }}"
+                         "/lane-definition/.github/workflows/node-repo-module-pack.yml")
+            if block.count(executing) != 1:
+                problems.append("select must name the exact checked-out reusable workflow once")
+            if block.count("JOB_WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}") != 1:
+                problems.append("select must pass job.workflow_sha to its checkout verification")
+            if "git -C lane-definition rev-parse HEAD" not in block:
+                problems.append("select must verify the workflow checkout resolved job.workflow_sha")
+            exact_self_test = ('python3 "$MODULE_PACK_BATCH" --self-test '
+                               '--workflow "$EXECUTING_WORKFLOW"')
+            if block.count(exact_self_test) != 1:
+                problems.append("select must self-test the exact workflow that defines the job")
+            if "meshweaver/.github/scripts/" in block:
+                problems.append("select invokes lane orchestration from the platform checkout")
     return problems
 
-def self_test() -> int:
+def self_test(workflow_path: Path | None = None) -> int:
     import subprocess
 
     failures: list[str] = []
@@ -452,13 +487,19 @@ def self_test() -> int:
         return {"package": m.split(".")[-1], "module": m, "project": f"src/{m}/{m}.csproj", **kw}
 
     print("== workflow: orchestration ref and platform ref stay separate")
-    workflow_path = Path(__file__).resolve().parents[1] / "workflows" / "node-repo-module-pack.yml"
+    # Older pinned reusable workflows call `--self-test` without `--workflow`; retain that fallback
+    # while current lanes pass the exact `job.workflow_sha` checkout explicitly. Dropping the
+    # fallback would make an old lane fetch a new helper and fail before it could migrate.
+    workflow_path = workflow_path or (
+        Path(__file__).resolve().parents[1] / "workflows" / "node-repo-module-pack.yml"
+    )
     if not workflow_path.is_file():
-        check("the real reusable workflow is present beside the helper", False, str(workflow_path))
+        check("the reusable workflow to inspect is present", False, str(workflow_path))
     else:
         workflow = workflow_path.read_text(encoding="utf-8")
         problems = workflow_script_ownership_problems(workflow)
-        check("pack and tests fetch this helper from build-logic-ref", not problems, "; ".join(problems))
+        check("select, pack and tests keep workflow, tooling and platform refs distinct",
+              not problems, "; ".join(problems))
         wrong_ref = workflow.replace(
             "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: build-logic",
             "ref: ${{ inputs.platform-ref }}\n          path: build-logic",
@@ -466,12 +507,19 @@ def self_test() -> int:
         )
         check("the ownership guard catches a helper checkout moved onto platform-ref",
               bool(workflow_script_ownership_problems(wrong_ref)))
+        wrong_workflow_ref = workflow.replace(
+            "ref: ${{ steps.workflow.outputs.sha }}\n          path: lane-definition",
+            "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: lane-definition",
+            1,
+        )
+        check("the ownership guard catches executing-workflow evidence moved onto another ref",
+              bool(workflow_script_ownership_problems(wrong_workflow_ref)))
         wrong_path = workflow.replace(
-            'python3 "$MODULE_PACK_BATCH"',
+            'python3 "$MODULE_PACK_BATCH" --self-test --workflow "$EXECUTING_WORKFLOW"',
             "python3 meshweaver/.github/scripts/module-pack-batch.py",
             1,
         )
-        check("the ownership guard catches a leg invoking the platform checkout",
+        check("the ownership guard catches select invoking the platform checkout",
               bool(workflow_script_ownership_problems(wrong_path)))
 
     print("== chunk: deterministic, sorted, ≤N is one leg, singleton unchanged")
@@ -610,6 +658,8 @@ def main(argv: list[str] | None = None) -> int:
     ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
     ap.add_argument("--state", help="the leg's state file (every subcommand but chunk)")
     ap.add_argument("--self-test", action="store_true")
+    ap.add_argument("--workflow", type=Path,
+                    help="reusable workflow YAML to inspect during --self-test")
     sub = ap.add_subparsers(dest="cmd")
 
     c = sub.add_parser("chunk", help="split a selection into batches of ≤N")
@@ -656,7 +706,9 @@ def main(argv: list[str] | None = None) -> int:
 
     a = ap.parse_args(argv)
     if a.self_test:
-        return self_test()
+        return self_test(a.workflow)
+    if a.workflow:
+        die("--workflow is only valid with --self-test")
     if not a.cmd:
         ap.print_help()
         return 2

--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -58,6 +58,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 import tempfile
 from pathlib import Path
@@ -401,14 +402,25 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
     copy beside either independently moving checkout.
     """
     problems: list[str] = []
-    boundaries = {"select": "prepare", "pack": "tests", "tests": "verify"}
+    boundaries: dict[str, str | None] = {
+        "select": "prepare",
+        "prepare": "build-workspace",
+        "build-workspace": "pack",
+        "pack": "tests",
+        "tests": "verify",
+        "verify": None,
+    }
+    blocks: dict[str, str] = {}
     for job, next_job in boundaries.items():
         start_marker = f"\n  {job}:\n"
-        end_marker = f"\n  {next_job}:\n"
-        if start_marker not in workflow or end_marker not in workflow:
+        end_marker = f"\n  {next_job}:\n" if next_job else None
+        if start_marker not in workflow or (end_marker and end_marker not in workflow):
             problems.append(f"cannot find the {job} job boundary")
             continue
-        block = workflow.split(start_marker, 1)[1].split(end_marker, 1)[0]
+        block = workflow.split(start_marker, 1)[1]
+        if end_marker:
+            block = block.split(end_marker, 1)[0]
+        blocks[job] = block
         steps = block.split("\n      - ")
         logic_ref = ("ref: ${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}"
                      if job == "select"
@@ -425,22 +437,29 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             if "uses: actions/checkout@" in step
             and "repository: Systemorph/MeshWeaver" in step
             and logic_ref in step
-            and "path: build-logic" in step
+            and "\n          path: build-logic\n" in f"\n{step}\n"
             and (job == "select" or "sparse-checkout: .github/scripts" in step)
         ]
-        expected_platform = 0 if job == "select" else 1
+        expected_platform = 1 if job in {"prepare", "pack", "tests"} else 0
         if len(platform_checkouts) != expected_platform:
             problems.append(f"{job} needs exactly {expected_platform} platform-ref checkout(s) at meshweaver")
         if len(logic_checkouts) != 1:
             problems.append(f"{job} needs exactly one build-logic-ref checkout at build-logic")
+        elif job == "build-workspace" and "if: always()" not in logic_checkouts[0]:
+            problems.append("build-workspace must fetch ledger tooling after a failed compiler step")
+        elif job == "verify" and "if: needs.select.result == 'success'" not in logic_checkouts[0]:
+            problems.append("verify must not resolve an empty tooling ref when select itself failed")
         declaration = ("MODULE_PACK_BATCH: ${{ github.workspace }}"
-                       "/build-logic/.github/scripts/module-pack-batch.py")
-        if block.count(declaration) != 1:
-            problems.append(f"{job} must declare its batching helper exactly once from build-logic")
+                        "/build-logic/.github/scripts/module-pack-batch.py")
+        expected_declarations = 1 if job in {"select", "pack", "tests"} else 0
+        if block.count(declaration) != expected_declarations:
+            problems.append(
+                f"{job} must declare its batching helper exactly {expected_declarations} time(s) from build-logic"
+            )
         if "meshweaver/.github/scripts/module-pack-batch.py" in block:
             problems.append(f"{job} invokes the batching helper from platform-ref")
-        required_calls = 3 if job == "select" else 2
-        if block.count('"$MODULE_PACK_BATCH"') < required_calls:
+        required_calls = 3 if job == "select" else (2 if job in {"pack", "tests"} else 0)
+        if required_calls and block.count('"$MODULE_PACK_BATCH"') < required_calls:
             problems.append(f"{job} does not drive its batch through MODULE_PACK_BATCH")
         if job == "select":
             workflow_checkouts = [
@@ -472,13 +491,86 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
                 problems.append("select must pass job.workflow_sha to its checkout verification")
             if "git -C lane-definition rev-parse HEAD" not in block:
                 problems.append("select must verify the workflow checkout resolved job.workflow_sha")
+            compatibility_contract = (
+                '[ -f "$MODULE_PACK_BATCH" ]',
+                'python3 "$MODULE_PACK_BATCH" --help > "$helper_help"',
+                "grep -q -- '--workflow' \"$helper_help\"",
+            )
+            if any(fragment not in block for fragment in compatibility_contract):
+                problems.append("select must fail clearly when an explicit tooling ref lacks the loaded workflow's helper contract")
             exact_self_test = ('python3 "$MODULE_PACK_BATCH" --self-test '
                                '--workflow "$EXECUTING_WORKFLOW"')
             if block.count(exact_self_test) != 1:
                 problems.append("select must self-test the exact workflow that defines the job")
+            elif max(block.find(part) for part in compatibility_contract) > block.find(exact_self_test):
+                problems.append("select must validate the helper contract before invoking the exact workflow self-test")
             if "meshweaver/.github/scripts/" in block:
                 problems.append("select invokes lane orchestration from the platform checkout")
+
+    # Every script that implements this reusable workflow moves with the workflow. Only the two
+    # scripts that interpret the platform itself stay on platform-ref: the SemVer floor comparator
+    # is pinned against the runtime implementation, and module-owned-platform measures that exact
+    # platform's shipped assembly set. This allow-list makes the audit executable: a new
+    # meshweaver/.github/scripts consumer is a failure until its ownership is chosen deliberately.
+    platform_scripts = re.findall(r"meshweaver/\.github/scripts/([A-Za-z0-9_.-]+)", workflow)
+    expected_platform_scripts = {
+        "check-module-platform-floor.py": 1,
+        "module-owned-platform.sh": 3,
+    }
+    actual_platform_scripts = {name: platform_scripts.count(name) for name in set(platform_scripts)}
+    if actual_platform_scripts != expected_platform_scripts:
+        problems.append(
+            "platform-ref script consumers must be exactly the floor comparator once and "
+            f"module-owned-platform three times (found {actual_platform_scripts})"
+        )
+
+    orchestration_scripts = (
+        "acr-login.sh",
+        "module-build-key.py",
+        "module-build-ledger.py",
+        "module-pack-batch.py",
+        "node-repo-pack-verify.py",
+        "node-repo-publication-base.py",
+        "node-repo-publication-reuse.py",
+        "node-repo-scope.py",
+        "workspace-build-verify.py",
+    )
+    for script in orchestration_scripts:
+        if f"meshweaver/.github/scripts/{script}" in workflow:
+            problems.append(f"lane orchestration {script} is invoked from platform-ref")
+
+    build_workspace = blocks.get("build-workspace", "")
+    login_checkout = (
+        "ref: ${{ needs.select.outputs.build-logic-ref }}\n"
+        "          path: build-logic-login\n"
+        "          sparse-checkout: .github/scripts/acr-login.sh"
+    )
+    if build_workspace.count(login_checkout) != 1:
+        problems.append("build-workspace must fetch its pre-build ACR helper from the resolved tooling ref")
+    if build_workspace.count("rm -rf build-logic-login") != 1:
+        problems.append("build-workspace must remove the pre-build tooling checkout before mounting the source tree")
+
+    required_tool_paths = {
+        "prepare": ("build-logic/.github/scripts/acr-login.sh",),
+        "build-workspace": (
+            "build-logic-login/.github/scripts/acr-login.sh",
+            "build-logic/.github/scripts/workspace-build-verify.py",
+            "build-logic/.github/scripts/module-build-ledger.py",
+        ),
+        "pack": (
+            "build-logic/.github/scripts/module-build-ledger.py",
+            "build-logic/.github/scripts/node-repo-scope.py",
+        ),
+        "tests": ("build-logic/.github/scripts/module-build-ledger.py",),
+        "verify": ("build-logic/.github/scripts/node-repo-pack-verify.py",),
+    }
+    for job, paths in required_tool_paths.items():
+        block = blocks.get(job, "")
+        for path in paths:
+            if path not in block:
+                problems.append(f"{job} must invoke {path} from the resolved tooling checkout")
     return problems
+
 
 def self_test(workflow_path: Path | None = None) -> int:
     import subprocess
@@ -505,7 +597,7 @@ def self_test(workflow_path: Path | None = None) -> int:
     else:
         workflow = workflow_path.read_text(encoding="utf-8")
         problems = workflow_script_ownership_problems(workflow)
-        check("select, pack and tests keep workflow, tooling and platform refs distinct",
+        check("every lane job keeps workflow tooling and platform semantics on their owning refs",
               not problems, "; ".join(problems))
         wrong_ref = workflow.replace(
             "ref: ${{ needs.select.outputs.build-logic-ref }}\n          path: build-logic",
@@ -535,6 +627,48 @@ def self_test(workflow_path: Path | None = None) -> int:
         )
         check("the ownership guard catches select invoking the platform checkout",
               bool(workflow_script_ownership_problems(wrong_path)))
+        no_contract = workflow.replace(
+            "          grep -q -- '--workflow' \"$helper_help\" || { echo \"::error::the resolved build-logic ref carries a module-pack-batch.py without the required --workflow contract. This workflow validates the exact YAML GitHub loaded; move an explicit build-logic-ref to a compatible commit, or omit it to use job.workflow_sha.\"; exit 1; }\n",
+            "",
+            1,
+        )
+        check("the ownership guard catches a missing explicit-tooling compatibility preflight",
+              bool(workflow_script_ownership_problems(no_contract)))
+        split_ledger = workflow.replace(
+            "build-logic/.github/scripts/module-build-ledger.py record",
+            "meshweaver/.github/scripts/module-build-ledger.py record",
+            1,
+        )
+        check("the ownership guard catches one ledger writer moved back to platform-ref",
+              bool(workflow_script_ownership_problems(split_ledger)))
+        split_scope = workflow.replace(
+            "build-logic/.github/scripts/node-repo-scope.py --for modules --root .",
+            "meshweaver/.github/scripts/node-repo-scope.py --for modules --root .",
+            1,
+        )
+        check("the ownership guard catches newest-only scope moved back to platform-ref",
+              bool(workflow_script_ownership_problems(split_scope)))
+        split_verifier = workflow.replace(
+            "build-logic/.github/scripts/node-repo-pack-verify.py \\",
+            "meshweaver/.github/scripts/node-repo-pack-verify.py \\",
+            1,
+        )
+        check("the ownership guard catches the production verifier moved back to platform-ref",
+              bool(workflow_script_ownership_problems(split_verifier)))
+        split_postcondition = workflow.replace(
+            "build-logic/.github/scripts/workspace-build-verify.py --self-test",
+            "meshweaver/.github/scripts/workspace-build-verify.py --self-test",
+            1,
+        )
+        check("the ownership guard catches the workspace postcondition moved back to platform-ref",
+              bool(workflow_script_ownership_problems(split_postcondition)))
+        wrong_platform_semantics = workflow.replace(
+            "meshweaver/.github/scripts/check-module-platform-floor.py",
+            "build-logic/.github/scripts/check-module-platform-floor.py",
+            1,
+        )
+        check("the ownership guard keeps the runtime-parity floor check on platform-ref",
+              bool(workflow_script_ownership_problems(wrong_platform_semantics)))
 
     print("== chunk: deterministic, sorted, ≤N is one leg, singleton unchanged")
     sel = [entry("MeshWeaver.Zeta"), entry("MeshWeaver.AI"), entry("MeshWeaver.Maps"),

--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -3,7 +3,8 @@
 per-module bookkeeping that keeps a batch from becoming a coupling.
 
 (The name on this first line is load-bearing: the module-pack lane fetches this file at the
-caller's `platform-ref` and its `select` job self-tests it on every run.)
+caller's `build-logic-ref` (falling back to `platform-ref`) and its `select` job self-tests it on
+every run. The framework checkout remains independently pinned by `platform-ref`.)
 
 WHY THIS EXISTS (measured 2026-09-05..12)
 ------------------------------------------
@@ -390,6 +391,52 @@ def cmd_verdict(a: argparse.Namespace) -> int:
 
 # ── self-test ──────────────────────────────────────────────────────────────────────────────────
 
+def workflow_script_ownership_problems(workflow: str) -> list[str]:
+    """Keep lane orchestration on build-logic-ref and compilation on platform-ref.
+
+    The two refs deliberately move independently. The 2026-09-12 batching rollout put this helper
+    in a new lane while `pack` and `tests` still invoked it from the older platform checkout; every
+    module-test batch then failed before its first suite. This reads the real workflow beside this
+    script, rather than a copied fixture, so the self-test run by every caller catches that split.
+    """
+    problems: list[str] = []
+    boundaries = {"pack": "tests", "tests": "verify"}
+    for job, next_job in boundaries.items():
+        start_marker = f"\n  {job}:\n"
+        end_marker = f"\n  {next_job}:\n"
+        if start_marker not in workflow or end_marker not in workflow:
+            problems.append(f"cannot find the {job} job boundary")
+            continue
+        block = workflow.split(start_marker, 1)[1].split(end_marker, 1)[0]
+        steps = block.split("\n      - ")
+        platform_checkouts = [
+            step for step in steps
+            if "uses: actions/checkout@" in step
+            and "repository: Systemorph/MeshWeaver" in step
+            and "ref: ${{ inputs.platform-ref }}" in step
+            and "path: meshweaver" in step
+        ]
+        logic_checkouts = [
+            step for step in steps
+            if "uses: actions/checkout@" in step
+            and "repository: Systemorph/MeshWeaver" in step
+            and "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}" in step
+            and "path: build-logic" in step
+            and "sparse-checkout: .github/scripts" in step
+        ]
+        if len(platform_checkouts) != 1:
+            problems.append(f"{job} needs exactly one platform-ref checkout at meshweaver")
+        if len(logic_checkouts) != 1:
+            problems.append(f"{job} needs exactly one build-logic-ref checkout at build-logic")
+        declaration = "MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py"
+        if block.count(declaration) != 1:
+            problems.append(f"{job} must declare its batching helper exactly once from build-logic")
+        if "meshweaver/.github/scripts/module-pack-batch.py" in block:
+            problems.append(f"{job} invokes the batching helper from platform-ref")
+        if block.count('"$MODULE_PACK_BATCH"') < 2:
+            problems.append(f"{job} does not drive its batch through MODULE_PACK_BATCH")
+    return problems
+
 def self_test() -> int:
     import subprocess
 
@@ -402,6 +449,29 @@ def self_test() -> int:
 
     def entry(m: str, **kw) -> dict:
         return {"package": m.split(".")[-1], "module": m, "project": f"src/{m}/{m}.csproj", **kw}
+
+    print("== workflow: orchestration ref and platform ref stay separate")
+    workflow_path = Path(__file__).resolve().parents[1] / "workflows" / "node-repo-module-pack.yml"
+    if not workflow_path.is_file():
+        check("the real reusable workflow is present beside the helper", False, str(workflow_path))
+    else:
+        workflow = workflow_path.read_text(encoding="utf-8")
+        problems = workflow_script_ownership_problems(workflow)
+        check("pack and tests fetch this helper from build-logic-ref", not problems, "; ".join(problems))
+        wrong_ref = workflow.replace(
+            "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: build-logic",
+            "ref: ${{ inputs.platform-ref }}\n          path: build-logic",
+            1,
+        )
+        check("the ownership guard catches a helper checkout moved onto platform-ref",
+              bool(workflow_script_ownership_problems(wrong_ref)))
+        wrong_path = workflow.replace(
+            'python3 "$MODULE_PACK_BATCH"',
+            "python3 meshweaver/.github/scripts/module-pack-batch.py",
+            1,
+        )
+        check("the ownership guard catches a leg invoking the platform checkout",
+              bool(workflow_script_ownership_problems(wrong_path)))
 
     print("== chunk: deterministic, sorted, ≤N is one leg, singleton unchanged")
     sel = [entry("MeshWeaver.Zeta"), entry("MeshWeaver.AI"), entry("MeshWeaver.Maps"),

--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -3,8 +3,8 @@
 per-module bookkeeping that keeps a batch from becoming a coupling.
 
 (The name on this first line is load-bearing: the module-pack lane fetches this file at the
-caller's `build-logic-ref` (falling back to `platform-ref`) and its `select` job self-tests it on
-every run. The framework checkout remains independently pinned by `platform-ref`.)
+caller's `build-logic-ref` (falling back to the exact loaded workflow SHA) and its `select` job
+self-tests it on every run. The framework checkout remains independently pinned by `platform-ref`.)
 
 WHY THIS EXISTS (measured 2026-09-05..12)
 ------------------------------------------
@@ -410,6 +410,9 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             continue
         block = workflow.split(start_marker, 1)[1].split(end_marker, 1)[0]
         steps = block.split("\n      - ")
+        logic_ref = ("ref: ${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}"
+                     if job == "select"
+                     else "ref: ${{ needs.select.outputs.build-logic-ref }}")
         platform_checkouts = [
             step for step in steps
             if "uses: actions/checkout@" in step
@@ -421,7 +424,7 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             step for step in steps
             if "uses: actions/checkout@" in step
             and "repository: Systemorph/MeshWeaver" in step
-            and "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}" in step
+            and logic_ref in step
             and "path: build-logic" in step
             and (job == "select" or "sparse-checkout: .github/scripts" in step)
         ]
@@ -457,6 +460,10 @@ def workflow_script_ownership_problems(workflow: str) -> list[str]:
             if ('echo "repository=$repository" >> "$GITHUB_OUTPUT"' not in block
                     or 'echo "sha=$sha" >> "$GITHUB_OUTPUT"' not in block):
                 problems.append("select must expose the validated job workflow identity to checkout")
+            resolved_logic = ("build-logic-ref: "
+                              "${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}")
+            if block.count(resolved_logic) != 1:
+                problems.append("select must expose one exact build-logic ref to downstream jobs")
             executing = ("EXECUTING_WORKFLOW: ${{ github.workspace }}"
                          "/lane-definition/.github/workflows/node-repo-module-pack.yml")
             if block.count(executing) != 1:
@@ -501,12 +508,19 @@ def self_test(workflow_path: Path | None = None) -> int:
         check("select, pack and tests keep workflow, tooling and platform refs distinct",
               not problems, "; ".join(problems))
         wrong_ref = workflow.replace(
-            "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: build-logic",
+            "ref: ${{ needs.select.outputs.build-logic-ref }}\n          path: build-logic",
             "ref: ${{ inputs.platform-ref }}\n          path: build-logic",
             1,
         )
         check("the ownership guard catches a helper checkout moved onto platform-ref",
               bool(workflow_script_ownership_problems(wrong_ref)))
+        wrong_default = workflow.replace(
+            "ref: ${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}\n          path: build-logic",
+            "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: build-logic",
+            1,
+        )
+        check("the ownership guard catches the default tooling ref coupled to platform-ref",
+              bool(workflow_script_ownership_problems(wrong_default)))
         wrong_workflow_ref = workflow.replace(
             "ref: ${{ steps.workflow.outputs.sha }}\n          path: lane-definition",
             "ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}\n          path: lane-definition",

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2234,6 +2234,12 @@ jobs:
     - name: "The merge-queue steward's decision table holds (self-test)"
       run: python3 .github/scripts/merge-queue-steward.py --self-test
 
+    # This helper is executed by the reusable module lane in every satellite, while the framework
+    # checkout can deliberately remain on an older released platform. Its self-test reads the real
+    # workflow and refuses any pack/tests invocation that drifts back onto that platform checkout.
+    - name: "Module batching runs from build logic, independently of the platform pin"
+      run: python3 .github/scripts/module-pack-batch.py --self-test
+
     - name: "Gate the shell CI itself runs"
       run: python3 .github/scripts/check-workflow-shell.py
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2235,10 +2235,13 @@ jobs:
       run: python3 .github/scripts/merge-queue-steward.py --self-test
 
     # This helper is executed by the reusable module lane in every satellite, while the framework
-    # checkout can deliberately remain on an older released platform. Its self-test reads the real
-    # workflow and refuses any pack/tests invocation that drifts back onto that platform checkout.
+    # checkout can deliberately remain on an older released platform. Its self-test reads the
+    # workflow passed explicitly and refuses any select/pack/tests invocation that drifts back onto
+    # that platform checkout.
     - name: "Module batching runs from build logic, independently of the platform pin"
-      run: python3 .github/scripts/module-pack-batch.py --self-test
+      run: >-
+        python3 .github/scripts/module-pack-batch.py --self-test
+        --workflow .github/workflows/node-repo-module-pack.yml
 
     - name: "Gate the shell CI itself runs"
       run: python3 .github/scripts/check-workflow-shell.py

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -788,6 +788,11 @@ jobs:
     name: Select the affected bundles
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      # The helper is lane orchestration, while the workflow below is the exact definition GitHub
+      # loaded for this job. Keep both absolute so a later `cd` cannot silently change either.
+      MODULE_PACK_BATCH: ${{ github.workspace }}/build-logic/.github/scripts/module-pack-batch.py
+      EXECUTING_WORKFLOW: ${{ github.workspace }}/lane-definition/.github/workflows/node-repo-module-pack.yml
     outputs:
       # The matrix the pack job expands: the scope's selection, each entry annotated by the ledger
       # (`ledger.decision` build|reuse, `ledger.key`, …) when the ledger is on.
@@ -927,7 +932,32 @@ jobs:
         with:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
-          path: meshweaver
+          path: build-logic
+      # A reusable workflow's `github` context belongs to its CALLER. The job context is the
+      # identity of the reusable workflow that actually defines this job. Read the whole context
+      # here because actionlint 1.7.7 predates the workflow_* members and rejects direct property
+      # syntax; the runtime fields are then validated before they can become checkout inputs.
+      - name: Resolve the exact reusable workflow that defines this job
+        id: workflow
+        env:
+          JOB_CONTEXT: ${{ toJSON(job) }}
+        run: |
+          set -euo pipefail
+          repository="$(jq -r '.workflow_repository // empty' <<< "$JOB_CONTEXT")"
+          sha="$(jq -r '.workflow_sha // empty' <<< "$JOB_CONTEXT")"
+          [[ "$repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || { echo "::error::job.workflow_repository is absent or invalid ('$repository')"; exit 1; }
+          [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::job.workflow_sha is absent or invalid ('$sha')"; exit 1; }
+          echo "repository=$repository" >> "$GITHUB_OUTPUT"
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      # The next step also verifies HEAD against the resolved job.workflow_sha before trusting the
+      # file as structural evidence, so neither build-logic-ref nor a moving @main can substitute.
+      - name: Check out the exact reusable workflow that defines this job
+        uses: actions/checkout@v7
+        with:
+          repository: ${{ steps.workflow.outputs.repository }}
+          ref: ${{ steps.workflow.outputs.sha }}
+          path: lane-definition
+          sparse-checkout: .github/workflows
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -937,20 +967,23 @@ jobs:
       - name: The selection can say no (self-test)
         env:
           BUILD_LOGIC_REF: ${{ inputs.build-logic-ref }}
+          JOB_WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
         run: |
           set -euo pipefail
           if [ -n "$BUILD_LOGIC_REF" ]; then
             [[ "$BUILD_LOGIC_REF" =~ ^[0-9a-f]{40}$ ]] || { echo '::error::build-logic-ref must be an immutable SHA'; exit 1; }
           fi
-          python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
+          actual_workflow_sha="$(git -C lane-definition rev-parse HEAD)"
+          [ "$actual_workflow_sha" = "$JOB_WORKFLOW_SHA" ] || { echo "::error::the workflow-definition checkout resolved '$actual_workflow_sha', but GitHub says this job is defined by '$JOB_WORKFLOW_SHA'"; exit 1; }
+          python3 build-logic/.github/scripts/node-repo-scope.py --self-test
           if [ -n "$BUILD_LOGIC_REF" ]; then
-            python3 meshweaver/.github/scripts/node-repo-publication-base.py --self-test
-            python3 meshweaver/.github/scripts/node-repo-publication-reuse.py --self-test
+            python3 build-logic/.github/scripts/node-repo-publication-base.py --self-test
+            python3 build-logic/.github/scripts/node-repo-publication-reuse.py --self-test
           fi
-          python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
-          python3 meshweaver/.github/scripts/module-build-key.py --self-test
-          python3 meshweaver/.github/scripts/module-build-ledger.py --self-test
-          python3 meshweaver/.github/scripts/module-pack-batch.py --self-test
+          python3 build-logic/.github/scripts/node-repo-pack-verify.py --self-test
+          python3 build-logic/.github/scripts/module-build-key.py --self-test
+          python3 build-logic/.github/scripts/module-build-ledger.py --self-test
+          python3 "$MODULE_PACK_BATCH" --self-test --workflow "$EXECUTING_WORKFLOW"
       - name: Decide which module bundles this diff can reach
         id: scope
         env:
@@ -979,7 +1012,7 @@ jobs:
           if [ -n "$BUILD_LOGIC_REF" ] && [[ "$PUBLICATION_RUN" =~ ^[0-9]+$ ]] && [[ "$PUBLICATION_BASE" =~ ^[0-9a-f]{40}$ ]]; then
             publication_args=(--publication-base "$PUBLICATION_BASE")
           fi
-          python3 meshweaver/.github/scripts/node-repo-scope.py \
+          python3 build-logic/.github/scripts/node-repo-scope.py \
             --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
             --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" \
             "${publication_args[@]}" > "$RUNNER_TEMP/scope.json"
@@ -1034,14 +1067,14 @@ jobs:
                 exit 0
               fi
               echo "module build ledger: REQUIRED — keying $COUNT selected module(s) against $MW_LEDGER_URL"
-              python3 meshweaver/.github/scripts/module-build-key.py --root repo \
+              python3 build-logic/.github/scripts/module-build-key.py --root repo \
                 --modules "@$RUNNER_TEMP/selection.json" \
                 --tester-digest "$TESTER_DIGEST" --platform-digest "$PLATFORM_DIGEST" --platform-ref "$PLATFORM_REF" \
                 > "$RUNNER_TEMP/keys.json"
               # Waits at most 40 of this job's 45 minutes on a live holder; a holder still busy then is
               # built anyway (a duplicate build, flagged), never a red. Exit 1 ONLY for a key the same
               # inputs already compiled RED elsewhere — that is a verdict, not the ledger's outage.
-              python3 meshweaver/.github/scripts/module-build-ledger.py decide \
+              python3 build-logic/.github/scripts/module-build-ledger.py decide \
                 --keys "@$RUNNER_TEMP/keys.json" --matrix "@$RUNNER_TEMP/selection.json" \
                 --publish "$PUBLISH" --lane "$MW_LEDGER_LANE" --wait-max 2400 --poll 30 \
                 --out-matrix "$RUNNER_TEMP/matrix.out.json" --out-build "$RUNNER_TEMP/build.out.json"
@@ -1069,7 +1102,7 @@ jobs:
             echo "build=$BUILD" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          python3 meshweaver/.github/scripts/node-repo-publication-reuse.py \
+          python3 build-logic/.github/scripts/node-repo-publication-reuse.py \
             --matrix "$MATRIX" --run "$PUBLICATION_RUN" --sha "$PUBLICATION_BASE"
 
       # ───────────── WHICH OF THE SELECTION STILL OWES A TEST RUN ─────────────
@@ -1113,10 +1146,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "pack legs:"
-          python3 meshweaver/.github/scripts/module-pack-batch.py chunk \
+          python3 "$MODULE_PACK_BATCH" chunk \
             --modules "@$RUNNER_TEMP/final.json" --size "$BATCH_SIZE" --github-output "$GITHUB_OUTPUT"
           echo "tests legs:"
-          python3 meshweaver/.github/scripts/module-pack-batch.py chunk \
+          python3 "$MODULE_PACK_BATCH" chunk \
             --modules "@$RUNNER_TEMP/suites.json" --size "$BATCH_SIZE" --github-output "$GITHUB_OUTPUT" --prefix test-
           {
             echo "### Batched legs"

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -935,7 +935,7 @@ jobs:
           path: build-logic
       # A reusable workflow's `github` context belongs to its CALLER. The job context is the
       # identity of the reusable workflow that actually defines this job. Read the whole context
-      # here because actionlint 1.7.7 predates the workflow_* members and rejects direct property
+      # here because actionlint 1.7.x predates the workflow_* members and rejects direct property
       # syntax; the runtime fields are then validated before they can become checkout inputs.
       - name: Resolve the exact reusable workflow that defines this job
         id: workflow

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -625,9 +625,10 @@ on:
         default: install
       build-logic-ref:
         description: >
-          Optional immutable core SHA for selection scripts. Separate from platform-ref, which
-          selects the framework source the tests build. Set it to opt into publication baseline
-          and dependency reuse; existing callers retain their platform-ref selector.
+          Optional immutable core SHA for lane orchestration scripts. Separate from platform-ref,
+          which selects the framework source the modules and tests build against. Set it to opt
+          into publication baseline, dependency reuse and newer lane helpers; existing callers
+          fall back to platform-ref.
         required: false
         type: string
         default: ''
@@ -917,10 +918,11 @@ jobs:
           # shallow clone would make every range unresolvable — which the scope script turns into
           # a FULL pack rather than an empty one, but silently paying for 29 jobs is not the plan.
           fetch-depth: 0
-      # The scope script is the PLATFORM's (one implementation, every repo), read from the same
-      # checkout the pack jobs make at platform-ref — so a workflow newer than the checkout can
-      # never call a script the checkout does not have (run 33073476996's exact failure).
-      - name: Check out Systemorph/MeshWeaver at the pinned ref
+      # The scope scripts are the LANE'S tooling (one implementation, every repo), independently
+      # pinned from the framework source modules compile against. Pack/tests use the same resolved
+      # build-logic ref for their batching helper; an older released platform cannot make a newer
+      # reusable lane call a script that does not exist (Plugins run 34706516117).
+      - name: Check out Systemorph/MeshWeaver at the build-logic ref
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
@@ -1747,6 +1749,9 @@ jobs:
       # The self-hosted runner is non-root: setup-dotnet cannot write /usr/share/dotnet there.
       # EMPTY on ubuntu-latest, which setup-dotnet reads as unset — the default path is unchanged.
       DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
+      # Workflow orchestration belongs to build-logic-ref. The platform checkout below is the
+      # framework source/tests compile against and can deliberately predate this lane's scripts.
+      MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py
     # Inherit the caller's least-privilege map; declaring OIDC here rejects basic-auth callers at
     # graph creation time, before this job's `acr-login` mode can choose its conditional steps.
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
@@ -1808,6 +1813,13 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      - name: Check out the batching helper at the build-logic ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
+          path: build-logic
+          sparse-checkout: .github/scripts
       # ───────────── THIS LEG'S MODULES — enumerated once, from the matrix batch ─────────────
       # The state file every step below drives; `init` refuses an empty or duplicated batch. The
       # module list is printed here so a leg's log opens with what it owns.
@@ -1824,7 +1836,7 @@ jobs:
           # and writes it through module-pack-batch.py; exported ONCE, here, so no step can point
           # at another file (a job-level `env:` cannot read `runner.temp`).
           echo "BATCH_STATE=$RUNNER_TEMP/batch/state.json" >> "$GITHUB_ENV"
-          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
+          python3 "$MODULE_PACK_BATCH" --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
       # ═══════ THE .NET SDK — INSTALLED BECAUSE SOMETHING DECLARED IT, NOT BY REFLEX ═══════
       # 🚨 "make installing dotnet sdk a feature flag" (maintainer, 2026-08-31). The rationale and
       # the anti-trapdoor argument are at the top of this file, under "The .NET SDK is a DECLARED
@@ -1841,7 +1853,7 @@ jobs:
           POLICY: ${{ inputs.dotnet-sdk }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           # EVERY consumer this job would hand to a runner SDK, named one by one and evaluated
           # against every entry of the batch — not a summary, an inventory. `build: container`
           # (MeshWeaver#2854) removes the COMPILER from it and NOTHING ELSE: the container path
@@ -1936,7 +1948,7 @@ jobs:
           PLATFORM_VERSION: ${{ needs.prepare.outputs.platform-version }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok)
           for MODULE in "${modules[@]}"; do
             PACKAGE="$(bk get --module "$MODULE" package)"
@@ -2005,7 +2017,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok)
           for MODULE in "${modules[@]}"; do
             ENTRY_LEDGER="$(bk get --module "$MODULE" ledger --default null)"
@@ -2266,7 +2278,7 @@ jobs:
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where decision=build)
           [ "${#modules[@]}" -gt 0 ] || echo "no module in this batch is built here — every one is reused from the ledger, or failed before this step (see above)"
           for MODULE in "${modules[@]}"; do
@@ -2448,7 +2460,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where decision=reuse)
           [ "${#modules[@]}" -gt 0 ] || echo "no module in this batch is reused from the ledger"
           for MODULE in "${modules[@]}"; do
@@ -2513,7 +2525,7 @@ jobs:
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where decision=build)
           [ "${#modules[@]}" -gt 0 ] || { echo "nothing to pack in this batch"; exit 0; }
           own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src" ${PLATFORM_APP:+"$PLATFORM_APP"})"
@@ -2643,7 +2655,7 @@ jobs:
           PLATFORM_APP: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.app || '' }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where decision=build)
           [ "${#modules[@]}" -gt 0 ] || { echo "nothing to inspect in this batch"; exit 0; }
           # ONE script computes the set for the pack AND for this check — and with $PLATFORM_APP it
@@ -2764,7 +2776,7 @@ jobs:
         id: bundles
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           echo "paths=$(bk paths bundle)" >> "$GITHUB_OUTPUT"
           bk slots --max 10 --where 'bundle!=' --github-output "$GITHUB_OUTPUT"
 
@@ -2869,7 +2881,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where decision=build --where 'key!=' --where 'bundle!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" key)"
@@ -2915,7 +2927,7 @@ jobs:
           LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/built"
           [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no marker of this leg could be attributed to this call and the verifier would refuse it anyway. Failing here, where it is readable."; exit 1; }
           any=false
@@ -3007,7 +3019,7 @@ jobs:
           DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           evidence=false
           mapfile -t modules < <(bk list --ok --where need_test=true)
           for MODULE in "${modules[@]}"; do
@@ -3061,7 +3073,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where tested=true --where 'key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" key)"
@@ -3100,7 +3112,7 @@ jobs:
           TRUNK: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           [ -z "$CONTENT_REPOSITORY" ] || { echo "::error::publish-newest-only reads THIS repository's trunk, but content-repository is '$CONTENT_REPOSITORY' — a lane packing another repository's content cannot say whether a newer commit of it exists. Turn one of the two off."; exit 1; }
           [ -n "$TRUNK" ] || { echo "::error::the event carries no default branch, so the trunk tip cannot be read — and 'cannot tell' must never publish as 'nothing newer'."; exit 1; }
           git fetch --no-tags --depth=1 origin "+refs/heads/$TRUNK:refs/remotes/origin/$TRUNK"
@@ -3172,7 +3184,7 @@ jobs:
           BUNDLES: ${{ steps.bundles.outputs.paths }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           if [ -z "${TOKEN:-}" ]; then
             echo "::error::publish was requested but no publish-token secret was provided — the registry would never receive this batch's modules, and this job would have reported success"
             exit 1
@@ -3236,7 +3248,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where published=true --where 'key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" key)"
@@ -3276,7 +3288,7 @@ jobs:
           BUNDLES: ${{ steps.bundles.outputs.paths }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/staged"
           [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no staged publication of this leg could be attributed to this call and the publication lane would refuse it anyway. Failing here, where it is readable."; exit 1; }
           any=false
@@ -3367,7 +3379,7 @@ jobs:
           BUNDLES: ${{ steps.bundles.outputs.paths }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/receipts"
           [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no receipt of this leg could be attributed to this call."; exit 1; }
           any=false
@@ -3479,8 +3491,8 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -uo pipefail
-          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || { echo "the leg stopped before its modules were enumerated — no claim of this leg to record against"; exit 0; }
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f "$MODULE_PACK_BATCH" ] || { echo "the leg stopped before its modules were enumerated — no claim of this leg to record against"; exit 0; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           run="$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID"
           record() {
             local MODULE="$1" phase="$2" note="$3" key trx
@@ -3513,8 +3525,8 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -uo pipefail
-          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || exit 0
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f "$MODULE_PACK_BATCH" ] || exit 0
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           for MODULE in $(bk list --where 'key!='); do
             python3 meshweaver/.github/scripts/module-build-ledger.py release --key "$(bk get --module "$MODULE" key)" || true
           done
@@ -3529,7 +3541,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           for MODULE in $(bk list --ok --where 'key!='); do
             python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$(bk get --module "$MODULE" key)"
           done
@@ -3543,7 +3555,7 @@ jobs:
       - name: Every module of this batch has its verdict
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
+          python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
 
   # ════════ THE MODULE SUITES — A LANE OF THEIR OWN ON A NON-PUBLISHING RUN ════════
   # 🚨 THE MEASUREMENT THIS JOB EXISTS FOR (MeshWeaver.Plugins run 33656010754, a 39-minute PR):
@@ -3619,6 +3631,9 @@ jobs:
       # The self-hosted runner is non-root: setup-dotnet cannot write /usr/share/dotnet there.
       # EMPTY on ubuntu-latest, which setup-dotnet reads as unset — the default path is unchanged.
       DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
+      # Keep the orchestration helper on the lane/tooling axis; meshweaver remains the platform
+      # source axis used by dotnet test below.
+      MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py
     strategy:
       # One leg's red suite must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false
@@ -3659,6 +3674,13 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      - name: Check out the batching helper at the build-logic ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
+          path: build-logic
+          sparse-checkout: .github/scripts
       - name: This leg's modules
         env:
           BATCH: ${{ toJSON(matrix.batch) }}
@@ -3671,7 +3693,7 @@ jobs:
           # and writes it through module-pack-batch.py; exported ONCE, here, so no step can point
           # at another file (a job-level `env:` cannot read `runner.temp`).
           echo "BATCH_STATE=$RUNNER_TEMP/batch/state.json" >> "$GITHUB_ENV"
-          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
+          python3 "$MODULE_PACK_BATCH" --state "$RUNNER_TEMP/batch/state.json" init --batch "@$RUNNER_TEMP/batch/batch.json"
       # 🚨 UNCONDITIONAL, and the log says why. `dotnet-sdk: by-declaration` exists so a job that
       # compiles nothing on the runner stops installing an SDK by reflex — but this job's ONLY
       # work is `dotnet test`, a verb the platform image's build-project does not have at all. So
@@ -3704,7 +3726,7 @@ jobs:
           DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           evidence=false
           mapfile -t modules < <(bk list --ok)
           for MODULE in "${modules[@]}"; do
@@ -3755,7 +3777,7 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mapfile -t modules < <(bk list --ok --where tested=true --where 'ledger.key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" ledger.key)"
@@ -3786,7 +3808,7 @@ jobs:
           LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           mkdir -p "$RUNNER_TEMP/test-receipts"
           [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so no receipt of this leg could be attributed to this call and the verifier would refuse it anyway."; exit 1; }
           any=false
@@ -3822,8 +3844,8 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -uo pipefail
-          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f meshweaver/.github/scripts/module-pack-batch.py ] || { echo "the leg stopped before its modules were enumerated — nothing to record"; exit 0; }
-          bk() { python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" "$@"; }
+          [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f "$MODULE_PACK_BATCH" ] || { echo "the leg stopped before its modules were enumerated — nothing to record"; exit 0; }
+          bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           record() {
             local MODULE="$1" note="$2" key trx
             key="$(bk get --module "$MODULE" ledger.key)"
@@ -3848,7 +3870,7 @@ jobs:
       - name: Every module of this batch has its verdict
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/module-pack-batch.py --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
+          python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" verdict --summary "$GITHUB_STEP_SUMMARY"
 
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════
   # 🚨 A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -627,8 +627,10 @@ on:
         description: >
           Optional immutable core SHA for lane orchestration scripts. Separate from platform-ref,
           which selects the framework source the modules and tests build against. Set it to opt
-          into publication baseline and dependency reuse. When absent, tooling comes from the exact
-          reusable-workflow SHA GitHub loaded — never from an independently older platform ref.
+          into publication baseline and dependency reuse. The SHA must carry the same tooling
+          contract as the loaded reusable workflow; select checks that contract before it makes a
+          build decision. When absent, tooling comes from the exact reusable-workflow SHA GitHub
+          loaded — never from an independently older platform ref.
         required: false
         type: string
         default: ''
@@ -979,6 +981,10 @@ jobs:
           fi
           actual_workflow_sha="$(git -C lane-definition rev-parse HEAD)"
           [ "$actual_workflow_sha" = "$JOB_WORKFLOW_SHA" ] || { echo "::error::the workflow-definition checkout resolved '$actual_workflow_sha', but GitHub says this job is defined by '$JOB_WORKFLOW_SHA'"; exit 1; }
+          [ -f "$MODULE_PACK_BATCH" ] || { echo "::error::the resolved build-logic ref carries no .github/scripts/module-pack-batch.py. This workflow requires that helper; when build-logic-ref is explicit, move it to a commit compatible with the loaded reusable workflow."; exit 1; }
+          helper_help="$RUNNER_TEMP/module-pack-batch-help.txt"
+          python3 "$MODULE_PACK_BATCH" --help > "$helper_help"
+          grep -q -- '--workflow' "$helper_help" || { echo "::error::the resolved build-logic ref carries a module-pack-batch.py without the required --workflow contract. This workflow validates the exact YAML GitHub loaded; move an explicit build-logic-ref to a compatible commit, or omit it to use job.workflow_sha."; exit 1; }
           python3 build-logic/.github/scripts/node-repo-scope.py --self-test
           if [ -n "$BUILD_LOGIC_REF" ]; then
             python3 build-logic/.github/scripts/node-repo-publication-base.py --self-test
@@ -1208,6 +1214,13 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      - name: Check out the lane tools at the build-logic ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ needs.select.outputs.build-logic-ref }}
+          path: build-logic
+          sparse-checkout: .github/scripts
       - name: Restore the module-pack tool (per-platform-pin cache)
         if: needs.select.outputs.build-modules != '[]'
         id: tool-cache
@@ -1280,7 +1293,7 @@ jobs:
           && (steps.image-cache.outputs.cache-hit != 'true'
               || steps.refs-cache.outputs.cache-hit != 'true'
               || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
-        run: bash meshweaver/.github/scripts/acr-login.sh
+        run: bash build-logic/.github/scripts/acr-login.sh
       - name: Fill whichever cache is cold — the run's ONE trip to the registry
         if: >-
           inputs.platform-image-digest != ''
@@ -1502,13 +1515,16 @@ jobs:
           repository: ${{ inputs.content-repository || github.repository }}
           ref: ${{ inputs.content-ref || github.sha }}
           token: ${{ steps.content-token.outputs.token || github.token }}
-      - name: Check out the ACR login helper
+      # The registry helper is lane orchestration too, but the global compiler mounts the whole
+      # workspace as its source tree. Fetch this one pre-build helper into a disposable path, then
+      # remove it before the mount; the durable tools checkout lands after the build below.
+      - name: Check out the ACR login helper at the build-logic ref
         if: inputs.acr-login == 'oidc'
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
-          path: meshweaver
+          ref: ${{ needs.select.outputs.build-logic-ref }}
+          path: build-logic-login
           sparse-checkout: .github/scripts/acr-login.sh
       - name: Restore the platform image tarball (per-digest cache)
         if: ${{ inputs.platform-image-digest != '' }}
@@ -1539,7 +1555,10 @@ jobs:
           inputs.acr-login == 'oidc'
           && ((inputs.platform-image-digest != '' && steps.image-cache.outputs.cache-hit != 'true')
               || (inputs.tester-image-digest != '' && steps.tester-cache.outputs.cache-hit != 'true'))
-        run: bash meshweaver/.github/scripts/acr-login.sh
+        run: bash build-logic-login/.github/scripts/acr-login.sh
+      - name: Keep lane tooling out of the global compiler's source mount
+        if: inputs.acr-login == 'oidc'
+        run: rm -rf build-logic-login
       # 🚨 `build-modules`, not `modules`: the ledger handed some entries a reusable bundle, and those
       # are NOT compiled here. The postcondition below is fed the SAME list — one enumerator.
       - name: Build every selected container entry in ONE workspace
@@ -1663,17 +1682,19 @@ jobs:
             --entrypoint dotnet "$img" \
             /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out --bind-to-image ${accepts[@]+"${accepts[@]}"} ${superseded[@]+"${superseded[@]}"} 2>&1 | tee "$out/workspace-build.log"
           echo "built=true" >> "$GITHUB_OUTPUT"
-      # 🚨 THE PLATFORM CHECKOUT LANDS **AFTER** THE BUILD, ON PURPOSE. This job mounts
+      # 🚨 THE TOOLING CHECKOUT LANDS **AFTER** THE BUILD, ON PURPOSE. This job mounts
       # `$GITHUB_WORKSPACE` at `/repo:ro` for the container build, so anything checked out beside
-      # the content tree BEFORE that line is inside what the builder sees. The pack job checks
-      # core out at `path: meshweaver` up front because it has no such mount; here the order is
-      # inverted so the compile input stays exactly the content repository and nothing else.
-      - name: Check out Systemorph/MeshWeaver at the pinned ref
+      # the content tree before that line becomes compiler input. `always()` makes the ledger's
+      # failure writer available when the global build itself fails; the checkout is tooling only,
+      # because this job's platform is the digest-pinned image above.
+      - name: Check out the lane tools at the build-logic ref
+        if: always()
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
-          path: meshweaver
+          ref: ${{ needs.select.outputs.build-logic-ref }}
+          path: build-logic
+          sparse-checkout: .github/scripts
       # ───────────── THE BUILD ASSERTS ITS OWN POSTCONDITION (Plugins#1051) ─────────────
       # A green here used to mean "the compiler did not throw" and was read as "the selected set
       # was emitted". Those are different claims, and the gap between them surfaced N JOBS LATER:
@@ -1697,9 +1718,9 @@ jobs:
           MODULES: ${{ needs.select.outputs.build-modules }}
         run: |
           set -euo pipefail
-          python3 meshweaver/.github/scripts/workspace-build-verify.py --self-test
+          python3 build-logic/.github/scripts/workspace-build-verify.py --self-test
           printf '%s' "$MODULES" > "$RUNNER_TEMP/selection.json"
-          python3 meshweaver/.github/scripts/workspace-build-verify.py \
+          python3 build-logic/.github/scripts/workspace-build-verify.py \
             --modules "@$RUNNER_TEMP/selection.json" \
             --output "$RUNNER_TEMP/module-build"
       # ───────── THE LEDGER HEARS ABOUT THIS JOB — a heartbeat on success, the verdict on failure ─────────
@@ -1720,7 +1741,7 @@ jobs:
           set -euo pipefail
           while IFS= read -r key; do
             [ -n "$key" ] || continue
-            python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
+            python3 build-logic/.github/scripts/module-build-ledger.py heartbeat --key "$key"
           done < <(jq -r '.[] | select(.build == "container") | .ledger.key // empty' <<< "$MODULES")
       - name: Ledger — record the compile verdict of a failed workspace
         if: failure() && inputs.ledger == 'required'
@@ -1743,7 +1764,7 @@ jobs:
             else
               { echo "the one-workspace build failed before this module's verdict; log tail:"; tail -40 "$log" 2>/dev/null; } > "$evidence"
             fi
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" --failure-file "$evidence" || true
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" --failure-file "$evidence" || true
           done < <(jq -r '.[] | select(.build == "container") | select(.ledger.key != null) | [.module, .project, .ledger.key] | @tsv' <<< "$MODULES")
       - name: Hand the workspace to the matrix
         if: steps.build.outputs.built == 'true'
@@ -2083,7 +2104,7 @@ jobs:
                   echo "plan: REUSE $MODULE from run $art_run ($art_name, sha256 ${sha:-unrecorded}; holder $holder) — tests: $need_test, publish: $need_publish"
                 else
                   echo "plan: BUILD $MODULE (ledger key ${key:-<none>}; $(jq -r 'if .unavailable then "WITHOUT coordination: " + .unavailable else "attempt " + (.attempts|tostring) end' <<< "$ENTRY_LEDGER")) — tests: $need_test, publish: $need_publish"
-                  [ -z "$key" ] || python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
+                  [ -z "$key" ] || python3 build-logic/.github/scripts/module-build-ledger.py heartbeat --key "$key"
                 fi
               else
                 echo "plan: BUILD $MODULE (ledger off) — tests: $need_test, publish: $need_publish"
@@ -2926,7 +2947,7 @@ jobs:
             VERSION="$(bk get --module "$MODULE" version)"
             set +e
             ( set -euo pipefail
-              python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Built \
+              python3 build-logic/.github/scripts/module-build-ledger.py record --key "$KEY" --status Built \
                 --bundle "$BUNDLE" --artifact-name "module-bundle-$MODULE" --retention-days 7 \
                 --version "$VERSION" ${PLATFORM_IDENTITY:+--platform-identity "$PLATFORM_IDENTITY"}
             )
@@ -3114,7 +3135,7 @@ jobs:
           mapfile -t modules < <(bk list --ok --where tested=true --where 'key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" key)"
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
               || bk fail --module "$MODULE" --phase test --reason "the ledger refused the Tested record (see above)"
           done
 
@@ -3173,7 +3194,7 @@ jobs:
                 mkdir -p "$RUNNER_TEMP/mods/$MODULE"
                 bk get --module "$MODULE" entry --default '{}' | jq '[.]' > "$RUNNER_TEMP/mods/$MODULE/newer-entry.json"
                 GITHUB_OUTPUT="$RUNNER_TEMP/mods/$MODULE/newer-scope.out" GITHUB_STEP_SUMMARY=/dev/null \
-                  python3 meshweaver/.github/scripts/node-repo-scope.py --for modules --root . \
+                  python3 build-logic/.github/scripts/node-repo-scope.py --for modules --root . \
                     --modules "@$RUNNER_TEMP/mods/$MODULE/newer-entry.json" --event pull_request \
                     --changed-list "$changed" > "$RUNNER_TEMP/mods/$MODULE/newer-scope.json"
                 if [ "$(jq -r '.count' "$RUNNER_TEMP/mods/$MODULE/newer-scope.json")" != "0" ]; then
@@ -3289,7 +3310,7 @@ jobs:
           mapfile -t modules < <(bk list --ok --where published=true --where 'key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" key)"
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published \
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published \
               || bk fail --module "$MODULE" --phase publish --reason "the ledger refused the Published record (see above)"
           done
 
@@ -3541,7 +3562,7 @@ jobs:
             trx="$RUNNER_TEMP/trx/$MODULE/ledger.trx"
             trxarg=()
             if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" \
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" \
               --failure-file "$RUNNER_TEMP/mods/$MODULE/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
           }
           for MODULE in $(bk list --failed); do
@@ -3565,7 +3586,7 @@ jobs:
           [ -n "${BATCH_STATE:-}" ] && [ -f "$BATCH_STATE" ] && [ -f "$MODULE_PACK_BATCH" ] || exit 0
           bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           for MODULE in $(bk list --where 'key!='); do
-            python3 meshweaver/.github/scripts/module-build-ledger.py release --key "$(bk get --module "$MODULE" key)" || true
+            python3 build-logic/.github/scripts/module-build-ledger.py release --key "$(bk get --module "$MODULE" key)" || true
           done
       # The leg is over for the modules still in play: a record left at Built/Tested (no publish on
       # this event) is marked finished so a follower stops waiting for a publish that will never
@@ -3580,7 +3601,7 @@ jobs:
           set -euo pipefail
           bk() { python3 "$MODULE_PACK_BATCH" --state "$BATCH_STATE" "$@"; }
           for MODULE in $(bk list --ok --where 'key!='); do
-            python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$(bk get --module "$MODULE" key)"
+            python3 build-logic/.github/scripts/module-build-ledger.py finish --key "$(bk get --module "$MODULE" key)"
           done
 
       # ─────────────────────────── THE VERDICT — one line per module, LAST ───────────────────────────
@@ -3818,7 +3839,7 @@ jobs:
           mapfile -t modules < <(bk list --ok --where tested=true --where 'ledger.key!=')
           for MODULE in "${modules[@]}"; do
             KEY="$(bk get --module "$MODULE" ledger.key)"
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/$MODULE/ledger.trx" \
               || bk fail --module "$MODULE" --phase test --reason "the ledger refused the Tested record (see above)"
           done
       - name: Upload the failing suites' evidence
@@ -3892,7 +3913,7 @@ jobs:
             trx="$RUNNER_TEMP/trx/$MODULE/ledger.trx"
             trxarg=()
             if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
-            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase test \
+            python3 build-logic/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase test \
               --failure-file "$RUNNER_TEMP/mods/$MODULE/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
           }
           for MODULE in $(bk list --failed); do
@@ -3939,12 +3960,14 @@ jobs:
     outputs:
       bundles-built: ${{ steps.verify.outputs.bundles_built }}
     steps:
-      - name: Check out Systemorph/MeshWeaver at the pinned ref
+      - name: Check out the verifier at the build-logic ref
+        if: needs.select.result == 'success'
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.platform-ref }}
-          path: meshweaver
+          ref: ${{ needs.select.outputs.build-logic-ref }}
+          path: build-logic
+          sparse-checkout: .github/scripts
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
@@ -4040,7 +4063,7 @@ jobs:
           # by module name; `--lane` separates them by the stamp the producer wrote, so a marker
           # or receipt this call cannot attribute to itself is set aside and NAMED, and a
           # SELECTED module left without one reads as not built.
-          python3 meshweaver/.github/scripts/node-repo-pack-verify.py \
+          python3 build-logic/.github/scripts/node-repo-pack-verify.py \
             --expected "$EXPECTED" \
             --receipts "$RUNNER_TEMP/receipts" \
             --pack-result "$PACK_RESULT" \

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -627,8 +627,8 @@ on:
         description: >
           Optional immutable core SHA for lane orchestration scripts. Separate from platform-ref,
           which selects the framework source the modules and tests build against. Set it to opt
-          into publication baseline, dependency reuse and newer lane helpers; existing callers
-          fall back to platform-ref.
+          into publication baseline and dependency reuse. When absent, tooling comes from the exact
+          reusable-workflow SHA GitHub loaded — never from an independently older platform ref.
         required: false
         type: string
         default: ''
@@ -817,6 +817,9 @@ jobs:
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
       lane: ${{ steps.lane.outputs.id }}
+      # One concrete tooling identity for every downstream job. An explicit input wins; otherwise
+      # use the exact reusable-workflow commit resolved from the job context below.
+      build-logic-ref: ${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}
       # The matrix as GIVEN, for the workflow's `declared` output — never the selection above, which a
       # narrowed run shrinks; the publication lane's set-aside check needs the whole catalog.
       declared: ${{ inputs.modules }}
@@ -923,16 +926,6 @@ jobs:
           # shallow clone would make every range unresolvable — which the scope script turns into
           # a FULL pack rather than an empty one, but silently paying for 29 jobs is not the plan.
           fetch-depth: 0
-      # The scope scripts are the LANE'S tooling (one implementation, every repo), independently
-      # pinned from the framework source modules compile against. Pack/tests use the same resolved
-      # build-logic ref for their batching helper; an older released platform cannot make a newer
-      # reusable lane call a script that does not exist (Plugins run 34706516117).
-      - name: Check out Systemorph/MeshWeaver at the build-logic ref
-        uses: actions/checkout@v7
-        with:
-          repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
-          path: build-logic
       # A reusable workflow's `github` context belongs to its CALLER. The job context is the
       # identity of the reusable workflow that actually defines this job. Read the whole context
       # here because actionlint 1.7.x predates the workflow_* members and rejects direct property
@@ -949,6 +942,17 @@ jobs:
           [[ "$sha" =~ ^[0-9a-f]{40}$ ]] || { echo "::error::job.workflow_sha is absent or invalid ('$sha')"; exit 1; }
           echo "repository=$repository" >> "$GITHUB_OUTPUT"
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
+      # The scope scripts are the LANE'S tooling (one implementation, every repo), independently
+      # pinned from the framework source modules compile against. Pack/tests use this same resolved
+      # ref. If the caller does not supply one, the exact loaded workflow SHA is the only safe
+      # default: an older released platform cannot supply a newer lane's scripts (Plugins run
+      # 34706516117).
+      - name: Check out Systemorph/MeshWeaver at the build-logic ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.build-logic-ref || steps.workflow.outputs.sha }}
+          path: build-logic
       # The next step also verifies HEAD against the resolved job.workflow_sha before trusting the
       # file as structural evidence, so neither build-logic-ref nor a moving @main can substitute.
       - name: Check out the exact reusable workflow that defines this job
@@ -1850,7 +1854,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
+          ref: ${{ needs.select.outputs.build-logic-ref }}
           path: build-logic
           sparse-checkout: .github/scripts
       # ───────────── THIS LEG'S MODULES — enumerated once, from the matrix batch ─────────────
@@ -3711,7 +3715,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver
-          ref: ${{ inputs.build-logic-ref || inputs.platform-ref }}
+          ref: ${{ needs.select.outputs.build-logic-ref }}
           path: build-logic
           sparse-checkout: .github/scripts
       - name: This leg's modules

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1751,7 +1751,7 @@ jobs:
       DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
       # Workflow orchestration belongs to build-logic-ref. The platform checkout below is the
       # framework source/tests compile against and can deliberately predate this lane's scripts.
-      MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py
+      MODULE_PACK_BATCH: ${{ github.workspace }}/build-logic/.github/scripts/module-pack-batch.py
     # Inherit the caller's least-privilege map; declaring OIDC here rejects basic-auth callers at
     # graph creation time, before this job's `acr-login` mode can choose its conditional steps.
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
@@ -3633,7 +3633,7 @@ jobs:
       DOTNET_INSTALL_DIR: ${{ inputs.runner != 'ubuntu-latest' && '/home/runner/.dotnet' || '' }}
       # Keep the orchestration helper on the lane/tooling axis; meshweaver remains the platform
       # source axis used by dotnet test below.
-      MODULE_PACK_BATCH: build-logic/.github/scripts/module-pack-batch.py
+      MODULE_PACK_BATCH: ${{ github.workspace }}/build-logic/.github/scripts/module-pack-batch.py
     strategy:
       # One leg's red suite must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -134,8 +134,8 @@ which is untouched. Arithmetic for Plugins at N=6: the ~40 sub-minute pack legs 
 from ~40 billed minutes to ~7 (each batch ≈ 6 × 1.1 min of work ≈ 7 min, rounded once), and the
 per-leg checkout + SDK install is paid 7 times instead of 40.
 
-The batching helper is **lane orchestration**, so `pack` and `tests` fetch it at
-`build-logic-ref` (falling back to `platform-ref` only for callers that do not separate the two).
+The batching helper is **lane orchestration**, so `select`, `pack`, and `tests` fetch it at
+`build-logic-ref` (falling back to the exact reusable-workflow SHA when the input is absent).
 Their `meshweaver/` checkout stays at `platform-ref`, because that tree is the framework source and
 reference set the module compiles and tests against. The distinction is executable: the helper's
 self-test reads the exact reusable workflow identified by GitHub's `job.workflow_repository` and

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -134,6 +134,16 @@ which is untouched. Arithmetic for Plugins at N=6: the ~40 sub-minute pack legs 
 from ~40 billed minutes to ~7 (each batch ≈ 6 × 1.1 min of work ≈ 7 min, rounded once), and the
 per-leg checkout + SDK install is paid 7 times instead of 40.
 
+The batching helper is **lane orchestration**, so `pack` and `tests` fetch it at
+`build-logic-ref` (falling back to `platform-ref` only for callers that do not separate the two).
+Their `meshweaver/` checkout stays at `platform-ref`, because that tree is the framework source and
+reference set the module compiles and tests against. The distinction is executable: the helper's
+self-test reads the real reusable workflow and requires both checkouts in both jobs. This closes the
+2026-09-12 rollout failure in MeshWeaver.Plugins run 34706516117: the reusable workflow already
+contained batched legs, while the released platform pin `4764a607…` predated
+`module-pack-batch.py`; all seven test batches therefore stopped before running a suite. A new lane
+helper must always move on the tooling axis, independently of the platform it verifies.
+
 ### Where a module's own suite runs — and why `publish` decides
 
 A `needs:` on a `uses:` job waits for the **whole** called workflow, so anything inside the last

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -134,17 +134,28 @@ which is untouched. Arithmetic for Plugins at N=6: the ~40 sub-minute pack legs 
 from ~40 billed minutes to ~7 (each batch ≈ 6 × 1.1 min of work ≈ 7 min, rounded once), and the
 per-leg checkout + SDK install is paid 7 times instead of 40.
 
-The batching helper is **lane orchestration**, so `select`, `pack`, and `tests` fetch it at
-`build-logic-ref` (falling back to the exact reusable-workflow SHA when the input is absent).
-Their `meshweaver/` checkout stays at `platform-ref`, because that tree is the framework source and
-reference set the module compiles and tests against. The distinction is executable: the helper's
-self-test reads the exact reusable workflow identified by GitHub's `job.workflow_repository` and
-`job.workflow_sha`, verifies that checkout resolved the stated SHA, and requires the `select`,
-`pack`, and `tests` jobs to keep workflow, tooling, and platform identities separate. This closes
-the 2026-09-12 rollout failure in MeshWeaver.Plugins run 34706516117: the reusable workflow already
-contained batched legs, while the released platform pin `4764a607…` predated
-`module-pack-batch.py`; all seven test batches therefore stopped before running a suite. A new lane
-helper must always move on the tooling axis, independently of the platform it verifies.
+Every script that **operates this lane** moves with the lane: selection and newest-only scope,
+batch state, the build ledger protocol, the workspace postcondition, ACR transport, and the final
+receipt verifier. `select`, `prepare`, `build-workspace`, `pack`, `tests`, and `verify` fetch those
+clients from one resolved `build-logic-ref`, falling back to the exact reusable-workflow SHA when
+the input is absent. An explicit ref is an advanced compatibility pin: `select` requires an
+immutable SHA, verifies that its batching helper exists and supports the loaded workflow's
+`--workflow` contract, then self-tests the clients before making a build decision. It fails there
+with a migration message rather than letting an older helper fail later in a matrix job.
+
+The separate `meshweaver/` checkout stays at `platform-ref`, because that tree is the framework
+source and reference set the module compiles and tests against. Exactly two scripts deliberately
+move on that platform axis: `check-module-platform-floor.py`, whose SemVer result is parity-pinned
+to the selected runtime implementation, and `module-owned-platform.sh`, which measures the
+selected platform's shipped assembly set. The batching self-test reads the exact reusable workflow
+identified by GitHub's `job.workflow_repository` and `job.workflow_sha`, verifies that checkout
+resolved the stated SHA, and enforces that complete ownership map—including every ledger writer,
+the newest-only selector, the production verifier, and the two allowed platform clients. This
+closes the 2026-09-12 rollout failure in MeshWeaver.Plugins run 34706516117: the reusable workflow
+already contained batched legs, while the released platform pin `4764a607…` predated
+`module-pack-batch.py`; all seven test batches therefore stopped before running a suite. A lane
+helper or protocol client must always move on the tooling axis, independently of the platform it
+verifies.
 
 ### Where a module's own suite runs — and why `publish` decides
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -138,8 +138,10 @@ The batching helper is **lane orchestration**, so `pack` and `tests` fetch it at
 `build-logic-ref` (falling back to `platform-ref` only for callers that do not separate the two).
 Their `meshweaver/` checkout stays at `platform-ref`, because that tree is the framework source and
 reference set the module compiles and tests against. The distinction is executable: the helper's
-self-test reads the real reusable workflow and requires both checkouts in both jobs. This closes the
-2026-09-12 rollout failure in MeshWeaver.Plugins run 34706516117: the reusable workflow already
+self-test reads the exact reusable workflow identified by GitHub's `job.workflow_repository` and
+`job.workflow_sha`, verifies that checkout resolved the stated SHA, and requires the `select`,
+`pack`, and `tests` jobs to keep workflow, tooling, and platform identities separate. This closes
+the 2026-09-12 rollout failure in MeshWeaver.Plugins run 34706516117: the reusable workflow already
 contained batched legs, while the released platform pin `4764a607…` predated
 `module-pack-batch.py`; all seven test batches therefore stopped before running a suite. A new lane
 helper must always move on the tooling axis, independently of the platform it verifies.


### PR DESCRIPTION
## What & why

The reusable module lane was executing workflow and protocol scripts from its independently older `platform-ref`. MeshWeaver.Plugins run 34706516117 loaded the new batched workflow over platform `4764a607…`; that platform had no `module-pack-batch.py`, so all seven test batches failed before a suite ran. The same split also put ledger decisions and ledger writes on different revisions, and self-tested a different scope/verifier from the code used in production jobs.

Every lane orchestration client now comes from one resolved tooling SHA: selection, batching, ledger reads/writes/releases, workspace postcondition, ACR transport, newest-only scope, and the final receipt verifier. An explicit `build-logic-ref` wins; otherwise the exact reusable-workflow commit from `job.workflow_sha` is the default. `select` validates the exact workflow checkout and rejects an explicit tooling commit that lacks the required `--workflow` helper contract before making a build decision. `platform-ref` remains independently pinned for framework compilation and for the two platform-semantic probes: runtime-parity floor comparison and shipped-assembly measurement.

The helper's self-test enforces that complete ownership map across `select`, `prepare`, `build-workspace`, `pack`, `tests`, and `verify`, including mutations for a split ledger writer, newest-only selector, production verifier, workspace postcondition, missing compatibility preflight, and a platform-semantic probe moved to tooling.

## Merge preconditions

- [x] **(a) Build is green with warnings-as-errors** — full `dotnet build -c Release -warnaserror`, 0 warnings / 0 errors on the functional branch; the review delta changes workflow, Python guard, and docs only.
- [x] **(b) Tests are green locally** — helper self-test in explicit and fallback modes, actionlint, workflow YAML/timeout/shell guards, extracted CD decision harness, and `DocumentationLinkIntegrityTest` are green on current `main`.
- [ ] **(c) Reviewed** — fresh exact-head ruleset review pending.
- [x] **(d) Review comments dealt with** — workflow identity, fallback, ledger, newest-only scope, production verifier, and explicit-pin compatibility findings are implemented and pinned by mutation checks.

## Notes for reviewers

The architecture record includes the exact failed run, the full tooling/platform ownership map, and the explicit-pin migration behavior. The no-argument helper self-test remains only for an older loaded workflow consuming a newer helper; the current lane and core CI pass the exact workflow explicitly.

Pairs-with: none — callers receive the fix through their existing reusable-workflow resolution; no satellite workflow edit is required.
