### PR TITLE
fix(ci): pack probes the platform volume as the refresh lays it out (sha256-<tester>/platform-refs), so the mount can hit

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -281,10 +281,15 @@ name: node-repo module pack
 #     no `docker`, no `azure/login`, no `acr-*` secret is referenced anywhere in either job
 #     (grep them). `tests` never consumed an image at all. `pack` takes the pinned image's /app
 #     from, in this order (Memex#316, maintainer decision 2026-09-12):
-#       1. the runner's PLATFORM MOUNT `/opt/platform/<platform-image-digest>/` — an Azure Files
-#          volume the runner pods carry, populated once per sealed set by a refresh job, so a
-#          runner keeps the platform installed until the platform updates. Real only when its
-#          `.complete` marker holds the digest; a plain directory test, never a registry call.
+#       1. the runner's PLATFORM MOUNT `/opt/platform/sha256-<tester hex>/platform-refs/` — an
+#          Azure Files volume the runner pods carry, populated once per sealed set by a refresh
+#          job, so a runner keeps the platform installed until the platform updates. A set is
+#          keyed by the TESTER digest with `:` → `-` (Azure Files forbids `:`), holds the PORTAL
+#          /app under `platform-refs/`, and is real only when its `.complete` marker holds the
+#          tester digest and its `platform.json` pairs the pinned portal; a plain directory
+#          test, never a registry call. The layout is the refresh script's (Systemorph/Memex
+#          deployments/aks/ci-runners/ci-platform-refresh.py); the probe mirrors
+#          resolve-gate-platform.sh, the gate lane's reader of the same volume.
 #       2. the RUN ARTIFACT `platform-refs-<lane>` — the very bytes `prepare` took with
 #          `docker cp` on its hosted runner, tarred and handed over with actions/upload-artifact
 #          (retention 1 day). Guaranteed within the run, which a cache entry never is.
@@ -680,7 +685,7 @@ on:
           org's self-hosted scale set: non-root, NO Docker, no preinstalled toolchain, 2 vCPU /
           6 GiB per runner — the two honouring jobs set DOTNET_INSTALL_DIR under /home/runner for
           it. Neither honouring job runs `docker` or touches a registry: `pack` takes the pinned
-          image's /app from the runner's `/opt/platform/<digest>/` mount, else from the artifact
+          image's /app from the runner's `/opt/platform/sha256-<tester hex>/platform-refs/` mount, else from the artifact
           `prepare` hands over, else fails RED naming both; `tests` consumes no image. Wire it
           from a repository variable (`vars.MW_RUNNER_HEAVY`, falling back to `ubuntu-latest`
           when unset — the header shows the expression) so the move is one edit to revert.
@@ -2140,34 +2145,80 @@ jobs:
       #
       # 🚨 NO DOCKER, NO REGISTRY, NO CACHE IN THIS JOB (Memex#316, "Where the heavy legs run" in
       # the header). The /app comes from, in order:
-      #   1. the runner's platform mount `/opt/platform/<digest>/`, real only when its `.complete`
-      #      marker holds the digest — a directory test, read in place;
+      #   1. the runner's platform mount — the set `/opt/platform/sha256-<tester hex>/`, real only
+      #      when its `.complete` marker holds the tester digest and its `platform.json` pairs the
+      #      pinned portal; the portal's /app is that set's `platform-refs/`. A directory test,
+      #      read in place;
       #   2. the run artifact `platform-refs-<lane>` that `prepare` handed over;
       #   3. neither ⇒ RED, naming both and the job that should have produced the artifact.
       # The download is `continue-on-error` ONLY so that the verdict step below can say all of
       # that by name instead of "Artifact not found" — the verdict step is unconditional within
       # the pinned mode and is what goes RED. Which source was taken is in the job summary.
