### PR TITLE
ci(module-pack): fetch module-pack-batch.py at the lane's scripts-ref — Plugins main published nothing since #4096

### DIFF
--- a/.github/scripts/module-pack-batch.py
+++ b/.github/scripts/module-pack-batch.py
@@ -3,7 +3,9 @@
 per-module bookkeeping that keeps a batch from becoming a coupling.
 
 (The name on this first line is load-bearing: the module-pack lane fetches this file at the
-caller's `platform-ref` and its `select` job self-tests it on every run.)
+lane's `scripts-ref` — NOT out of its `platform-ref` checkout, which for an unpinned caller is the
+newest sealed set and did not have it (#4096, Plugins main 2026-09-12) — and every job that runs
+it self-tests the fetched bytes first.)
 
 WHY THIS EXISTS (measured 2026-09-05..12)
 ------------------------------------------

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -386,6 +386,18 @@ name: node-repo module pack
 # (`Module bundles`), which is untouched. A caller that wants the old one-leg-per-module shape
 # passes `batch-size: 1`. Doc: Doc/Architecture/ModuleBuildArchitecture ("The pipeline, end to
 # end", the 2026-09-12 batching note).
+#
+# 🚨 module-pack-batch.py is the LANE's script and is FETCHED at the lane's SCRIPTS ref
+# (`scripts-ref`, then `build-logic-ref`, then `platform-ref`) in `select`, `pack` and `tests` —
+# never read out of the `meshweaver/` checkout those jobs make at `platform-ref`. The checkout is
+# the PLATFORM's commit, and for an unpinned caller that is the newest SEALED set, hours behind a
+# lane called at `@main`: #4096 merged at 16:43Z on 2026-09-12 and every `pack` leg of Plugins main
+# read the script out of a checkout sealed at a7450f3aa (14:46Z) — `python3: can't open file` —
+# so Plugins published nothing until a seal carried it. This is the scripts-ref / platform-ref
+# split node-repo-gate.yml already lives by (#4095, compose-gate-host.sh). A caller of this lane
+# at `@main` passes `scripts-ref: main`. ScriptsRefFetchGuard (MeshWeaver.Documentation.Test) fails
+# any lane job that runs a `meshweaver/.github/scripts/*.py` it neither fetched at scripts-ref nor
+# lists as old enough to be in every sealed set.
 
 on:
   workflow_call:
@@ -410,6 +422,26 @@ on:
         description: The Systemorph/MeshWeaver commit the modules build against (a pin, not a branch).
         required: true
         type: string
+      scripts-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref this lane's OWN helper scripts are fetched at — today
+          `module-pack-batch.py`, the batching bookkeeping every `pack` and `tests` leg drives and
+          `select` self-tests. Same contract as node-repo-gate's `scripts-ref`: distinct from
+          `platform-ref`, which names the PLATFORM the modules build against and is, for an
+          unpinned caller, the newest SEALED set — hours behind the lane called at `@main`.
+          Empty (the default) falls back to `build-logic-ref` (this lane's existing pin for its
+          selection scripts — an immutable core SHA a caller resolves at run time) and then to
+          `platform-ref`, right for a caller that pins the lane and the platform to one commit.
+          🚨 A caller that pins NOTHING passes `main` here: on 2026-09-12 (#4096) this lane's
+          batching script landed on core main at 16:43Z, every `pack` leg of MeshWeaver.Plugins
+          main read it out of the checkout at `platform-ref` — a set sealed at a7450f3aa, two
+          hours earlier — and died with `python3: can't open file '…/module-pack-batch.py'`, so
+          Plugins published nothing until a seal carried the file. `github.job_workflow_sha` cannot
+          stand in: it is EMPTY inside a reusable called from another repository (measured
+          2026-08-30), so the lane's own ref is an input, never inferred.
+        required: false
+        type: string
+        default: ''
       publish:
         description: >
           Hand the packed bundles to the registry. TRUNK-ONLY, not push-only — a PR packs and
@@ -920,6 +952,11 @@ jobs:
       # The scope script is the PLATFORM's (one implementation, every repo), read from the same
       # checkout the pack jobs make at platform-ref — so a workflow newer than the checkout can
       # never call a script the checkout does not have (run 33073476996's exact failure).
+      # 🚨 That holds only for scripts OLDER than every platform a caller can resolve. A script
+      # added to core AFTER the newest sealed set is exactly what this checkout does not have —
+      # module-pack-batch.py, #4096, Plugins run 34707906260 — so that one is FETCHED at the
+      # lane's scripts ref two steps down, never read from here. ScriptsRefFetchGuard names the
+      # scripts allowed to be read from the checkout; a new one must be fetched.
       - name: Check out Systemorph/MeshWeaver at the pinned ref
         uses: actions/checkout@v7
         with:
@@ -929,6 +966,36 @@ jobs:
       - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      # 🚨 THE LANE'S OWN batching script, at the LANE's scripts ref — never read out of the
+      # checkout above. That checkout is the PLATFORM's commit (`platform-ref`; `select` prefers
+      # `build-logic-ref`), and for an unpinned caller the platform is the newest SEALED set, hours
+      # behind a lane called at `@main`. #4096 landed module-pack-batch.py on core main at 16:43Z
+      # on 2026-09-12; every Plugins `pack` leg then read it out of a checkout sealed at a7450f3aa
+      # (14:46Z) and died with `python3: can't open file '…/module-pack-batch.py'` — Plugins main
+      # published nothing until a seal carried the file. Same fetch shape as node-repo-gate.yml's
+      # compose-gate-host.sh (#4095): curl (the self-hosted runner ships no `gh`), the raw media
+      # type, RED by name on a miss, and the self-test right after — an unproven script is no
+      # script. Written INTO the checkout's path, so every `python3 meshweaver/.github/scripts/
+      # module-pack-batch.py` below reads the fetched bytes. ScriptsRefFetchGuard (Documentation.Test)
+      # holds this step in every job that runs the script.
+      - name: Fetch module-pack-batch.py at the lane's scripts ref
+        env:
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.build-logic-ref || inputs.platform-ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SCRIPT="meshweaver/.github/scripts/module-pack-batch.py"
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / build-logic-ref / platform-ref are all empty — module-pack-batch.py has no ref to be fetched at"; exit 1; }
+          mkdir -p "$(dirname "$SCRIPT")"
+          curl -fsSL --retry 3 --retry-delay 5 -o "$SCRIPT" \
+            -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github.raw+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL:-https://api.github.com}/repos/Systemorph/MeshWeaver/contents/.github/scripts/module-pack-batch.py?ref=${SCRIPTS_REF}" \
+            || { echo "::error::could not fetch module-pack-batch.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver. The file is read at the lane's SCRIPTS ref (inputs.scripts-ref, then build-logic-ref, then platform-ref) and a ref older than the lane does not have it — a caller of this lane at @main passes scripts-ref: main (MeshWeaver#4096: Plugins main stalled on 2026-09-12 reading it out of a sealed platform-ref)."; exit 1; }
+          [ -s "$SCRIPT" ] || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is empty"; exit 1; }
+          head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
+          python3 "$SCRIPT" --self-test
+          echo "module-pack-batch.py: fetched at ${SCRIPTS_REF} into $SCRIPT and self-tested"
       # 🚨 The selection logic owes its own proof that it can say no AND that every fallback still
       # falls back. It runs here, on every run, next to the answer it produces — a selector whose
       # self-test is only run by someone remembering to is a selector nobody checks.
@@ -1808,6 +1875,36 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      # 🚨 THE LANE'S OWN batching script, at the LANE's scripts ref — never read out of the
+      # checkout above. That checkout is the PLATFORM's commit (`platform-ref`; `select` prefers
+      # `build-logic-ref`), and for an unpinned caller the platform is the newest SEALED set, hours
+      # behind a lane called at `@main`. #4096 landed module-pack-batch.py on core main at 16:43Z
+      # on 2026-09-12; every Plugins `pack` leg then read it out of a checkout sealed at a7450f3aa
+      # (14:46Z) and died with `python3: can't open file '…/module-pack-batch.py'` — Plugins main
+      # published nothing until a seal carried the file. Same fetch shape as node-repo-gate.yml's
+      # compose-gate-host.sh (#4095): curl (the self-hosted runner ships no `gh`), the raw media
+      # type, RED by name on a miss, and the self-test right after — an unproven script is no
+      # script. Written INTO the checkout's path, so every `python3 meshweaver/.github/scripts/
+      # module-pack-batch.py` below reads the fetched bytes. ScriptsRefFetchGuard (Documentation.Test)
+      # holds this step in every job that runs the script.
+      - name: Fetch module-pack-batch.py at the lane's scripts ref
+        env:
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.build-logic-ref || inputs.platform-ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SCRIPT="meshweaver/.github/scripts/module-pack-batch.py"
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / build-logic-ref / platform-ref are all empty — module-pack-batch.py has no ref to be fetched at"; exit 1; }
+          mkdir -p "$(dirname "$SCRIPT")"
+          curl -fsSL --retry 3 --retry-delay 5 -o "$SCRIPT" \
+            -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github.raw+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL:-https://api.github.com}/repos/Systemorph/MeshWeaver/contents/.github/scripts/module-pack-batch.py?ref=${SCRIPTS_REF}" \
+            || { echo "::error::could not fetch module-pack-batch.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver. The file is read at the lane's SCRIPTS ref (inputs.scripts-ref, then build-logic-ref, then platform-ref) and a ref older than the lane does not have it — a caller of this lane at @main passes scripts-ref: main (MeshWeaver#4096: Plugins main stalled on 2026-09-12 reading it out of a sealed platform-ref)."; exit 1; }
+          [ -s "$SCRIPT" ] || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is empty"; exit 1; }
+          head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
+          python3 "$SCRIPT" --self-test
+          echo "module-pack-batch.py: fetched at ${SCRIPTS_REF} into $SCRIPT and self-tested"
       # ───────────── THIS LEG'S MODULES — enumerated once, from the matrix batch ─────────────
       # The state file every step below drives; `init` refuses an empty or duplicated batch. The
       # module list is printed here so a leg's log opens with what it owns.
@@ -3659,6 +3756,36 @@ jobs:
           repository: Systemorph/MeshWeaver
           ref: ${{ inputs.platform-ref }}
           path: meshweaver
+      # 🚨 THE LANE'S OWN batching script, at the LANE's scripts ref — never read out of the
+      # checkout above. That checkout is the PLATFORM's commit (`platform-ref`; `select` prefers
+      # `build-logic-ref`), and for an unpinned caller the platform is the newest SEALED set, hours
+      # behind a lane called at `@main`. #4096 landed module-pack-batch.py on core main at 16:43Z
+      # on 2026-09-12; every Plugins `pack` leg then read it out of a checkout sealed at a7450f3aa
+      # (14:46Z) and died with `python3: can't open file '…/module-pack-batch.py'` — Plugins main
+      # published nothing until a seal carried the file. Same fetch shape as node-repo-gate.yml's
+      # compose-gate-host.sh (#4095): curl (the self-hosted runner ships no `gh`), the raw media
+      # type, RED by name on a miss, and the self-test right after — an unproven script is no
+      # script. Written INTO the checkout's path, so every `python3 meshweaver/.github/scripts/
+      # module-pack-batch.py` below reads the fetched bytes. ScriptsRefFetchGuard (Documentation.Test)
+      # holds this step in every job that runs the script.
+      - name: Fetch module-pack-batch.py at the lane's scripts ref
+        env:
+          SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.build-logic-ref || inputs.platform-ref }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          SCRIPT="meshweaver/.github/scripts/module-pack-batch.py"
+          [ -n "${SCRIPTS_REF:-}" ] || { echo "::error::scripts-ref / build-logic-ref / platform-ref are all empty — module-pack-batch.py has no ref to be fetched at"; exit 1; }
+          mkdir -p "$(dirname "$SCRIPT")"
+          curl -fsSL --retry 3 --retry-delay 5 -o "$SCRIPT" \
+            -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github.raw+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "${GITHUB_API_URL:-https://api.github.com}/repos/Systemorph/MeshWeaver/contents/.github/scripts/module-pack-batch.py?ref=${SCRIPTS_REF}" \
+            || { echo "::error::could not fetch module-pack-batch.py at ${SCRIPTS_REF} from Systemorph/MeshWeaver. The file is read at the lane's SCRIPTS ref (inputs.scripts-ref, then build-logic-ref, then platform-ref) and a ref older than the lane does not have it — a caller of this lane at @main passes scripts-ref: main (MeshWeaver#4096: Plugins main stalled on 2026-09-12 reading it out of a sealed platform-ref)."; exit 1; }
+          [ -s "$SCRIPT" ] || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is empty"; exit 1; }
+          head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched module-pack-batch.py at ${SCRIPTS_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
+          python3 "$SCRIPT" --self-test
+          echo "module-pack-batch.py: fetched at ${SCRIPTS_REF} into $SCRIPT and self-tested"
       - name: This leg's modules
         env:
           BATCH: ${{ toJSON(matrix.batch) }}

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -134,6 +134,24 @@ which is untouched. Arithmetic for Plugins at N=6: the ~40 sub-minute pack legs 
 from ~40 billed minutes to ~7 (each batch ≈ 6 × 1.1 min of work ≈ 7 min, rounded once), and the
 per-leg checkout + SDK install is paid 7 times instead of 40.
 
+> 🚨 **The batching script is FETCHED at the lane's `scripts-ref`, never read out of the
+> `platform-ref` checkout** (2026-09-12, the same day). #4096 merged at 16:43Z, and every `pack`
+> leg of MeshWeaver.Plugins main then ran `python3 meshweaver/.github/scripts/module-pack-batch.py`
+> out of a checkout at the run's *platform* — the newest sealed set, cut at a7450f3aa (14:46Z),
+> two hours before the file existed — and died with `python3: can't open file … [Errno 2]`, so
+> Plugins published nothing until a seal carried it (run 34707906260). That is the
+> `scripts-ref` / `platform-ref` split the gate lane already lives by (#3842, #4095): the lane's
+> OWN tooling moves with the lane, the platform moves with the seal, and for a caller at `@main`
+> the two are hours apart. So `node-repo-module-pack.yml` now takes `scripts-ref` (empty →
+> `build-logic-ref` → `platform-ref`; a caller that pins nothing passes `main`) and `select`,
+> `pack` and `tests` each curl `module-pack-batch.py` at that ref into the checkout's path, assert
+> `#!`, and run its `--self-test` before the first `init` — RED by name on a miss, never a
+> warning. `ScriptsRefFetchGuard` (MeshWeaver.Documentation.Test) holds the rule fleet-wide: every
+> `meshweaver/.github/scripts/<x>` a lane job runs is fetched at `${SCRIPTS_REF}` in that job or is
+> on an explicit allow-list of scripts old enough to be in every sealed set (with its landing
+> date); a stale allow-list entry is RED too. The guard fires by content on the lane exactly as
+> #4096 merged it, naming all three jobs.
+
 ### Where a module's own suite runs — and why `publish` decides
 
 A `needs:` on a `uses:` job waits for the **whole** called workflow, so anything inside the last

--- a/test/MeshWeaver.Documentation.Test/ScriptsRefFetchGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ScriptsRefFetchGuard.cs
@@ -1,0 +1,245 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 THE TRAP: a reusable lane checks Systemorph/MeshWeaver out at the caller's <c>platform-ref</c>
+/// — the PLATFORM the modules build against, which for an unpinned caller is the newest SEALED
+/// set, hours behind the lane itself when the lane is called at <c>@main</c> — and then runs its
+/// OWN helper scripts out of that checkout (<c>python3 meshweaver/.github/scripts/&lt;x&gt;.py</c>).
+/// A script added to core in the SAME PR as the lane step that calls it is therefore absent from
+/// every caller's checkout until a seal carries it, and the lane is red fleet-wide with
+/// <c>python3: can't open file '…/meshweaver/.github/scripts/&lt;x&gt;.py': [Errno 2]</c>.
+///
+/// <para>It has happened twice. Plugins#1566 (2026-09-09): <c>check-abbreviated-shas.py</c> fetched
+/// at a platform-ref cut hours before it landed — answered by the <c>scripts-ref</c> input on the
+/// gate lane (MeshWeaver#3842) and the curl fetch shape of #4095. #4096 (2026-09-12, 16:43Z):
+/// <c>module-pack-batch.py</c> landed with the batching step that runs it in <c>select</c>,
+/// <c>pack</c> and <c>tests</c>; every <c>pack</c> leg of MeshWeaver.Plugins main (run
+/// 34707906260) read it out of a checkout sealed at a7450f3aa (14:46Z) and died, and Plugins
+/// published nothing until a seal carried the file. Nothing in core's own CI can see this: core's
+/// <c>main-cd</c> calls the lane at <c>./</c> with its own sha as <c>platform-ref</c>, so the
+/// checkout there always has the script.</para>
+///
+/// <para>THE RULE this guard holds: every <c>meshweaver/.github/scripts/&lt;file&gt;</c> a lane job
+/// runs is either (a) FETCHED in that job, at the lane's SCRIPTS ref (<c>?ref=${SCRIPTS_REF}</c>
+/// bound from <c>inputs.scripts-ref</c>, curl or <c>gh api</c>, into the path the job reads,
+/// BEFORE the first use — or the job's whole <c>meshweaver</c> checkout is at
+/// <c>inputs.scripts-ref</c>), or (b) on the explicit allow-list below of scripts old enough to be
+/// in every set a caller can resolve. A new lane script is not "old enough" — it goes in (a), or
+/// this guard names it. And the allow-list is a ratchet in both directions: an entry nothing
+/// references any more is RED too.</para>
+/// </summary>
+public class ScriptsRefFetchGuard
+{
+    private const string ModulePack = ".github/workflows/node-repo-module-pack.yml";
+
+    /// <summary>
+    /// Scripts read out of the <c>platform-ref</c> checkout WITHOUT a fetch, and why that is
+    /// tolerable for each: the date it landed on core main, after which every sealed set carries
+    /// it. A frozen caller (<c>vars.MW_PLATFORM_REF</c>) pins the lane to the same wave, so the
+    /// checkout it makes is never older than the lane that reads it. Adding an entry here is a
+    /// claim that no caller can resolve a set from before that date — NOT a way past a red guard
+    /// on the day the script lands.
+    /// </summary>
+    private static readonly IReadOnlyDictionary<string, string> OldEnoughToBeInEverySealedSet =
+        new Dictionary<string, string>(StringComparer.Ordinal)
+        {
+            ["acr-login.sh"] = "2026-09-07 (88201f021)",
+            ["check-module-platform-floor.py"] = "2026-09-07 (88201f021)",
+            ["module-build-key.py"] = "2026-09-07 (88201f021)",
+            ["module-build-ledger.py"] = "2026-09-07 (88201f021)",
+            ["module-owned-platform.sh"] = "2026-09-07 (88201f021)",
+            ["node-repo-pack-verify.py"] = "2026-09-07 (88201f021)",
+            ["node-repo-scope.py"] = "2026-09-07 (88201f021)",
+            ["workspace-build-verify.py"] = "2026-09-07 (88201f021)",
+            ["node-repo-publication-base.py"] = "2026-09-09 (3a5f44b02)",
+            ["node-repo-publication-reuse.py"] = "2026-09-09 (3a5f44b02)",
+            ["module-publication.py"] = "2026-09-10 (0c7e29e50)",
+        };
+
+    private static readonly Regex ScriptReference =
+        new(@"meshweaver/\.github/scripts/(?<file>[A-Za-z0-9_.-]+\.(?:py|sh))", RegexOptions.Compiled);
+
+    [Fact]
+    public void EveryLaneScriptReadFromTheMeshweaverCheckout_IsFetchedAtScriptsRef_OrOldEnough()
+    {
+        var offenders = new List<string>();
+        var referenced = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var (workflow, job, body) in LaneJobs())
+        {
+            var scripts = ScriptReference.Matches(body).Select(m => m.Groups["file"].Value).Distinct().ToList();
+            if (scripts.Count == 0)
+                continue;
+
+            // (a') The job's whole checkout of Systemorph/MeshWeaver is at the lane's scripts ref —
+            // the gate's `merge` job shape for gate-shard-merge.py.
+            var checkoutAtScriptsRef = Regex.IsMatch(body,
+                @"repository: Systemorph/MeshWeaver\n\s+ref: \$\{\{ inputs\.scripts-ref[^\n]*\n\s+path: meshweaver\n");
+
+            foreach (var script in scripts)
+            {
+                referenced.Add(script);
+                if (checkoutAtScriptsRef)
+                    continue;
+
+                var fetch = body.IndexOf($"contents/.github/scripts/{script}?ref=${{SCRIPTS_REF}}", StringComparison.Ordinal);
+                var firstUse = ScriptReference.Matches(body).First(m => m.Groups["file"].Value == script).Index;
+                if (fetch >= 0)
+                {
+                    // The ref the fetch reads must be the LANE's scripts ref, never platform-ref alone.
+                    if (!Regex.IsMatch(body, @"SCRIPTS_REF: \$\{\{ inputs\.scripts-ref(?: \|\||\s*\}\})"))
+                        offenders.Add($"{workflow} job `{job}`: fetches {script} at ${{SCRIPTS_REF}} but binds SCRIPTS_REF to something other than `inputs.scripts-ref || …`");
+                    // Before the first use: the STEP that fetches (its `SCRIPT=…` target path is
+                    // itself a reference) must be the first step that names the script.
+                    var fetchStep = Math.Max(0, body.LastIndexOf("\n      - ", fetch, StringComparison.Ordinal));
+                    if (firstUse < fetchStep)
+                        offenders.Add($"{workflow} job `{job}`: fetches {script} AFTER its first use (fetch step at {fetchStep}, first use at {firstUse})");
+                    continue;
+                }
+
+                if (OldEnoughToBeInEverySealedSet.ContainsKey(script))
+                    continue;
+
+                offenders.Add($"{workflow} job `{job}`: runs meshweaver/.github/scripts/{script} out of the platform-ref checkout "
+                              + "without fetching it at ${SCRIPTS_REF}, and it is not on the old-enough allow-list");
+            }
+        }
+
+        Assert.True(offenders.Count == 0,
+            "A reusable lane may not run a script out of its `meshweaver/` checkout unless the script is fetched in that "
+            + "job at the lane's SCRIPTS ref (`curl … contents/.github/scripts/<x>?ref=${SCRIPTS_REF}` with "
+            + "`SCRIPTS_REF: ${{ inputs.scripts-ref || … }}`, before the first use — the node-repo-gate.yml "
+            + "compose-gate-host.sh shape, #4095) or is old enough to be in every sealed platform set (the allow-list in "
+            + "this guard, with its landing date). The checkout is at the caller's PLATFORM-ref — for an unpinned caller "
+            + "the newest SEALED set, hours behind a lane called at @main — so a script that lands with the step that runs "
+            + "it is absent fleet-wide until a seal carries it: #4096 stalled MeshWeaver.Plugins main publication on "
+            + "2026-09-12 exactly this way (`python3: can't open file '…/meshweaver/.github/scripts/module-pack-batch.py'`).\n  "
+            + string.Join("\n  ", offenders));
+
+        var stale = OldEnoughToBeInEverySealedSet.Keys.Where(k => !referenced.Contains(k)).OrderBy(k => k, StringComparer.Ordinal).ToList();
+        Assert.True(stale.Count == 0,
+            "Allow-list entries no lane reads out of its meshweaver/ checkout any more — remove them, the list is a ratchet: "
+            + string.Join(", ", stale));
+    }
+
+    [Theory]
+    [InlineData("select")]
+    [InlineData("pack")]
+    [InlineData("tests")]
+    public void ModulePack_FetchesTheBatchScriptAtItsScriptsRef_AndSelfTestsIt_InEveryJobThatRunsIt(string job)
+    {
+        var body = JobBody(ModulePack, job);
+        Assert.Contains("meshweaver/.github/scripts/module-pack-batch.py", body, StringComparison.Ordinal);
+
+        var step = StepBlock(body, "- name: Fetch module-pack-batch.py at the lane's scripts ref");
+        // The lane's scripts ref, falling back to this lane's existing selection pin (an immutable
+        // core SHA the Plugins caller resolves at run time — what unstrands it without a caller
+        // change) and only then to the platform's commit.
+        Assert.Contains("SCRIPTS_REF: ${{ inputs.scripts-ref || inputs.build-logic-ref || inputs.platform-ref }}", step, StringComparison.Ordinal);
+        // curl, not gh: `pack` and `tests` honour `runs-on: ${{ inputs.runner }}` and the self-hosted
+        // image ships no `gh`. Same headers as the gate's compose-gate-host.sh fetch.
+        Assert.Contains("curl -fsSL --retry 3 --retry-delay 5 -o \"$SCRIPT\"", step, StringComparison.Ordinal);
+        Assert.Contains("-H \"Accept: application/vnd.github.raw+json\"", step, StringComparison.Ordinal);
+        Assert.Contains("/repos/Systemorph/MeshWeaver/contents/.github/scripts/module-pack-batch.py?ref=${SCRIPTS_REF}", step, StringComparison.Ordinal);
+        // Into the path every later `python3 meshweaver/.github/scripts/module-pack-batch.py` reads.
+        Assert.Contains("SCRIPT=\"meshweaver/.github/scripts/module-pack-batch.py\"", step, StringComparison.Ordinal);
+        // RED by name on a miss, on empty bytes, on a non-script — and the fetched bytes prove
+        // themselves before anything drives them. Never weakened to a warning, never skipped.
+        Assert.Contains("could not fetch module-pack-batch.py at ${SCRIPTS_REF}", step, StringComparison.Ordinal);
+        Assert.Contains("[ -s \"$SCRIPT\" ] ||", step, StringComparison.Ordinal);
+        Assert.Contains("head -c 2 \"$SCRIPT\" | grep -q '#!' ||", step, StringComparison.Ordinal);
+        Assert.Contains("python3 \"$SCRIPT\" --self-test", step, StringComparison.Ordinal);
+        Assert.DoesNotContain("continue-on-error", step, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning::", step, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ModulePack_DeclaresScriptsRef_AndSelectStillSelfTestsTheBatchScript()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), ModulePack));
+        var input = Regex.Match(text, @"\n      scripts-ref:\n(?<body>(?:(?:        .*)?\n)+)");
+        Assert.True(input.Success, $"{ModulePack} must declare a `scripts-ref` input (the gate lane's contract, MeshWeaver#3842)");
+        Assert.Contains("default: ''", input.Groups["body"].Value, StringComparison.Ordinal);
+        // The selection's own self-test inventory keeps the batch script — the fetch step proves
+        // the bytes, this proves the selector's inventory is complete.
+        Assert.Contains("python3 meshweaver/.github/scripts/module-pack-batch.py --self-test", JobBody(ModulePack, "select"), StringComparison.Ordinal);
+    }
+
+    /// <summary>Every (workflow, job, executable body) of every workflow under .github/workflows
+    /// — the reusable lanes are the ones with a <c>meshweaver/</c> checkout, and the reference
+    /// scan is what selects them.</summary>
+    private static IEnumerable<(string Workflow, string Job, string Body)> LaneJobs()
+    {
+        var dir = Path.Combine(FindRepoRoot(), ".github", "workflows");
+        foreach (var file in Directory.EnumerateFiles(dir, "*.yml", SearchOption.TopDirectoryOnly).OrderBy(f => f, StringComparer.Ordinal))
+        {
+            var text = File.ReadAllText(file);
+            var name = Path.GetFileName(file);
+            foreach (var (job, body) in Jobs(text))
+                yield return (name, job, body);
+        }
+    }
+
+    /// <summary>The jobs after the top-level <c>jobs:</c> key — a job key sits at exactly two
+    /// spaces — with comment lines dropped so a prose mention of a script is not an invocation.</summary>
+    private static IEnumerable<(string Job, string Body)> Jobs(string yaml)
+    {
+        var lines = yaml.Split('\n');
+        var start = Array.FindIndex(lines, l => l == "jobs:");
+        if (start < 0)
+            yield break;
+        string? job = null;
+        var body = new List<string>();
+        for (var i = start + 1; i <= lines.Length; i++)
+        {
+            var line = i < lines.Length ? lines[i] : null;
+            var header = line is not null ? Regex.Match(line, @"^  (?<job>[A-Za-z_][A-Za-z0-9_-]*):\s*$") : null;
+            if (line is null || header!.Success)
+            {
+                if (job is not null)
+                    yield return (job, string.Join('\n', body.Where(l => !l.TrimStart().StartsWith('#'))));
+                if (line is null)
+                    yield break;
+                job = header!.Groups["job"].Value;
+                body = new List<string>();
+                continue;
+            }
+            body.Add(line);
+        }
+    }
+
+    private static string JobBody(string workflow, string job)
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), workflow));
+        var found = Jobs(text).FirstOrDefault(j => j.Job == job);
+        Assert.True(found.Job == job, $"{workflow} must have a `{job}` job");
+        return found.Body;
+    }
+
+    /// <summary>The step that carries <paramref name="marker"/>, up to the next step.</summary>
+    private static string StepBlock(string job, string marker)
+    {
+        var at = job.IndexOf(marker, StringComparison.Ordinal);
+        Assert.True(at >= 0, $"the step `{marker.Trim()}` is gone — a lane job runs module-pack-batch.py out of a checkout that may not have it (#4096)");
+        var end = job.IndexOf("\n      - ", at + 1, StringComparison.Ordinal);
+        return job.Substring(at, (end < 0 ? job.Length : end) - at);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (MeshWeaver.slnx) above the test bin");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
## MeshWeaver.Plugins `main` has published NOTHING since 16:43Z today

Every batch leg of Plugins main (run [34707906260](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/34707906260), head `7726c7e0`, and every push since) fails in `Module bundles / Module bundle (batch n/7: …)` at step **This leg's modules**:

```
python3: can't open file '/home/runner/work/MeshWeaver.Plugins/MeshWeaver.Plugins/meshweaver/.github/scripts/module-pack-batch.py': [Errno 2] No such file or directory
##[error]Process completed with exit code 2
```

All 7 batch legs red → `All selected bundles built` red → every gate hanging off it red → no seal, no publication. Stalled since #4096 merged at **2026-09-12 16:43:55Z**.

## Root cause (verified by content)

`.github/workflows/node-repo-module-pack.yml` (core `origin/main`, `65bdead0d`):

- **`pack` L1809** and **`tests` L3660**: `Check out Systemorph/MeshWeaver at the pinned ref` — `ref: ${{ inputs.platform-ref }}`, `path: meshweaver`.
- **`pack` L1827** / **`tests` L3674**: `python3 meshweaver/.github/scripts/module-pack-batch.py --state … init` — the first of ~40 `bk()` invocations per leg.
- **`select` L927**: checkout at `inputs.build-logic-ref || inputs.platform-ref`; **L951**: `python3 meshweaver/.github/scripts/module-pack-batch.py --self-test`, unconditional.

`platform-ref` for an unpinned caller is the newest **sealed** platform set — the failing run resolved `a7450f3aa` (merged 14:46Z), two hours before `module-pack-batch.py` existed on core (`dcabce799`, via #4096). The script only lands in a caller's checkout once a seal carries it; batching is default-on (`batch-size` 6) and `select` self-tests the script unconditionally, so no caller could opt out. Plugins' `select` survived only because it passes `build-logic-ref` (core main's tip); `pack`/`tests` read the platform checkout and died. MeshWeaver.SocialMedia (calls the lane `@main`, passes neither) is stranded in `select`.

This is the **scripts-ref vs platform-ref split** the gate lane already lives by (#3842; #4095 hit the same trap for `compose-gate-host.sh` and fetched it at `scripts-ref` with curl). `github.job_workflow_sha` is empty inside a reusable called cross-repo, so the lane's own ref must be an input.

## Mechanism (same as #4095)

- New input **`scripts-ref`** on `node-repo-module-pack.yml`, the gate's contract: empty (default) → `build-logic-ref` → `platform-ref`. Plugins passes `build-logic-ref` = core main's tip at run time, so **it is unstranded by this merge with no caller change**. A caller of the lane `@main` that pins nothing should pass `scripts-ref: main` (SocialMedia's own `no-pins` rule already says lanes with a `scripts-ref` input get `main` — that is a one-line follow-up there, not touched here).
- **`select`, `pack`, `tests`** each get the step `Fetch module-pack-batch.py at the lane's scripts ref` before the first use: `curl -fsSL --retry 3` with `Accept: application/vnd.github.raw+json` at `?ref=${SCRIPTS_REF}` (curl, not `gh` — `pack`/`tests` honour `inputs.runner` and the self-hosted image ships no `gh`), written **into `meshweaver/.github/scripts/module-pack-batch.py`** so every `bk()` reads the fetched bytes; asserts non-empty, asserts `#!`, runs `--self-test` on the fetched bytes. RED by name on a miss (`could not fetch module-pack-batch.py at <ref> … a caller of this lane at @main passes scripts-ref: main`), on an empty ref, on a non-script. The existing self-test line in `select` stays; nothing is weakened or skipped.
- Simulated locally against the real API: at `main` → fetched (31,888 bytes), self-test green, exit 0; at `a7450f3aa` (the sealed set) → 404 → `::error::could not fetch module-pack-batch.py at a7450f3aa…`, exit 1; empty ref → `::error::… all empty`, exit 1.
- `batch-size` default unchanged. MeshWeaver.Plugins not touched.

## Guard so it cannot recur — `ScriptsRefFetchGuard` (test/MeshWeaver.Documentation.Test)

Scans every job of every workflow for `meshweaver/.github/scripts/<x>.(py|sh)` references (comments stripped). Each must be (a) fetched **in that job** at `?ref=${SCRIPTS_REF}` with `SCRIPTS_REF: ${{ inputs.scripts-ref || … }}`, and the fetching step must precede the first use — or the job's whole `meshweaver` checkout is at `inputs.scripts-ref` (the gate's `merge` job shape) — or (b) on an explicit allow-list of scripts old enough to be in every sealed set, each entry carrying its landing date (`88201f021` 09-07 ×8, `3a5f44b02` 09-09 ×2, `0c7e29e50` 09-10). The trap is stated in the class doc and in the failure message. A stale allow-list entry is RED too (ratchet). Plus a theory pinning the fetch step's shape in `select`/`pack`/`tests` (curl, raw media type, target path, `#!`, `--self-test`, no `continue-on-error`, no `::warning::`) and the `scripts-ref` input.

**Deletion proof (by content):**
- Lane **as merged on `origin/main`** (the defect): `EveryLaneScriptReadFromTheMeshweaverCheckout_IsFetchedAtScriptsRef_OrOldEnough` **fails**, naming `select`, `pack`, `tests` — *"runs meshweaver/.github/scripts/module-pack-batch.py out of the platform-ref checkout without fetching it at ${SCRIPTS_REF}, and it is not on the old-enough allow-list"*.
- Fixed lane with only `pack`'s fetch step deleted: **2 failures** — the general rule naming `pack`, and `ModulePack_FetchesTheBatchScriptAtItsScriptsRef…(job: "pack")`: *"the step `- name: Fetch module-pack-batch.py at the lane's scripts ref` is gone"*.
- Fixed lane: 5/5 green; full `MeshWeaver.Documentation.Test`: **446/446**.

## Guards run

- `actionlint -shellcheck= -pyflakes=` (CI's flags, all workflows): clean.
- `check-workflow-shell` / `-timeouts` / `-yaml-keys` / `check-pr-secret-preflight` / `check-workflow-permission-pairing` — `--self-test` all green; `--root .` 0 violations each (shell: 1 pre-existing allow-listed finding, 0 live); permission-pairing `--fleet .github/lane-caller-grants.yml`: 56 pairs, 0 violations.
- `check-combo-verify`, `check-pin-set-consistency`, `test-cd-steps`: green.
- `dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror`: 446 passed.

Also: `ModuleBuildArchitecture.md` gets the note under the batching section; the script's docstring no longer claims it is fetched at `platform-ref`.

**After merge:** Plugins' next `main` run (lane `@main`) fetches the script at `build-logic-ref` and publishes again — no seal needed. Hop: this is the lane, not an image; nothing to roll.

Refs #4096

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqTDZe4Skkn81GuGkwMrXS