-      - name: Is the platform mounted on this runner? (/opt/platform/<digest>)
+      #
+      # 🚨 THE VOLUME'S LAYOUT IS READ FROM THE SCRIPT THAT WRITES IT — Systemorph/Memex
+      # deployments/aks/ci-runners/ci-platform-refresh.py (and the README's "Platform kept between
+      # jobs"), measured 2026-09-12 — not from a description of it. Until this step was rewritten
+      # it probed `/opt/platform/$DIGEST` with the PORTAL digest, colon and all, and expected the
+      # assemblies at that directory's top level; the refresh lays a set out as
+      #   /opt/platform/sha256-<hex>/               keyed by the TESTER image digest — Azure Files
+      #                                             forbids `:` in a name, so `sha256:` → `sha256-`
+      #   /opt/platform/sha256-<hex>/platform-refs/ the PORTAL image's /app (what this leg compiles against)
+      #   /opt/platform/sha256-<hex>/platform.json  `portal-image-digest`: the portal the set pairs
+      #   /opt/platform/sha256-<hex>/.complete      the tester digest, COLON form, written LAST
+      # so the probe could never hit and every aks-silos leg took the artifact (Plugins run
+      # 34711540604) while the volume did nothing for this lane. resolve-gate-platform.sh (the gate
+      # lane's reader of the same layout) is what this mirrors — `${digest/:/-}` for the directory,
+      # the colon form for the marker, `platform.json` for the pairing — minus its refusals: here a
+      # miss FALLS THROUGH to the run artifact, by design (the header). PlatformMountLayoutGuard
+      # (test/MeshWeaver.Documentation.Test) holds the probe to this layout.
+      - name: Is the platform mounted on this runner? (/opt/platform/sha256-<tester hex>/platform-refs)
         if: inputs.platform-image-digest != ''
         id: platform-mount
         env:
           DIGEST: ${{ inputs.platform-image-digest }}
+          TESTER_DIGEST: ${{ inputs.tester-image-digest }}
         run: |
           set -euo pipefail
-          mount="/opt/platform/$DIGEST"
-          if [ -d "$mount" ] && [ -f "$mount/.complete" ] && [ "$(tr -d '[:space:]' < "$mount/.complete")" = "$DIGEST" ]; then
-            n=$(find "$mount" -maxdepth 1 -name '*.dll' | wc -l | tr -d ' ')
-            if [ "$n" -gt 50 ]; then
-              echo "mounted=true" >> "$GITHUB_OUTPUT"
-              echo "platform mount: $mount is complete ($n assemblies) — the artifact is not needed"
-              exit 0
-            fi
-            echo "::warning::$mount carries a .complete marker for $DIGEST but only $n assemblies — not a platform /app; falling through to the run artifact"
-          elif [ -d "$mount" ]; then
-            echo "platform mount: $mount exists but its .complete marker is absent or names another digest — a refresh in flight; falling through to the run artifact"
-          else
-            echo "platform mount: $mount is not present on $RUNNER_NAME — falling through to the run artifact"
+          root=/opt/platform
+          if [ ! -d "$root" ]; then
+            echo "platform mount: $root is not present on $RUNNER_NAME — falling through to the run artifact"
+            echo "mounted=false" >> "$GITHUB_OUTPUT"; exit 0
           fi
+          if [ -n "$TESTER_DIGEST" ]; then
+            # The set is keyed by the tester digest, so a tester pin names it outright.
+            candidates="$root/${TESTER_DIGEST/:/-}"
+          else
+            # No tester pin: any complete set whose platform.json pairs the pinned portal will do.
+            candidates="$(find "$root" -mindepth 1 -maxdepth 1 -type d -name 'sha256-*' | sort)"
+            [ -n "$candidates" ] || echo "platform mount: $root holds no sha256-* set at all (the refresh has never completed a run on it) — falling through to the run artifact"
+          fi
+          for set in $candidates; do
+            name="$(basename "$set")"
+            case "$name" in *.tmp.*) continue ;; esac     # a refresh's per-run scratch, never a set
+            want="${TESTER_DIGEST:-sha256:${name#sha256-}}"
+            if [ ! -d "$set" ]; then
+              echo "platform mount: no set $name under $root (it holds: $(find "$root" -mindepth 1 -maxdepth 1 -exec basename {} \; | sort | tr '\n' ' ')) — ci-platform-refresh (Systemorph/Memex) keeps the 3 newest sealed sets, so this tester pin is older than those or not yet sealed; falling through to the run artifact"
+              continue
+            fi
+            if [ ! -f "$set/.complete" ] || [ "$(tr -d '[:space:]' < "$set/.complete")" != "$want" ]; then
+              echo "platform mount: $set exists but its .complete marker is absent or names another digest — a refresh in flight; falling through to the run artifact"
+              continue
+            fi
+            portal="$(sed -n 's/.*"portal-image-digest"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$set/platform.json" 2>/dev/null | head -1)"
+            if [ "$portal" != "$DIGEST" ]; then
+              echo "platform mount: $set pairs portal ${portal:-<none recorded>}, not the pinned $DIGEST — falling through to the run artifact"
+              continue
+            fi
+            n=$(find "$set/platform-refs" -maxdepth 1 -name '*.dll' 2>/dev/null | wc -l | tr -d ' ')
+            if [ "$n" -le 50 ]; then
+              echo "::warning::$set/platform-refs is marked complete for $want but holds only $n assemblies — not a platform /app; falling through to the run artifact"
+              continue
+            fi
+            echo "dir=$set/platform-refs" >> "$GITHUB_OUTPUT"
+            echo "mounted=true" >> "$GITHUB_OUTPUT"
+            echo "platform mount: $set/platform-refs is complete ($n assemblies for $DIGEST; set $name) — the artifact is not needed"
+            exit 0
+          done
           echo "mounted=false" >> "$GITHUB_OUTPUT"
       - name: Fetch the platform's /app (handed over by prepare)
         if: inputs.platform-image-digest != '' && steps.platform-mount.outputs.mounted != 'true'
@@ -2184,16 +2235,17 @@ jobs:
           DIGEST: ${{ inputs.platform-image-digest }}
           LANE: ${{ needs.select.outputs.lane }}
           MOUNTED: ${{ steps.platform-mount.outputs.mounted }}
+          MOUNT_DIR: ${{ steps.platform-mount.outputs.dir }}
           FETCHED: ${{ steps.platform-artifact.outcome }}
         run: |
           set -euo pipefail
           if [ "$MOUNTED" = true ]; then
-            dir="/opt/platform/$DIGEST"
+            dir="$MOUNT_DIR"
             source="mount"
           else
             tarball="$RUNNER_TEMP/platform-refs-artifact/platform-refs.tar.gz"
             if [ "$FETCHED" != success ] || [ ! -f "$tarball" ]; then
-              echo "::error::no platform /app for $DIGEST on this runner ($RUNNER_NAME): /opt/platform/$DIGEST/.complete is absent (the runner's platform mount, Memex#316) AND the run artifact platform-refs-$LANE could not be fetched (download outcome: ${FETCHED:-skipped}). 'Warm the shared build environment (once)' (job: prepare) uploads that artifact in this same run — if it is green, the artifact expired (retention 1 day) or this run was re-run past it; re-run the whole lane, never this leg alone. This job runs no docker and holds no registry credential, by design."
+              echo "::error::no platform /app for $DIGEST on this runner ($RUNNER_NAME): no complete set under /opt/platform/sha256-<tester hex>/ pairs it (the runner's platform mount, Memex#316 — the step above says why) AND the run artifact platform-refs-$LANE could not be fetched (download outcome: ${FETCHED:-skipped}). 'Warm the shared build environment (once)' (job: prepare) uploads that artifact in this same run — if it is green, the artifact expired (retention 1 day) or this run was re-run past it; re-run the whole lane, never this leg alone. This job runs no docker and holds no registry credential, by design."
               exit 1
             fi
             stampfile="$RUNNER_TEMP/platform-refs-artifact/digest.txt"
@@ -2210,7 +2262,7 @@ jobs:
           echo "dir=$dir" >> "$GITHUB_OUTPUT"
           echo "source=$source" >> "$GITHUB_OUTPUT"
           echo "platform refs: $n assemblies for $DIGEST from the $source ($dir)"
-          printf '### Platform reference set\n\n**%s** — %s, %s assemblies for %s (no docker, no registry in this job; sources tried in order: the mount /opt/platform/<digest>/, then the run artifact platform-refs-%s).\n' "$source" "$dir" "$n" "$DIGEST" "$LANE" >> "$GITHUB_STEP_SUMMARY"
+          printf '### Platform reference set\n\n**%s** — %s, %s assemblies for %s (no docker, no registry in this job; sources tried in order: the mount /opt/platform/sha256-<tester hex>/platform-refs/, then the run artifact platform-refs-%s).\n' "$source" "$dir" "$n" "$DIGEST" "$LANE" >> "$GITHUB_STEP_SUMMARY"
       # 🚨 THE SDK LEG NEEDS THE SUPERSEDE TOO — it did not have it, and that is a whole class of
       # red (#3175 wave). `superseded-image-assemblies` reached ONLY the container leg, as
       # `--superseded-image-assembly` on `build-project`. The SDK leg compiles with

--- a/test/MeshWeaver.Documentation.Test/PlatformMountLayoutGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformMountLayoutGuard.cs
@@ -1,0 +1,274 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the module-pack lane's probe of the runner's PLATFORM VOLUME — the
+/// Azure Files share every ARC runner pod mounts read-only at <c>/opt/platform</c>
+/// (Memex#316, layer 2), from which <c>pack</c> takes the pinned portal's <c>/app</c> instead of
+/// downloading the run artifact.
+///
+/// <para>🚨 THE DEFECT THIS HOLDS SHUT (measured on MeshWeaver.Plugins run 34711540604, 2026-09-12):
+/// the probe was written from a DESCRIPTION of the volume, not from the script that writes it.
+/// It tested <c>/opt/platform/$DIGEST</c> — the PORTAL digest, in its <c>sha256:</c> colon form,
+/// with the assemblies expected at that directory's top level. The refresh
+/// (Systemorph/Memex <c>deployments/aks/ci-runners/ci-platform-refresh.py</c>; the README's
+/// "Platform kept between jobs") lays a set out as <c>/opt/platform/sha256-&lt;hex&gt;/</c> — keyed
+/// by the TESTER digest, with the colon turned into a dash because Azure Files forbids <c>:</c>
+/// in a name — holding the portal's <c>/app</c> under <c>platform-refs/</c>, the pairing in
+/// <c>platform.json</c> (<c>portal-image-digest</c>) and the tester digest, colon form, in
+/// <c>.complete</c>. Three mismatches, each sufficient on its own: the mount could never hit,
+/// every aks-silos leg quietly took the artifact, and the volume did nothing for this lane while
+/// its log read as a normal fallback. Nothing in a green run distinguished "the volume is not
+/// there" from "the volume is there and unreadable to us".</para>
+///
+/// <para>Why a guard that RUNS the probe: a text assertion alone would pass a rewrite that spells
+/// <c>sha256-</c> and still looks in the wrong place. So the probe's own <c>run:</c> body is
+/// executed under bash against a synthetic volume laid out exactly as the refresh writes it, and
+/// must report <c>mounted=true</c> with the set's <c>platform-refs/</c> as the directory — and
+/// against the volume laid out as the OLD probe imagined it, must report <c>mounted=false</c>.
+/// Swap today's probe for the pre-fix one and both halves go red. The gate lane's reader of the
+/// same volume, <c>resolve-gate-platform.sh</c> (#4115), resolves <c>${digest/:/-}</c> the same
+/// way; this is the module-pack lane's equivalent, minus that script's refusals (here a miss falls
+/// through to the run artifact by design).</para>
+/// </summary>
+public class PlatformMountLayoutGuard
+{
+    private const string Lane = ".github/workflows/node-repo-module-pack.yml";
+
+    // The digests a set is keyed and paired by — deliberately distinct, so a probe that confused
+    // the two (the defect) cannot pass by accident.
+    private const string TesterDigest = "sha256:1111111111111111111111111111111111111111111111111111111111111111";
+    private const string PortalDigest = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
+    [Fact]
+    public void TheProbe_KeysTheSetByTheTesterDigestWithTheColonTurnedIntoADash_NeverByThePortalDigestVerbatim()
+    {
+        var run = ProbeBody();
+
+        // The directory: `${TESTER_DIGEST/:/-}` — the first `:` becomes `-`, exactly as the refresh's
+        // `digest.replace(":", "-", 1)` and the gate lane's `${resolved/:/-}` spell it. The scan
+        // (no tester pin) globs the same dash form.
+        Assert.Contains("candidates=\"$root/${TESTER_DIGEST/:/-}\"", run, StringComparison.Ordinal);
+        Assert.Contains("find \"$root\" -mindepth 1 -maxdepth 1 -type d -name 'sha256-*'", run, StringComparison.Ordinal);
+
+        // 🚨 The colon form is NEVER a path component, and the portal digest is never the key.
+        Assert.DoesNotContain("/opt/platform/$DIGEST", run, StringComparison.Ordinal);
+        Assert.DoesNotContain("$root/$DIGEST", run, StringComparison.Ordinal);
+        Assert.DoesNotContain("$root/$TESTER_DIGEST", run, StringComparison.Ordinal);
+        Assert.DoesNotContain("/sha256:", run, StringComparison.Ordinal);
+
+        // The marker holds the ORIGINAL colon-form tester digest (what `write_file(.complete, digest)`
+        // writes), so it is compared against that form — reconstructed from the directory name when
+        // no tester pin was given.
+        Assert.Contains("want=\"${TESTER_DIGEST:-sha256:${name#sha256-}}\"", run, StringComparison.Ordinal);
+        Assert.Contains("< \"$set/.complete\")\" != \"$want\"", run, StringComparison.Ordinal);
+
+        // The portal's /app is the set's platform-refs/, and the set must PAIR the pinned portal.
+        Assert.Contains("find \"$set/platform-refs\"", run, StringComparison.Ordinal);
+        Assert.Contains("\"portal-image-digest\"", run, StringComparison.Ordinal);
+        Assert.Contains("\"$set/platform.json\"", run, StringComparison.Ordinal);
+        Assert.Contains("echo \"dir=$set/platform-refs\" >> \"$GITHUB_OUTPUT\"", run, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheVerdictStep_TakesTheDirectoryTheProbeResolved_AndDoesNotRecomputeIt()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var verdict = StepBody(text, "id: platform");
+        Assert.Contains("MOUNT_DIR: ${{ steps.platform-mount.outputs.dir }}", verdict, StringComparison.Ordinal);
+        Assert.Contains("dir=\"$MOUNT_DIR\"", verdict, StringComparison.Ordinal);
+        Assert.DoesNotContain("dir=\"/opt/platform/$DIGEST\"", verdict, StringComparison.Ordinal);
+        // The lane's own prose names the real layout, not the imagined one.
+        Assert.Contains("/opt/platform/sha256-<tester hex>/platform-refs/", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("/opt/platform/<platform-image-digest>/", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("/opt/platform/<digest>/", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheProbe_Executed_HitsAVolumeLaidOutAsTheRefreshWritesIt()
+    {
+        using var volume = new SyntheticVolume();
+        // As ci-platform-refresh.py writes it: sha256-<tester hex>/{app,platform-refs,platform.json,.complete}.
+        var set = volume.Set(TesterDigest.Replace(':', '-'), ".complete", TesterDigest, PortalDigest, dllsUnder: "platform-refs");
+        // A refresh's per-run scratch beside it, which must not be mistaken for a set.
+        Directory.CreateDirectory(set + ".tmp.ci-platform-refresh-abc12");
+
+        var pinned = volume.Probe(PortalDigest, TesterDigest);
+        Assert.Equal("true", pinned.Outputs["mounted"]);
+        Assert.Equal(Path.Combine(set, "platform-refs"), pinned.Outputs["dir"]);
+        Assert.Contains("the artifact is not needed", pinned.Stdout, StringComparison.Ordinal);
+
+        // Without a tester pin the probe scans for the set that pairs the pinned portal.
+        var scanned = volume.Probe(PortalDigest, testerDigest: "");
+        Assert.Equal("true", scanned.Outputs["mounted"]);
+        Assert.Equal(Path.Combine(set, "platform-refs"), scanned.Outputs["dir"]);
+
+        // The same set does not serve ANOTHER portal, tester pin or not.
+        const string otherPortal = "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+        Assert.Equal("false", volume.Probe(otherPortal, TesterDigest).Outputs["mounted"]);
+        Assert.Equal("false", volume.Probe(otherPortal, testerDigest: "").Outputs["mounted"]);
+    }
+
+    /// <summary>
+    /// 🚨 The "could this fail?" half. The volume laid out as the PRE-FIX probe imagined it —
+    /// <c>/opt/platform/sha256:&lt;portal hex&gt;/</c>, <c>.complete</c> holding the portal digest,
+    /// the assemblies at the top level — must NOT be taken: it is not what the refresh writes, and
+    /// a probe that accepts it is the one that never hit the real share. Restore the old probe and
+    /// this passes it, i.e. goes red.
+    /// </summary>
+    [Fact]
+    public void TheProbe_Executed_DoesNotHitTheLayoutTheOldProbeImagined()
+    {
+        using var volume = new SyntheticVolume();
+        volume.Set(PortalDigest, ".complete", PortalDigest, PortalDigest, dllsUnder: "");
+
+        Assert.Equal("false", volume.Probe(PortalDigest, TesterDigest).Outputs["mounted"]);
+        Assert.Equal("false", volume.Probe(PortalDigest, testerDigest: "").Outputs["mounted"]);
+    }
+
+    [Fact]
+    public void TheProbe_Executed_FallsThroughOnAHalfInstall_AndOnAnAbsentMount()
+    {
+        using var volume = new SyntheticVolume();
+        var set = volume.Set(TesterDigest.Replace(':', '-'), ".complete", TesterDigest, PortalDigest, dllsUnder: "platform-refs");
+        File.Delete(Path.Combine(set, ".complete"));
+        var half = volume.Probe(PortalDigest, TesterDigest);
+        Assert.Equal("false", half.Outputs["mounted"]);
+        Assert.Contains("a refresh in flight", half.Stdout, StringComparison.Ordinal);
+
+        var absent = volume.Probe(PortalDigest, TesterDigest, root: Path.Combine(volume.Root, "not-mounted"));
+        Assert.Equal("false", absent.Outputs["mounted"]);
+        Assert.Contains("is not present on", absent.Stdout, StringComparison.Ordinal);
+    }
+
+    // ── the probe, lifted from the lane and run as shipped ─────────────────────────────────────
+
+    private static string ProbeBody()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var run = RunBlock(StepBody(text, "id: platform-mount"));
+        Assert.True(run.Length > 0, $"{Lane}: the `platform-mount` step must have a `run:` block");
+        return run;
+    }
+
+    /// <summary>The step (in the pack job) whose body carries the given `id:` line, up to the next step.</summary>
+    private static string StepBody(string lane, string idLine)
+    {
+        var lines = lane.Split('\n');
+        var start = Array.FindIndex(lines, l => l.Trim() == idLine);
+        Assert.True(start >= 0, $"{Lane} must have a step with `{idLine}`");
+        while (start > 0 && !lines[start].StartsWith("      - name:", StringComparison.Ordinal)) start--;
+        var end = start + 1;
+        // Up to the next step — or the next JOB, should the step be the job's last.
+        while (end < lines.Length && !lines[end].StartsWith("      - name:", StringComparison.Ordinal)
+               && !(lines[end].Length > 2 && lines[end][0] == ' ' && lines[end][1] == ' ' && char.IsLetter(lines[end][2]))) end++;
+        return string.Join('\n', lines[start..end]);
+    }
+
+    /// <summary>The `run: |` scalar of a step, dedented to the script as bash receives it.</summary>
+    private static string RunBlock(string step)
+    {
+        var lines = step.Split('\n');
+        var run = Array.FindIndex(lines, l => l.TrimEnd() == "        run: |");
+        Assert.True(run >= 0, "the step must have a `run: |` block");
+        var body = lines[(run + 1)..]
+            .TakeWhile(l => l.Length == 0 || l.StartsWith("          ", StringComparison.Ordinal))
+            .Select(l => l.Length >= 10 ? l[10..] : l);
+        return string.Join('\n', body);
+    }
+
+    private sealed class SyntheticVolume : IDisposable
+    {
+        public string Root { get; } = Path.Combine(Path.GetTempPath(), "mw-platform-volume-" + Guid.NewGuid().ToString("N"));
+        private readonly string script;
+
+        public SyntheticVolume()
+        {
+            Directory.CreateDirectory(Root);
+            var body = ProbeBody();
+            // The lane hardcodes the mount point; the test redirects it and asserts the redirect
+            // actually landed, so a probe that stopped saying `root=/opt/platform` cannot pass by
+            // probing the runner's real filesystem.
+            const string mount = "root=/opt/platform\n";
+            Assert.Contains(mount, body, StringComparison.Ordinal);
+            script = Path.Combine(Root, "probe.sh");
+            File.WriteAllText(script, body.Replace(mount, "root=\"${PROBE_ROOT:?}\"\n", StringComparison.Ordinal));
+        }
+
+        /// <summary>Lays down one set directory named <paramref name="dirName"/> under the root.</summary>
+        public string Set(string dirName, string marker, string markerValue, string portalDigest, string dllsUnder)
+        {
+            var dir = Path.Combine(Root, dirName);
+            Directory.CreateDirectory(Path.Combine(dir, "app"));
+            var dlls = dllsUnder.Length == 0 ? dir : Path.Combine(dir, dllsUnder);
+            Directory.CreateDirectory(dlls);
+            for (var i = 0; i < 60; i++) File.WriteAllText(Path.Combine(dlls, $"Assembly{i}.dll"), "");
+            File.WriteAllText(Path.Combine(dir, "platform.json"),
+                $"{{\n  \"set\": \"3.0.0-ci.1\",\n  \"image-digest\": \"{markerValue}\",\n  \"portal-image-digest\": \"{portalDigest}\"\n}}\n");
+            File.WriteAllText(Path.Combine(dir, marker), markerValue + "\n");
+            File.WriteAllText(Path.Combine(Root, "current"), markerValue + "\n");
+            return dir;
+        }
+
+        public ProbeResult Probe(string portalDigest, string testerDigest, string? root = null)
+        {
+            var id = Guid.NewGuid().ToString("N");
+            var outPath = Path.Combine(Root, $"stdout-{id}.txt");
+            var errPath = Path.Combine(Root, $"stderr-{id}.txt");
+            var ghOutput = Path.Combine(Root, $"github-output-{id}.txt");
+            File.WriteAllText(ghOutput, "");
+
+            // Redirected to FILES, never piped: a pipe read before WaitForExit blocks in the read
+            // and the bounded wait below could never fire (MemexLocalDiscoversNodeRepoSiblingsGuard).
+            var info = new ProcessStartInfo("/bin/bash", ["-c", $"bash '{script}' > '{outPath}' 2> '{errPath}'"]);
+            info.Environment["PROBE_ROOT"] = root ?? Root;
+            info.Environment["DIGEST"] = portalDigest;
+            info.Environment["TESTER_DIGEST"] = testerDigest;
+            info.Environment["RUNNER_NAME"] = "synthetic-runner";
+            info.Environment["GITHUB_OUTPUT"] = ghOutput;
+
+            using var process = Process.Start(info)!;
+            if (!process.WaitForExit(60_000))
+            {
+                process.Kill(entireProcessTree: true);
+                Assert.Fail("the platform-mount probe did not finish within 60s against a synthetic volume — it is stuck.");
+            }
+            var stdout = File.ReadAllText(outPath);
+            var stderr = File.ReadAllText(errPath);
+            Assert.True(process.ExitCode == 0,
+                $"the platform-mount probe must never fail — a miss FALLS THROUGH to the run artifact (exit {process.ExitCode}).\nstdout:\n{stdout}\nstderr:\n{stderr}");
+
+            var outputs = File.ReadAllLines(ghOutput)
+                .Where(l => l.Contains('='))
+                .Select(l => l.Split('=', 2))
+                .ToDictionary(kv => kv[0], kv => kv[1], StringComparer.Ordinal);
+            Assert.True(outputs.ContainsKey("mounted"),
+                $"the probe must always write `mounted=` to $GITHUB_OUTPUT — the fetch step's `if:` reads it.\nstdout:\n{stdout}");
+            return new ProbeResult(stdout, outputs);
+        }
+
+        public void Dispose()
+        {
+            try { Directory.Delete(Root, recursive: true); } catch (IOException) { /* best effort */ }
+        }
+    }
+
+    private sealed record ProbeResult(string Stdout, IReadOnlyDictionary<string, string> Outputs);
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (MeshWeaver.slnx) above the test bin");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
## The defect

Measured on MeshWeaver.Plugins run 34711540604 (PR #1736): after #4108, `pack` checks `/opt/platform/$DIGEST` — the **portal** digest, in `sha256:` colon form — and expects the assemblies at that directory's top level. The CI platform volume (Systemorph/Memex `deployments/aks/ci-runners/ci-platform-refresh.py`, and the README's "Platform kept between jobs"; read by content, not by description) lays a set out as:

```
/opt/platform/sha256-<TESTER hex>/               keyed by the TESTER digest; `:` → `-` (Azure Files forbids `:`)
/opt/platform/sha256-<TESTER hex>/platform-refs/ the PORTAL image's /app — what pack compiles against
/opt/platform/sha256-<TESTER hex>/platform.json  `portal-image-digest`: the portal the set pairs
/opt/platform/sha256-<TESTER hex>/.complete      the tester digest, COLON form, written LAST
```

Three mismatches, each sufficient on its own — the colon was one of them, not the only one. The mount never hit, every aks-silos leg quietly took the run artifact (207 MB gzipped, `platform-refs-catalog-…`), and the volume did nothing for this lane while the log read as a normal fallback.

## The fix (`pack` only — `tests` reads no volume)

The probe mirrors `resolve-gate-platform.sh` (#4115, the gate lane's reader of the same share): `${TESTER_DIGEST/:/-}` for the set directory — or a scan of `sha256-*` when the caller pinned no tester — the colon-form marker compared as the refresh writes it, `platform.json` for the pairing against `platform-image-digest`, `platform-refs/` for the assemblies. It still **falls through to the run artifact on a miss**, by design (the lane header, Memex#316), and prints which source it took exactly as before (`platform refs: N assemblies for <digest> from the mount (<dir>)` / `source=mount`). The verdict step takes the directory the probe resolved instead of recomputing it.

## The guard (cannot pass vacuously)

`test/MeshWeaver.Documentation.Test/PlatformMountLayoutGuard.cs` — five facts, and it **executes the probe's own `run:` body under bash** against a synthetic volume:

- by text: the directory comes from `${TESTER_DIGEST/:/-}` / `sha256-*`; `/opt/platform/$DIGEST`, `$root/$DIGEST` and `/sha256:` never appear as a path; the marker is compared in colon form; the assemblies are read from `platform-refs/`; the pairing from `platform.json`; the verdict step reads `steps.platform-mount.outputs.dir`; the lane's prose names the real layout.
- by execution: the refresh's layout (tester-keyed dash directory, portal under `platform-refs/`) → `mounted=true`, `dir=<set>/platform-refs`, tester-pinned and scanned; the layout the OLD probe imagined (`sha256:<portal>/` with the dlls on top) → `mounted=false`; another portal, a half-install (no `.complete`) and an absent mount → `mounted=false`, exit 0 (a miss never fails the step).

Against the pre-fix lane from `origin/main`: **5/5 red**. Against this branch: 5/5 green, 446/446 in the project.

## Guards run

`actionlint -shellcheck= -pyflakes=` (as dotnet-test.yml runs it) clean; `check-workflow-shell/timeouts/yaml-keys/pr-secret-preflight` with `--root .` and `--self-test`, `check-workflow-permission-pairing` with `--root .`, `--root . --fleet .github/lane-caller-grants.yml` and `--self-test`: all green; `dotnet test test/MeshWeaver.Documentation.Test -c Release -warnaserror`: 446 passed.

## Proof on a real runner

The satellites consume this lane `@main`, so the live proof (a `pack` leg on the aks-silos scale set logging `from the mount` instead of `from the artifact`) is dispatched after this merges; the result and the time saved versus the 207 MB artifact download will be posted on this PR. `/opt/platform/current` at 17:34Z named `sha256:3c5dd3c9…`.

Refs Systemorph/Memex#316. Relates to #4115 (gate lane volume mode) and Plugins #1736.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DqTDZe4Skkn81GuGkwMrXS
